### PR TITLE
🐛 `spatial.transform`: accept proper Euler angles in `Rotation.as_euler`

### DIFF
--- a/scipy-stubs/spatial/transform/_rotation.pyi
+++ b/scipy-stubs/spatial/transform/_rotation.pyi
@@ -17,31 +17,11 @@ _Float2D3D: TypeAlias = _Float2D | _Float3D
 _RotOrder: TypeAlias = L["e", "extrinsic", "i", "intrinsic"]
 _RotGroup: TypeAlias = L["I", "O", "T", "D", "Dn", "C", "Cn"]
 _RotAxisSeq: TypeAlias = L[
-    "xyz",
-    "xzy",
-    "yxz",
-    "yzx",
-    "zxy",
-    "zyx",
-    "xyx",
-    "xzx",
-    "yxy",
-    "yzy",
-    "zxz",
-    "zyz",
-    "XYZ",
-    "XZY",
-    "YXZ",
-    "YZX",
-    "ZXY",
-    "ZYX",
-    "XYX",
-    "XZX",
-    "YXY",
-    "YZY",
-    "ZXZ",
-    "ZYZ",
-]
+    "xyz", "xzy", "yxz", "yzx", "zxy", "zyx",
+    "xyx", "xzx", "yxy", "yzy", "zxz", "zyz",
+    "XYZ", "XZY", "YXZ", "YZX", "ZXY", "ZYX",
+    "XYX", "XZX", "YXY", "YZY", "ZXZ", "ZYZ",
+]  # fmt: skip
 _RotAxis: TypeAlias = L["X", "Y", "Z"]
 
 _RotationT = TypeVar("_RotationT", bound=Rotation)

--- a/scipy-stubs/spatial/transform/_rotation.pyi
+++ b/scipy-stubs/spatial/transform/_rotation.pyi
@@ -17,10 +17,30 @@ _Float2D3D: TypeAlias = _Float2D | _Float3D
 _RotOrder: TypeAlias = L["e", "extrinsic", "i", "intrinsic"]
 _RotGroup: TypeAlias = L["I", "O", "T", "D", "Dn", "C", "Cn"]
 _RotAxisSeq: TypeAlias = L[
-    "xyz", "xzy", "yxz", "yzx", "zxy", "zyx",
-    "xyx", "xzx", "yxy", "yzy", "zxz", "zyz",
-    "XYZ", "XZY", "YXZ", "YZX", "ZXY", "ZYX",
-    "XYX", "XZX", "YXY", "YZY", "ZXZ", "ZYZ",
+    "xyz",
+    "xzy",
+    "yxz",
+    "yzx",
+    "zxy",
+    "zyx",
+    "xyx",
+    "xzx",
+    "yxy",
+    "yzy",
+    "zxz",
+    "zyz",
+    "XYZ",
+    "XZY",
+    "YXZ",
+    "YZX",
+    "ZXY",
+    "ZYX",
+    "XYX",
+    "XZX",
+    "YXY",
+    "YZY",
+    "ZXZ",
+    "ZYZ",
 ]
 _RotAxis: TypeAlias = L["X", "Y", "Z"]
 

--- a/scipy-stubs/spatial/transform/_rotation.pyi
+++ b/scipy-stubs/spatial/transform/_rotation.pyi
@@ -20,7 +20,7 @@ _RotAxisSeq: TypeAlias = L[
     "xyz", "xzy", "yxz", "yzx", "zxy", "zyx",
     "xyx", "xzx", "yxy", "yzy", "zxz", "zyz",
     "XYZ", "XZY", "YXZ", "YZX", "ZXY", "ZYX",
-    "XYX", "XZX", "YXY", "YZY", "ZXZ", "ZYZ"
+    "XYX", "XZX", "YXY", "YZY", "ZXZ", "ZYZ",
 ]
 _RotAxis: TypeAlias = L["X", "Y", "Z"]
 

--- a/scipy-stubs/spatial/transform/_rotation.pyi
+++ b/scipy-stubs/spatial/transform/_rotation.pyi
@@ -16,7 +16,12 @@ _Float2D3D: TypeAlias = _Float2D | _Float3D
 
 _RotOrder: TypeAlias = L["e", "extrinsic", "i", "intrinsic"]
 _RotGroup: TypeAlias = L["I", "O", "T", "D", "Dn", "C", "Cn"]
-_RotAxisSeq: TypeAlias = L["xyz", "xzy", "yzx", "yxz", "zxy", "zyx", "XYZ", "XZY", "YXZ", "YZX", "ZXY", "ZYX"]
+_RotAxisSeq: TypeAlias = Literal[
+    "xyz", "xzy", "yxz", "yzx", "zxy", "zyx",
+    "xyx", "xzx", "yxy", "yzy", "zxz", "zyz",
+    "XYZ", "XZY", "YXZ", "YZX", "ZXY", "ZYX",
+    "XYX", "XZX", "YXY", "YZY", "ZXZ", "ZYZ"
+]
 _RotAxis: TypeAlias = L["X", "Y", "Z"]
 
 _RotationT = TypeVar("_RotationT", bound=Rotation)

--- a/scipy-stubs/spatial/transform/_rotation.pyi
+++ b/scipy-stubs/spatial/transform/_rotation.pyi
@@ -16,7 +16,7 @@ _Float2D3D: TypeAlias = _Float2D | _Float3D
 
 _RotOrder: TypeAlias = L["e", "extrinsic", "i", "intrinsic"]
 _RotGroup: TypeAlias = L["I", "O", "T", "D", "Dn", "C", "Cn"]
-_RotAxisSeq: TypeAlias = Literal[
+_RotAxisSeq: TypeAlias = L[
     "xyz", "xzy", "yxz", "yzx", "zxy", "zyx",
     "xyx", "xzx", "yxy", "yzy", "zxz", "zyz",
     "XYZ", "XZY", "YXZ", "YZX", "ZXY", "ZYX",


### PR DESCRIPTION
Current definition

>  _RotAxisSeq: TypeAlias = L["xyz", "xzy", "yzx", "yxz", "zxy", "zyx", "XYZ", "XZY", "YXZ", "YZX", "ZXY", "ZYX"]

only includes Tait-Bryan sequences.

Documentation at:
https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.transform.Rotation.as_euler.html

shows its viable to use proper Euler also.

> [0, 180] degrees if first and third axes are the same (like zxz)
