### PR TITLE
📌 bump `optype` to `0.9.3`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
     "Typing :: Stubs Only",
 ]
 requires-python = ">=3.10"
-dependencies = ["optype>=0.9.2"]
+dependencies = ["optype>=0.9.3"]
 
     [project.optional-dependencies]
     scipy = ["scipy>=1.15.2,<1.16"]

--- a/scipy-stubs/optimize/_slsqp_py.pyi
+++ b/scipy-stubs/optimize/_slsqp_py.pyi
@@ -13,7 +13,7 @@ _FT = TypeVar("_FT", bound=onp.ToFloat | onp.ToFloatND)
 _Fun: TypeAlias = Callable[Concatenate[onp.Array1D[np.float64], ...], _FT]
 _Fun0D: TypeAlias = _Fun[onp.ToFloat]
 _Fun1D: TypeAlias = _Fun[onp.ToFloat1D]
-_Fun2D: TypeAlias = _Fun[onp.ToFloat2D]  # type: ignore[type-var]
+_Fun2D: TypeAlias = _Fun[onp.ToFloat2D]
 
 _Ignored: TypeAlias = object
 

--- a/scipy-stubs/optimize/_zeros_py.pyi
+++ b/scipy-stubs/optimize/_zeros_py.pyi
@@ -150,7 +150,7 @@ def newton(
     args: tuple[object, ...] = (),
     tol: onp.ToFloat = 1.48e-08,
     maxiter: onp.ToJustInt = 50,
-    fprime2: _Fun1D[onp.ToFloat2D] | None = None,  # type: ignore[type-var]
+    fprime2: _Fun1D[onp.ToFloat2D] | None = None,
     x1: onp.ToFloat1D | None = None,
     rtol: onp.ToFloat = 0.0,
     full_output: Falsy = False,

--- a/uv.lock
+++ b/uv.lock
@@ -263,14 +263,14 @@ wheels = [
 
 [[package]]
 name = "optype"
-version = "0.9.2"
+version = "0.9.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/32/c2/76a520809f1a5dd970eab9cc7da3aaa0e16e3fb8a0252fecec1a7a23ad73/optype-0.9.2.tar.gz", hash = "sha256:d7487a5b7fe96bacfc5dc8fab6b90c14f1e65e7ba6e7b22a8bef48d29690edac", size = 96126 }
+sdist = { url = "https://files.pythonhosted.org/packages/88/3c/9d59b0167458b839273ad0c4fc5f62f787058d8f5aed7f71294963a99471/optype-0.9.3.tar.gz", hash = "sha256:5f09d74127d316053b26971ce441a4df01f3a01943601d3712dd6f34cdfbaf48", size = 96143 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ed/1a/40593f6fb9432fea750c9833e0cff0cd71452b9711b9df83faa251b0fe4e/optype-0.9.2-py3-none-any.whl", hash = "sha256:f9aee29e24794a7af637af80347b9fefbb110dffe012c133079615e551e52ef9", size = 84314 },
+    { url = "https://files.pythonhosted.org/packages/73/d8/ac50e2982bdc2d3595dc2bfe3c7e5a0574b5e407ad82d70b5f3707009671/optype-0.9.3-py3-none-any.whl", hash = "sha256:2935c033265938d66cc4198b0aca865572e635094e60e6e79522852f029d9e8d", size = 84357 },
 ]
 
 [[package]]
@@ -581,7 +581,7 @@ type = [
 
 [package.metadata]
 requires-dist = [
-    { name = "optype", specifier = ">=0.9.2" },
+    { name = "optype", specifier = ">=0.9.3" },
     { name = "scipy", marker = "extra == 'scipy'", specifier = ">=1.15.2,<1.16" },
 ]
 provides-extras = ["scipy"]


### PR DESCRIPTION
https://github.com/jorenham/optype/releases/tag/v0.9.3