### PR TITLE
🐛 `optimize`: allow calling `minimize_scalar` without a `bracket`

### DIFF
--- a/scipy-stubs/optimize/_minimize.pyi
+++ b/scipy-stubs/optimize/_minimize.pyi
@@ -5,6 +5,7 @@ from typing_extensions import LiteralString
 import numpy as np
 import optype.numpy as onp
 import optype.numpy.compat as npc
+from numpy.polynomial._polybase import ABCPolyBase
 from scipy._typing import Falsy, Truthy
 from scipy.sparse.linalg import LinearOperator
 from ._hessian_update_strategy import HessianUpdateStrategy
@@ -26,7 +27,8 @@ _Float1D: TypeAlias = onp.Array1D[np.float64]
 _Float2D: TypeAlias = onp.Array2D[np.float64]
 
 _RT = TypeVar("_RT")
-_Fun0D: TypeAlias = Callable[Concatenate[float, ...], _RT] | Callable[Concatenate[np.float64, ...], _RT]
+# NOTE: `ABCPolyBase` is required to work around https://github.com/scipy/scipy-stubs/issues/465
+_Fun0D: TypeAlias = Callable[Concatenate[float, ...], _RT] | Callable[Concatenate[np.float64, ...], _RT] | ABCPolyBase
 _Fun1D: TypeAlias = Callable[Concatenate[_Float1D, ...], _RT]
 _Fun1Dp: TypeAlias = Callable[Concatenate[_Float1D, _Float1D, ...], _RT]
 
@@ -238,7 +240,7 @@ def minimize(
 @overload  # method="brent" or method="golden"
 def minimize_scalar(
     fun: _Fun0D[onp.ToFloat],
-    bracket: _ToBracket,
+    bracket: _ToBracket | None = None,
     bounds: None = None,
     args: _Args = (),
     method: Literal["brent", "golden"] | None = None,  # default: "brent"

--- a/tests/optimize/minimize_scalar.pyi
+++ b/tests/optimize/minimize_scalar.pyi
@@ -1,0 +1,16 @@
+from typing_extensions import assert_type
+
+import numpy.polynomial as npp
+from scipy.optimize import minimize_scalar
+
+def f(x: float) -> float: ...
+
+res = minimize_scalar(f)
+assert_type(res.success, bool)
+assert_type(res.nit, int)
+assert_type(res.nfev, int)
+
+# https://github.com/scipy/scipy-stubs/issues/465
+p = npp.Polynomial([3, -2, 1, 1, 0.2])
+res_poly = minimize_scalar(p)
+assert_type(res.success, bool)


### PR DESCRIPTION
This fixes a `1.15.2.0` regression that was introduced in https://github.com/scipy/scipy-stubs/pull/428.

The `optimize.minimize_scalar` now also accepts `numpy.polynomial` class instances.

Closes #465