### PR TITLE
👽️ scipy 1.16 change for `interpolate.RectBivariateSpline`

### DIFF
--- a/.mypyignore-todo
+++ b/.mypyignore-todo
@@ -1,6 +1,3 @@
-scipy.interpolate.RectBivariateSpline.__init__
-scipy.interpolate._?fitpack2.RectBivariateSpline.__init__
-scipy.interpolate.interpolate.RectBivariateSpline.__init__
 scipy.interpolate._bsplines.make_smoothing_spline
 scipy.interpolate.make_smoothing_spline
 

--- a/scipy-stubs/interpolate/_fitpack2.pyi
+++ b/scipy-stubs/interpolate/_fitpack2.pyi
@@ -169,6 +169,7 @@ class RectBivariateSpline(BivariateSpline):
         kx: int = 3,
         ky: int = 3,
         s: onp.ToFloat = 0,
+        maxit: int = 20,
     ) -> None: ...
 
 class SphereBivariateSpline(_BivariateSplineBase):


### PR DESCRIPTION
A `maxit=20` constructor parameter has been added to the `interpolate.RectBivariateSpline`  class.