### PR TITLE
🐛 `optimize`: accept a scalar for `x0` in `minimize`

### DIFF
--- a/scipy-stubs/optimize/_minimize.pyi
+++ b/scipy-stubs/optimize/_minimize.pyi
@@ -192,7 +192,7 @@ class OptimizeResult(_OptimizeResult):
 @overload  # `fun` return scalar, `jac` not truthy
 def minimize(
     fun: _Fun1D[onp.ToFloat],
-    x0: onp.ToFloat1D,
+    x0: onp.ToFloat | onp.ToFloat1D,
     args: _Args = (),
     method: MethodMimimize | _MinimizeMethodFun | None = None,
     jac: _Fun1D[onp.ToFloat1D] | _FDMethod | Falsy | None = None,
@@ -207,7 +207,7 @@ def minimize(
 @overload  # fun` return (scalar, vector), `jac` truthy  (positional)
 def minimize(
     fun: _Fun1D[tuple[onp.ToFloat, onp.ToFloat1D]],
-    x0: onp.ToFloat1D,
+    x0: onp.ToFloat | onp.ToFloat1D,
     args: _Args,
     method: MethodMimimize | _MinimizeMethodFun | None,
     jac: Truthy,
@@ -222,7 +222,7 @@ def minimize(
 @overload  # fun` return (scalar, vector), `jac` truthy  (keyword)
 def minimize(
     fun: _Fun1D[tuple[onp.ToFloat, onp.ToFloat1D]],
-    x0: onp.ToFloat1D,
+    x0: onp.ToFloat | onp.ToFloat1D,
     args: _Args = (),
     method: MethodMimimize | _MinimizeMethodFun | None = None,
     *,

--- a/tests/.ruff.toml
+++ b/tests/.ruff.toml
@@ -1,0 +1,3 @@
+extend = "../pyproject.toml"
+
+extend-ignore = ["PYI015"]

--- a/tests/optimize/minimize.pyi
+++ b/tests/optimize/minimize.pyi
@@ -1,0 +1,13 @@
+from typing import TypeAlias
+
+import numpy as np
+import numpy.typing as npt
+from scipy.optimize import minimize
+
+NDArrayFloat: TypeAlias = npt.NDArray[np.float16 | np.float32 | np.float64]
+
+def objective_function(CCT: NDArrayFloat, uv_: NDArrayFloat) -> np.float64: ...
+
+uv = np.atleast_1d([0.1978, 0.3124])
+
+minimize(objective_function, x0=6400, args=(uv,), method="Nelder-Mead", options={"fatol": 1e-10})


### PR DESCRIPTION
closes #496