### PR TITLE
👽️ scipy 1.16 change for `interpolate.make_smoothing_spline`

### DIFF
--- a/.mypyignore-todo
+++ b/.mypyignore-todo
@@ -1,6 +1,3 @@
-scipy.interpolate._bsplines.make_smoothing_spline
-scipy.interpolate.make_smoothing_spline
-
 scipy.io.matlab.MatWriteWarning
 scipy.io.matlab.__all__
 scipy.io.matlab._miobase.MatWriteWarning

--- a/scipy-stubs/interpolate/_bsplines.pyi
+++ b/scipy-stubs/interpolate/_bsplines.pyi
@@ -195,9 +195,11 @@ def make_lsq_spline(
 # NOTE: will unsafely cast complex input to float64
 def make_smoothing_spline(
     x: onp.ToComplex1D,
-    y: onp.ToComplex1D,
+    y: onp.ToComplexND,
     w: onp.ToFloat1D | None = None,
     lam: onp.ToFloat | None = None,
+    *,
+    axis: op.CanIndex = 0,
 ) -> BSpline[np.float64]: ...
 
 #


### PR DESCRIPTION
An `axis=0` keyword-only parameter has been added to the `interpolate.make_smoothing_spline` function, which now has batch support according to the release notes.