### PR TITLE
👽️ scipy 1.16 changes for `linalg.sqrtm`

### DIFF
--- a/.mypyignore-todo
+++ b/.mypyignore-todo
@@ -1,6 +1,3 @@
-scipy.linalg._matfuncs_sqrtm.__all__
-scipy.linalg._matfuncs_sqrtm.sqrtm
-
 scipy.ndimage.__all__
 scipy.ndimage._filters.__all__
 scipy.ndimage._filters.vectorized_filter

--- a/scipy-stubs/linalg/_matfuncs.pyi
+++ b/scipy-stubs/linalg/_matfuncs.pyi
@@ -1,11 +1,12 @@
 from collections.abc import Callable
 from typing import Any, Literal, TypeAlias, overload
+from typing_extensions import deprecated
 
 import numpy as np
+import optype as op
 import optype.numpy as onp
 from scipy._typing import Falsy, Truthy
 from ._expm_frechet import expm_cond, expm_frechet
-from ._matfuncs_sqrtm import sqrtm
 
 __all__ = [
     "coshm",
@@ -34,7 +35,10 @@ _Numeric2D: TypeAlias = onp.Array2D[np.number[Any]]
 _Float2D: TypeAlias = onp.Array2D[np.floating[Any]]
 _Inexact2D: TypeAlias = onp.Array2D[np.inexact[Any]]
 
+_Float64ND: TypeAlias = onp.ArrayND[np.float64]
 _FloatND: TypeAlias = onp.ArrayND[np.floating[Any]]
+_Complex128ND: TypeAlias = onp.ArrayND[np.complex128]
+_ComplexND: TypeAlias = onp.ArrayND[np.complexfloating[Any, Any]]
 _InexactND: TypeAlias = onp.ArrayND[np.inexact[Any]]
 
 _FloatFunc: TypeAlias = Callable[[onp.Array1D[np.float64]], onp.ToFloat1D]
@@ -50,6 +54,35 @@ def fractional_matrix_power(A: onp.ToFloat2D, t: onp.ToInt) -> _Real2D: ...
 def fractional_matrix_power(A: onp.ToComplex2D, t: onp.ToInt) -> _Numeric2D: ...
 @overload  # complex, float
 def fractional_matrix_power(A: onp.ToComplex2D, t: onp.ToJustFloat) -> _Complex2D: ...
+
+#
+@overload
+def sqrtm(A: onp.ToIntND | onp.ToJustFloat64_ND, disp: op.JustObject = ..., blocksize: op.JustObject = ...) -> _Float64ND: ...
+@overload
+def sqrtm(A: onp.ToJustFloatND, disp: op.JustObject = ..., blocksize: op.JustObject = ...) -> _FloatND: ...
+@overload
+def sqrtm(A: onp.ToJustComplex128_ND, disp: op.JustObject = ..., blocksize: op.JustObject = ...) -> _Complex128ND: ...
+@overload
+def sqrtm(A: onp.ToJustComplexND, disp: op.JustObject = ..., blocksize: op.JustObject = ...) -> _ComplexND: ...
+@overload
+def sqrtm(A: onp.ToComplexND, disp: op.JustObject = ..., blocksize: op.JustObject = ...) -> _InexactND: ...
+@overload
+@deprecated("The `disp` argument is deprecated and will be removed in SciPy 1.18.0.")
+def sqrtm(A: onp.ToComplexND, disp: Truthy, blocksize: op.JustObject = ...) -> _InexactND: ...
+@overload
+@deprecated("The `disp` argument is deprecated and will be removed in SciPy 1.18.0.")
+def sqrtm(A: onp.ToComplexND, disp: Falsy, blocksize: op.JustObject = ...) -> tuple[_InexactND, np.float64]: ...
+@overload
+@deprecated("The `blocksize` argument is deprecated and will be removed in SciPy 1.18.0.")
+def sqrtm(A: onp.ToComplexND, disp: op.JustObject = ..., *, blocksize: int) -> _InexactND: ...
+@overload
+@deprecated("The `blocksize` argument is deprecated and will be removed in SciPy 1.18.0.")
+@deprecated("The `disp` argument is deprecated and will be removed in SciPy 1.18.0.")
+def sqrtm(A: onp.ToComplexND, disp: Truthy, blocksize: int) -> _InexactND: ...
+@overload
+@deprecated("The `blocksize` argument is deprecated and will be removed in SciPy 1.18.0.")
+@deprecated("The `disp` argument is deprecated and will be removed in SciPy 1.18.0.")
+def sqrtm(A: onp.ToComplexND, disp: Falsy, blocksize: int) -> tuple[_InexactND, np.float64]: ...
 
 # NOTE: return dtype depends on the sign of the values
 @overload  # disp: True = ...

--- a/scipy-stubs/linalg/_matfuncs_sqrtm.pyi
+++ b/scipy-stubs/linalg/_matfuncs_sqrtm.pyi
@@ -1,19 +1,8 @@
-from typing import Any, TypeAlias, overload
-
 import numpy as np
 import optype.numpy as onp
-from scipy._typing import Falsy, Truthy
 
-__all__ = ["sqrtm"]
-
-_Inexact2D: TypeAlias = onp.Array2D[np.inexact[Any]]
-
-###
+__all__: list[str] = []
 
 class SqrtmError(np.linalg.LinAlgError): ...  # undocumented
 
-# NOTE: The output dtype (floating or complex) depends on the sign of the values, so this is the best we can do.
-@overload
-def sqrtm(A: onp.ToComplex2D, disp: Truthy = True, blocksize: onp.ToJustInt = 64) -> _Inexact2D: ...
-@overload
-def sqrtm(A: onp.ToComplex2D, disp: Falsy, blocksize: onp.ToJustInt = 64) -> tuple[_Inexact2D, np.floating[Any]]: ...
+def _sqrtm_triu(T: onp.ToComplex2D, blocksize: onp.ToJustInt = 64) -> onp.Array2D[np.float64 | np.complex128]: ...  # undocumented


### PR DESCRIPTION
The `scipy.linalg.sqrtm` function definition moved from `_matfuncs_sqrtm` to the `_matfuncs`, and its `disp` and `blocksize` parameters were deprecated and their defaults changed to an `object()` sentinel.

Relevant release note from https://github.com/scipy/scipy/releases/tag/v1.16.0rc1:

> `scipy.linalg.sqrtm` is rewritten in C and its performance is improved. It
also tries harder to return real-valued results for real-valued inputs if
possible. See the function docstring for more details. In this version the
input argument `disp` and the optional output argument `errest` are
deprecated and will be removed four versions later. Similarly, after
changing the underlying algorithm to recursion, the `blocksize` keyword
argument has no effect and will be removed two versions later.