### PR TITLE
⚗️ The `numtype` experiment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,12 +97,12 @@ jobs:
 
       - name: basedpyright
         run: >
-          uv run --with="numpy==${{ matrix.numpy }}"
+          uv run --no-group=lint --with="numpy==${{ matrix.numpy }}" --no-editable
           basedpyright
 
       - name: basedmypy
         run: >
-          uv run --with="numpy==${{ matrix.numpy }}"
+          uv run --no-group=lint --with="numpy==${{ matrix.numpy }}" --no-editable
           mypy
           --tb
           --hide-error-context
@@ -111,7 +111,49 @@ jobs:
 
       - name: stubtest
         run: >
-          uv run --with="numpy==${{ matrix.numpy }}" --no-editable
+          uv run --no-group=lint --with="numpy==${{ matrix.numpy }}" --no-editable
+          stubtest
+          --tb
+          --ignore-unused-allowlist
+          --allowlist=.mypyignore
+          --mypy-config-file=pyproject.toml
+          scipy
+
+  typetest-numtype:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["3.10", "3.11", "3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: setup uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          python-version: ${{ matrix.python }}
+
+      - name: basedpyright
+        run: >
+          uv run --no-group=lint --all-extras --no-editable
+          basedpyright
+
+      - name: basedmypy
+        run: >
+          uv run --no-group=lint --all-extras --no-editable
+          mypy
+          --tb
+          --hide-error-context
+          --hide-error-code-links
+          .
+
+      - name: stubtest
+        run: >
+          uv run --no-group=lint --all-extras --no-editable
           stubtest
           --tb
           --ignore-unused-allowlist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,10 @@ classifiers = [
     "Typing :: Stubs Only",
 ]
 requires-python = ">=3.10"
-dependencies = ["optype>=0.9.2"]
+dependencies = [
+    "numtype",
+    "optype>=0.9.2",
+]
 
     [project.optional-dependencies]
     scipy = ["scipy>=1.15.2,<1.16"]
@@ -230,3 +233,6 @@ line-length = 130
         [tool.ruff.lint.flake8-annotations]
         allow-star-arg-any = true
         mypy-init-return = true
+
+[tool.uv.sources]
+numtype = { git = "https://github.com/numpy/numtype", rev = "e4c738806df01f86feb5764421d8c81d9edd8cca" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,12 +33,12 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "numtype",
     "optype>=0.9.2",
 ]
 
     [project.optional-dependencies]
     scipy = ["scipy>=1.15.2,<1.16"]
+    numtype = ["numtype"]
 
     [project.urls]
     Homepage = "https://scipy.org/"
@@ -50,14 +50,11 @@ dependencies = [
 [dependency-groups]
 extras = ["scipy-stubs[scipy]"]
 ci = ["packaging>=24.2"]
-mdformat = [
+lint = [
+    {include-group = "extras"},
     "mdformat>=0.7.22",
     "mdformat-gfm>=0.4.1",
     "mdformat-gfm-alerts>=1.0.1",
-]
-lint = [
-    {include-group = "extras"},
-    {include-group = "mdformat"},
     "ruff>=0.11.0",
     "sp-repo-review[cli]>=2025.1.22",
 ]
@@ -79,6 +76,11 @@ packages = ["scipy-stubs"]
     [tool.hatch.build.targets.sdist]
     exclude = ["CODE_OF_CONDUCT.md", "README.md", "SECURITY.md", "uv.lock"]
     force-include = {".mypyignore" = ".mypyignore"}                         # for scipy-stubs-feedstock
+
+
+[tool.uv.sources.numtype]
+git = "https://github.com/numpy/numtype"
+rev = "e4c738806df01f86feb5764421d8c81d9edd8cca"
 
 
 [tool.poe.tasks.clean]
@@ -121,7 +123,7 @@ enable_error_code = [
     "redundant-expr",
     "truthy-bool",
 ]
-disallow_any_explicit = false                                                           # no other way to type e.g. `float64 <: number[Any]`
+disallow_any_explicit = false # no other way to type e.g. `float64 <: number[Any]`
 warn_unreachable = false
 warn_unused_ignores = true
 # basedmypy/mypy compat
@@ -233,6 +235,3 @@ line-length = 130
         [tool.ruff.lint.flake8-annotations]
         allow-star-arg-any = true
         mypy-init-return = true
-
-[tool.uv.sources]
-numtype = { git = "https://github.com/numpy/numtype", rev = "e4c738806df01f86feb5764421d8c81d9edd8cca" }

--- a/tests/special/test_ufuncs.pyi
+++ b/tests/special/test_ufuncs.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Literal as L, TypeAlias
+from typing import Literal as L, TypeAlias
 from typing_extensions import assert_type
 
 import numpy as np
@@ -11,8 +11,8 @@ _Complex64ND: TypeAlias = onp.ArrayND[np.complex64]
 _Complex128ND: TypeAlias = onp.ArrayND[np.complex128]
 
 _b1: np.bool_
-_i: np.integer[Any]
-_f: np.floating[Any]
+_i: np.unsignedinteger | np.signedinteger
+_f: np.floating
 _f2: np.float16
 _f4: np.float32
 _f8: np.float64

--- a/uv.lock
+++ b/uv.lock
@@ -262,6 +262,11 @@ wheels = [
 ]
 
 [[package]]
+name = "numtype"
+version = "2.2.3.0.dev0"
+source = { git = "https://github.com/numpy/numtype?rev=e4c738806df01f86feb5764421d8c81d9edd8cca#e4c738806df01f86feb5764421d8c81d9edd8cca" }
+
+[[package]]
 name = "optype"
 version = "0.9.2"
 source = { registry = "https://pypi.org/simple" }
@@ -531,6 +536,7 @@ name = "scipy-stubs"
 version = "1.15.2.2.dev0"
 source = { editable = "." }
 dependencies = [
+    { name = "numtype" },
     { name = "optype" },
 ]
 
@@ -579,6 +585,7 @@ type = [
 
 [package.metadata]
 requires-dist = [
+    { name = "numtype", git = "https://github.com/numpy/numtype?rev=e4c738806df01f86feb5764421d8c81d9edd8cca" },
     { name = "optype", specifier = ">=0.9.2" },
     { name = "scipy", marker = "extra == 'scipy'", specifier = ">=1.15.2,<1.16" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -536,11 +536,13 @@ name = "scipy-stubs"
 version = "1.15.2.2.dev0"
 source = { editable = "." }
 dependencies = [
-    { name = "numtype" },
     { name = "optype" },
 ]
 
 [package.optional-dependencies]
+numtype = [
+    { name = "numtype" },
+]
 scipy = [
     { name = "scipy" },
 ]
@@ -571,11 +573,6 @@ lint = [
     { name = "scipy-stubs", extra = ["scipy"] },
     { name = "sp-repo-review", extra = ["cli"] },
 ]
-mdformat = [
-    { name = "mdformat" },
-    { name = "mdformat-gfm" },
-    { name = "mdformat-gfm-alerts" },
-]
 type = [
     { name = "basedmypy", extra = ["faster-cache"] },
     { name = "basedpyright" },
@@ -585,11 +582,11 @@ type = [
 
 [package.metadata]
 requires-dist = [
-    { name = "numtype", git = "https://github.com/numpy/numtype?rev=e4c738806df01f86feb5764421d8c81d9edd8cca" },
+    { name = "numtype", marker = "extra == 'numtype'", git = "https://github.com/numpy/numtype?rev=e4c738806df01f86feb5764421d8c81d9edd8cca" },
     { name = "optype", specifier = ">=0.9.2" },
     { name = "scipy", marker = "extra == 'scipy'", specifier = ">=1.15.2,<1.16" },
 ]
-provides-extras = ["scipy"]
+provides-extras = ["scipy", "numtype"]
 
 [package.metadata.requires-dev]
 ci = [{ name = "packaging", specifier = ">=24.2" }]
@@ -612,11 +609,6 @@ lint = [
     { name = "ruff", specifier = ">=0.11.0" },
     { name = "scipy-stubs", extras = ["scipy"] },
     { name = "sp-repo-review", extras = ["cli"], specifier = ">=2025.1.22" },
-]
-mdformat = [
-    { name = "mdformat", specifier = ">=0.7.22" },
-    { name = "mdformat-gfm", specifier = ">=0.4.1" },
-    { name = "mdformat-gfm-alerts", specifier = ">=1.0.1" },
 ]
 type = [
     { name = "basedmypy", extras = ["faster-cache"], specifier = ">=2.10.0" },


### PR DESCRIPTION
https://github.com/numpy/numtype

NumType currently requires `nmpy>=2.2`, but `scipy-stubs` has to support `numpy>=1.23.5`, so  `numtype` cannot be a required dependency (yet). Instead, it is installable through a new `numtype` "extra".
