### PR TITLE
Correct key name in :class:`_OptionsMILP`

### DIFF
--- a/scipy-stubs/optimize/_milp.pyi
+++ b/scipy-stubs/optimize/_milp.pyi
@@ -31,7 +31,7 @@ class _OptionsMILP(TypedDict, total=False):
     presolve: onp.ToBool  # default: True
     node_limit: int  # default: no limit
     time_limit: onp.ToFloat  # default: no limit
-    min_rel_gap: onp.ToFloat  # default: ?
+    mip_rel_gap: onp.ToFloat  # default: ?
 
 @type_check_only
 class _OptimizeResultSucess(_OptimizeResult):


### PR DESCRIPTION
closes #510 

Updated key name "min_rel_gap" -> "mip_rel_gap" to match `scipy.optimize.milp` docs.