### PR TITLE
👽️ scipy 1.16 changes for `optimize.least_squares`

### DIFF
--- a/.mypyignore-todo
+++ b/.mypyignore-todo
@@ -1,6 +1,3 @@
-scipy.optimize._lsq.trf.trf
-scipy.optimize._lsq.trf.trf_bounds
-scipy.optimize._lsq.trf.trf_no_bounds
 scipy.optimize._numdiff.approx_derivative
 scipy.optimize._trustregion_constr._minimize_trustregion_constr
 scipy.optimize._trustregion_constr.minimize_trustregion_constr._minimize_trustregion_constr

--- a/.mypyignore-todo
+++ b/.mypyignore-todo
@@ -1,4 +1,3 @@
-scipy.optimize._lsq.dogbox.dogbox
 scipy.optimize._lsq.least_squares
 scipy.optimize._lsq.least_squares.call_minpack
 scipy.optimize._lsq.least_squares.check_x_scale

--- a/.mypyignore-todo
+++ b/.mypyignore-todo
@@ -1,14 +1,9 @@
-scipy.optimize._lsq.least_squares
-scipy.optimize._lsq.least_squares.call_minpack
-scipy.optimize._lsq.least_squares.check_x_scale
-scipy.optimize._lsq.least_squares.least_squares
 scipy.optimize._lsq.trf.trf
 scipy.optimize._lsq.trf.trf_bounds
 scipy.optimize._lsq.trf.trf_no_bounds
 scipy.optimize._numdiff.approx_derivative
 scipy.optimize._trustregion_constr._minimize_trustregion_constr
 scipy.optimize._trustregion_constr.minimize_trustregion_constr._minimize_trustregion_constr
-scipy.optimize.minpack.least_squares
 scipy.optimize.nnls
 scipy.optimize._nnls.nnls
 scipy.optimize.slsqp.__all__

--- a/scipy-stubs/optimize/_differentiable_functions.pyi
+++ b/scipy-stubs/optimize/_differentiable_functions.pyi
@@ -5,7 +5,7 @@ from typing_extensions import TypeVar
 
 import numpy as np
 import optype.numpy as onp
-from scipy.sparse import csr_matrix, sparray, spmatrix
+from scipy.sparse import csr_array, sparray, spmatrix
 from scipy.sparse.linalg import LinearOperator
 from ._hessian_update_strategy import HessianUpdateStrategy
 
@@ -19,7 +19,7 @@ _ToJac: TypeAlias = onp.ToFloat2D | spmatrix | sparray
 _ToHess: TypeAlias = _ToJac | LinearOperator
 
 _Vec: TypeAlias = onp.Array1D[_XT]
-_Jac: TypeAlias = onp.Array2D[_XT] | csr_matrix
+_Jac: TypeAlias = onp.Array2D[_XT] | csr_array[_XT]
 _Hess: TypeAlias = _Jac[_XT] | LinearOperator
 
 _ScalarFun: TypeAlias = Callable[Concatenate[onp.Array1D[_XT], ...], onp.ToFloat]
@@ -37,6 +37,8 @@ _ToHessFun: TypeAlias = _HessFun[_XT_contra] | _FDMethod | HessianUpdateStrategy
 @type_check_only
 class _DoesMap(Protocol):
     def __call__(self, func: Callable[[_VT], _RT], iterable: Iterable[_VT], /) -> Iterable[_RT]: ...
+
+_Workers: TypeAlias = int | _DoesMap
 
 ###
 
@@ -155,7 +157,7 @@ class VectorFunction(Generic[_XT_contra]):
         finite_diff_jac_sparsity: _ToJac | None = None,
         finite_diff_bounds: _FDBounds = ...,
         sparse_jacobian: onp.ToBool | None = None,
-        workers: int | _DoesMap | None = None,
+        workers: _Workers | None = None,
     ) -> None: ...
     @overload
     def __init__(
@@ -206,7 +208,7 @@ class LinearVectorFunction(Generic[_XT_contra]):
     sparse_jacobian: Final[bool]
     J: Final[_Jac]
 
-    H: Final[csr_matrix]
+    H: Final[csr_array]
     v: _Vec[np.float64]
 
     @overload
@@ -232,7 +234,7 @@ class LinearVectorFunction(Generic[_XT_contra]):
     #
     def fun(self, /, x: onp.ToFloat1D) -> _Vec: ...
     def jac(self, /, x: onp.ToFloat1D) -> _Jac: ...
-    def hess(self, /, x: onp.ToFloat1D, v: _Vec[np.float64]) -> csr_matrix: ...
+    def hess(self, /, x: onp.ToFloat1D, v: _Vec[np.float64]) -> csr_array: ...
 
 class IdentityVectorFunction(LinearVectorFunction[_XT_contra]):
     @overload

--- a/scipy-stubs/optimize/_lsq/dogbox.pyi
+++ b/scipy-stubs/optimize/_lsq/dogbox.pyi
@@ -34,8 +34,7 @@ class OptimizeResult(_OptimizeResult):
     njev: int
     status: Literal[0, 1, 2, 3, 4]
 
-# undocumented
-def lsmr_operator(Jop: LinearOperator, d: _Vector_f8, active_set: _Vector_b1) -> LinearOperator: ...
+def lsmr_operator(Jop: LinearOperator, d: _Vector_f8, active_set: _Vector_b1) -> LinearOperator: ...  # undocumented
 
 #
 def find_intersection(
@@ -57,7 +56,7 @@ def dogleg_step(
     ub: _Vector_f8,
 ) -> tuple[_Vector_f8, _Vector_i0, np.bool_]: ...
 
-# undocumented
+#
 def dogbox(
     fun: _FunResid,
     jac: _FunJac,
@@ -75,4 +74,5 @@ def dogbox(
     tr_solver: TRSolver | None,
     tr_options: Mapping[str, object],
     verbose: bool,
-) -> OptimizeResult: ...
+    callback: Callable[[OptimizeResult], object] | None = None,
+) -> OptimizeResult: ...  # undocumented

--- a/scipy-stubs/optimize/_lsq/least_squares.pyi
+++ b/scipy-stubs/optimize/_lsq/least_squares.pyi
@@ -4,52 +4,112 @@ from typing import Any, Concatenate, Final, Literal, Protocol, TypeAlias, type_c
 import numpy as np
 import optype as op
 import optype.numpy as onp
-from scipy.optimize import Bounds, OptimizeResult
+from scipy.optimize import Bounds, OptimizeResult as _OptimizeResult
+from scipy.optimize._differentiable_functions import _Workers
+from scipy.sparse import csr_array
 from scipy.sparse._base import _spbase
 from scipy.sparse.linalg import LinearOperator
 
+_Ignored: TypeAlias = object
+
 _Float1D: TypeAlias = onp.Array1D[np.float64]
 _Float1ND: TypeAlias = onp.Array[onp.AtLeast1D, np.float64]
-_ToJac2D: TypeAlias = onp.ToFloat2D | _spbase
 
 _LeastSquaresMethod: TypeAlias = Literal["trf", "dogbox", "lm"]
+
 _JacMethod: TypeAlias = Literal["2-point", "3-point", "cs"]
-_Jac: TypeAlias = _JacFunction | _JacMethod
+_ToJac2D: TypeAlias = onp.ToFloat2D | _spbase
+_JacFunction: TypeAlias = Callable[Concatenate[_Float1D, ...], _ToJac2D | LinearOperator]
+_ToJac: TypeAlias = _JacFunction | _JacMethod
+
 _XScaleMethod: TypeAlias = Literal["jac"]
 _XScale: TypeAlias = onp.ToFloat | onp.ToFloatND | _XScaleMethod
+
 _LossMethod: TypeAlias = Literal["linear", "soft_l1", "huber", "cauchy", "arctan"]
-_Loss: TypeAlias = _LossFunction | _LossMethod
+_Loss: TypeAlias = _UserLossFunction | _LossMethod
 
 _ResidFunction: TypeAlias = Callable[Concatenate[_Float1D, ...], onp.ToFloat1D]
-_JacFunction: TypeAlias = Callable[Concatenate[_Float1D, ...], _ToJac2D | LinearOperator]
+
+_ResultStatus: TypeAlias = Literal[-2, -1, 0, 1, 2, 3, 4]
 
 @type_check_only
-class _LossFunction(Protocol):
-    def __call__(self, x: _Float1D, /, *, cost_only: op.CanBool | None = None) -> onp.ToFloat1D: ...
+class _UserLossFunction(Protocol):
+    def __call__(self, x: _Float1D, /, *, cost_only: bool | None = None) -> onp.ToFloat1D: ...
 
 @type_check_only
-class _OptimizeResult(OptimizeResult):
-    x: object
-    info: Mapping[str, object]
-    status: object
+class _ImplementedLossFunction(Protocol):
+    def __call__(self, /, z: onp.Array1D[np.float64], rho: onp.Array2D[np.float64], cost_only: bool) -> None: ...
+
+@type_check_only
+class _BaseOptimizeResult(_OptimizeResult):
+    x: _Float1D
+    cost: float
+    fun: _Float1D
+    jac: onp.Array2D[np.float64] | csr_array[np.float64] | LinearOperator[np.float64]
+    grad: _Float1D
+    optimality: float
+    active_mask: onp.Array1D[np.int_]
+    nfev: int
+    njev: int | None
+    status: _ResultStatus
+
+@type_check_only
+class _Callback(Protocol):
+    def __call__(self, /, *, intermediate_result: _OptimizeResult) -> _Ignored: ...
+
+_ToCallback: TypeAlias = _Callback | Callable[[_Float1D], _Ignored]
 
 ###
+# undocumented internal machinery
 
-TERMINATION_MESSAGES: Final[dict[Literal[-1, 0, 1, 2, 3, 4], str]] = ...
+TERMINATION_MESSAGES: Final[dict[_ResultStatus, str]] = ...
 FROM_MINPACK_TO_COMMON: Final[dict[Literal[0, 1, 2, 3, 4, 5], Literal[-1, 2, 3, 4, 1, 0]]] = ...
-IMPLEMENTED_LOSSES: Final[dict[str, _ResidFunction]] = ...
 
-#
-def least_squares(
+def call_minpack(
     fun: _ResidFunction,
     x0: onp.ToFloat1D,
-    jac: _Jac = "2-point",
+    jac: _ToJac | None,
+    ftol: onp.ToFloat,
+    xtol: onp.ToFloat,
+    gtol: onp.ToFloat,
+    max_nfev: onp.ToInt | None,
+    x_scale: onp.ToFloat | _Float1ND,
+    jac_method: _ToJac | None = None,
+) -> _BaseOptimizeResult: ...
+def prepare_bounds(bounds: Iterable[onp.ToFloat | onp.ToFloat1D], n: op.CanIndex) -> tuple[_Float1D, _Float1D]: ...
+def check_tolerance(
+    ftol: onp.ToFloat | None, xtol: onp.ToFloat | None, gtol: onp.ToFloat | None, method: _LeastSquaresMethod
+) -> tuple[onp.ToFloat, onp.ToFloat, onp.ToFloat]: ...
+def check_x_scale(x_scale: _XScale, x0: onp.ArrayND[np.floating[Any]], method: _LeastSquaresMethod) -> _Float1ND: ...
+def check_jac_sparsity(jac_sparsity: _ToJac2D | None, m: onp.ToInt, n: onp.ToInt) -> _Float1D: ...
+
+#
+def huber(z: onp.Array1D[np.float64], rho: onp.Array2D[np.float64], cost_only: bool) -> None: ...
+def soft_l1(z: onp.Array1D[np.float64], rho: onp.Array2D[np.float64], cost_only: bool) -> None: ...
+def cauchy(z: onp.Array1D[np.float64], rho: onp.Array2D[np.float64], cost_only: bool) -> None: ...
+def arctan(z: onp.Array1D[np.float64], rho: onp.Array2D[np.float64], cost_only: bool) -> None: ...
+
+IMPLEMENTED_LOSSES: Final[dict[Literal["linear", "huber", "soft_l1", "cauchy", "arctan"], _ImplementedLossFunction]] = ...
+
+def construct_loss_function(m: op.CanIndex, loss: _Loss, f_scale: onp.ToFloat) -> _UserLossFunction: ...
+
+###
+# public API
+
+class OptimizeResult(_BaseOptimizeResult):
+    message: str
+    success: bool
+
+def least_squares(
+    fun: _ResidFunction,
+    x0: onp.ToFloat | onp.ToFloat1D,
+    jac: _ToJac = "2-point",
     bounds: tuple[onp.ToFloat | onp.ToFloat1D, onp.ToFloat | onp.ToFloat1D] | Bounds = ...,
     method: _LeastSquaresMethod = "trf",
-    ftol: onp.ToFloat | None = 1e-08,
-    xtol: onp.ToFloat | None = 1e-08,
-    gtol: onp.ToFloat | None = 1e-08,
-    x_scale: _XScale = 1.0,
+    ftol: onp.ToFloat | None = 1e-8,
+    xtol: onp.ToFloat | None = 1e-8,
+    gtol: onp.ToFloat | None = 1e-8,
+    x_scale: _XScale | None = None,
     loss: _Loss = "linear",
     f_scale: onp.ToFloat = 1.0,
     diff_step: onp.ToFloat1D | None = None,
@@ -60,39 +120,6 @@ def least_squares(
     verbose: Literal[0, 1, 2] = 0,
     args: Iterable[object] = (),
     kwargs: Mapping[str, object] | None = None,
-) -> _OptimizeResult: ...
-
-# undocumented
-def call_minpack(
-    fun: _ResidFunction,
-    x0: onp.ToFloat1D,
-    jac: _Jac | None,
-    ftol: onp.ToFloat,
-    xtol: onp.ToFloat,
-    gtol: onp.ToFloat,
-    max_nfev: onp.ToInt | None,
-    x_scale: onp.ToFloat | _Float1ND,
-    diff_step: onp.ToFloat1D | None,
-) -> _OptimizeResult: ...
-
-# undocumented
-def prepare_bounds(bounds: Iterable[onp.ToFloat | onp.ToFloat1D], n: op.CanIndex) -> tuple[_Float1D, _Float1D]: ...
-
-# undocumented
-def check_tolerance(
-    ftol: onp.ToFloat | None,
-    xtol: onp.ToFloat | None,
-    gtol: onp.ToFloat | None,
-    method: _LeastSquaresMethod,
-) -> tuple[onp.ToFloat, onp.ToFloat, onp.ToFloat]: ...
-def check_x_scale(x_scale: _XScale, x0: onp.ArrayND[np.floating[Any]]) -> _Float1ND: ...
-def check_jac_sparsity(jac_sparsity: _ToJac2D | None, m: onp.ToInt, n: onp.ToInt) -> _Float1D: ...
-
-# undocumented
-def huber(z: onp.ArrayND[np.float64], rho: onp.ArrayND[np.float64], cost_only: op.CanBool) -> None: ...
-def soft_l1(z: onp.ArrayND[np.float64], rho: onp.ArrayND[np.float64], cost_only: op.CanBool) -> None: ...
-def cauchy(z: onp.ArrayND[np.float64], rho: onp.ArrayND[np.float64], cost_only: op.CanBool) -> None: ...
-def arctan(z: onp.ToFloat, rho: onp.ArrayND[np.float64], cost_only: op.CanBool) -> None: ...
-
-# undocumented
-def construct_loss_function(m: op.CanIndex, loss: _Loss, f_scale: onp.ToFloat) -> Callable[[_Float1D], _Float1D]: ...
+    callback: _ToCallback | None = None,
+    workers: _Workers | None = None,
+) -> OptimizeResult: ...

--- a/scipy-stubs/optimize/_lsq/trf.pyi
+++ b/scipy-stubs/optimize/_lsq/trf.pyi
@@ -1,27 +1,25 @@
 from collections.abc import Callable, Mapping
-from typing import Literal, TypeAlias, type_check_only
-from typing_extensions import TypeVar
+from typing import Any, Literal, TypeAlias
 
 import numpy as np
 import optype.numpy as onp
-from scipy.optimize import OptimizeResult
+from scipy.optimize import OptimizeResult as _OptimizeResult
 from scipy.optimize._typing import TRSolver
 from scipy.sparse import sparray, spmatrix
 from scipy.sparse.linalg import LinearOperator
 
-_ShapeT = TypeVar("_ShapeT", bound=tuple[int, ...], default=tuple[int, ...])
-
+_Ignored: TypeAlias = object
 _ValueFloat: TypeAlias = float | np.float64
 
-_ArrayFloat: TypeAlias = onp.Array[_ShapeT, np.float64]
-_MatrixFloat: TypeAlias = onp.Array[_ShapeT, np.float64] | sparray | spmatrix | LinearOperator
+_ArrayFloat: TypeAlias = onp.ArrayND[np.float64]
+_MatrixFloat: TypeAlias = onp.ArrayND[np.float64] | sparray | spmatrix | LinearOperator
 
-_FunObj: TypeAlias = Callable[[_ArrayFloat[tuple[int]], _ValueFloat], _MatrixFloat]
-_FunJac: TypeAlias = Callable[[_ArrayFloat[tuple[int]], _ValueFloat], _MatrixFloat]
+_FunObj: TypeAlias = Callable[[onp.Array1D[np.float64], _ValueFloat], _MatrixFloat]
+_FunJac: TypeAlias = Callable[[onp.Array1D[np.float64], _ValueFloat], _MatrixFloat]
 _FunLoss: TypeAlias = Callable[[_ValueFloat], _ValueFloat]
+_FunCallback: TypeAlias = Callable[[OptimizeResult], _Ignored]
 
-@type_check_only
-class _OptimizeResult(OptimizeResult):
+class OptimizeResult(_OptimizeResult):
     x: _ArrayFloat
     jac: _MatrixFloat
     cost: _ValueFloat
@@ -34,7 +32,7 @@ class _OptimizeResult(OptimizeResult):
     x_scale: _ValueFloat | _ArrayFloat
     loss_function: _ValueFloat | _ArrayFloat
     tr_solver: TRSolver | None
-    tr_options: Mapping[str, object]
+    tr_options: Mapping[str, Any]
 
 # undocumented
 def trf(
@@ -54,7 +52,8 @@ def trf(
     tr_solver: TRSolver | None,
     tr_options: Mapping[str, object],
     verbose: bool,
-) -> _OptimizeResult: ...
+    callback: _FunCallback | None = None,
+) -> OptimizeResult: ...
 
 # undocumented
 def trf_bounds(
@@ -74,7 +73,8 @@ def trf_bounds(
     tr_solver: TRSolver | None,
     tr_options: Mapping[str, object],
     verbose: bool,
-) -> _OptimizeResult: ...
+    callback: _FunCallback | None = None,
+) -> OptimizeResult: ...
 
 # undocumented
 def trf_no_bounds(
@@ -92,7 +92,8 @@ def trf_no_bounds(
     tr_solver: TRSolver | None,
     tr_options: Mapping[str, object],
     verbose: bool,
-) -> _OptimizeResult: ...
+    callback: _FunCallback | None = None,
+) -> OptimizeResult: ...
 
 # undocumented
 def select_step(

--- a/scipy-stubs/optimize/minpack.pyi
+++ b/scipy-stubs/optimize/minpack.pyi
@@ -6,20 +6,13 @@ from typing_extensions import deprecated
 __all__ = ["OptimizeResult", "OptimizeWarning", "curve_fit", "fixed_point", "fsolve", "least_squares", "leastsq", "zeros"]
 
 @deprecated("will be removed in SciPy v2.0.0")
-def zeros(
-    shape: object,
-    dtype: object = ...,
-    order: object = ...,
-    *,
-    device: object = ...,
-    like: object = ...,
-) -> object: ...
-@deprecated("will be removed in SciPy v2.0.0")
 class OptimizeResult(Any): ...
 
 @deprecated("will be removed in SciPy v2.0.0")
 class OptimizeWarning(UserWarning): ...
 
+@deprecated("will be removed in SciPy v2.0.0")
+def zeros(shape: object, dtype: object = ..., order: object = ..., *, device: object = ..., like: object = ...) -> object: ...
 @deprecated("will be removed in SciPy v2.0.0")
 def least_squares(
     fun: object,
@@ -41,6 +34,8 @@ def least_squares(
     verbose: object = ...,
     args: tuple[object, ...] = (),
     kwargs: dict[str, object] | None = None,
+    callback: object | None = None,
+    workers: object | None = None,
 ) -> OptimizeResult: ...  # pyright: ignore[reportDeprecated]
 @deprecated("will be removed in SciPy v2.0.0")
 def fsolve(


### PR DESCRIPTION
from the 1.16.0rc1 brelease notes:

> `scipy.optimize.least_squares` has a new `callback` argument that is applicable
to the `trf` and `dogbox` methods. `callback` may be used to track
optimization results at each step or to provide custom conditions for
stopping.