### PR TITLE
👽️ scipy 1.16 changes for `optimize._numdiff`

### DIFF
--- a/.mypyignore-todo
+++ b/.mypyignore-todo
@@ -1,4 +1,3 @@
-scipy.optimize._numdiff.approx_derivative
 scipy.optimize._trustregion_constr._minimize_trustregion_constr
 scipy.optimize._trustregion_constr.minimize_trustregion_constr._minimize_trustregion_constr
 scipy.optimize.nnls

--- a/scipy-stubs/optimize/_numdiff.pyi
+++ b/scipy-stubs/optimize/_numdiff.pyi
@@ -1,11 +1,12 @@
 from collections.abc import Callable, Iterable, Mapping
-from typing import Concatenate, Literal, TypeAlias, overload
+from typing import Concatenate, Literal, TypeAlias, TypedDict, overload, type_check_only
 
 import numpy as np
 import optype.numpy as onp
 from scipy._typing import Falsy, Truthy
-from scipy.sparse import csr_matrix, sparray, spmatrix
+from scipy.sparse import csr_array, sparray, spmatrix
 from scipy.sparse.linalg import LinearOperator
+from ._differentiable_functions import _DoesMap
 
 _ToSparse: TypeAlias = spmatrix | sparray
 
@@ -20,12 +21,16 @@ _Sparsity: TypeAlias = _ToIntMatrix | tuple[_ToIntMatrix, onp.ToFloat1D]
 _Fun: TypeAlias = Callable[Concatenate[_Float1D, ...], _ToFloatOr1D]
 _Jac: TypeAlias = Callable[Concatenate[_Float1D, ...], onp.ToFloat1D | _ToFloatMatrix]
 
+@type_check_only
+class _InfoDict(TypedDict):
+    nfev: int
+
 ###
 
 def group_columns(A: _ToFloatMatrix, order: onp.ToInt | Iterable[onp.ToInt] = 0) -> onp.Array1D[np.intp]: ...
 
 #
-@overload  # sparsity: None (default), as_linear_operator: False (default)
+@overload  # sparsity: None (default), as_linear_operator: False (default), full_output: False (default)
 def approx_derivative(
     fun: _Fun,
     x0: _ToFloatOr1D,
@@ -38,8 +43,10 @@ def approx_derivative(
     as_linear_operator: Falsy = False,
     args: tuple[object, ...] = (),
     kwargs: Mapping[str, object] | None = None,
+    full_output: Falsy = False,
+    workers: int | _DoesMap | None = None,
 ) -> _Float1D | onp.Array2D[np.float64]: ...
-@overload  # sparsity: <given>, as_linear_operator: False (default)
+@overload  # sparsity: <given>, as_linear_operator: False (default), full_output: False (default)
 def approx_derivative(
     fun: _Fun,
     x0: _ToFloatOr1D,
@@ -53,8 +60,10 @@ def approx_derivative(
     as_linear_operator: Falsy = False,
     args: tuple[object, ...] = (),
     kwargs: Mapping[str, object] | None = None,
-) -> csr_matrix: ...
-@overload  # as_linear_operator: True
+    full_output: Falsy = False,
+    workers: int | _DoesMap | None = None,
+) -> csr_array: ...
+@overload  # as_linear_operator: True, full_output: False (default)
 def approx_derivative(
     fun: _Fun,
     x0: _ToFloatOr1D,
@@ -68,7 +77,60 @@ def approx_derivative(
     as_linear_operator: Truthy,
     args: tuple[object, ...] = (),
     kwargs: Mapping[str, object] | None = None,
+    full_output: Falsy = False,
+    workers: int | _DoesMap | None = None,
 ) -> LinearOperator: ...
+@overload  # sparsity: None (default), as_linear_operator: False (default), full_output: True (keyword)
+def approx_derivative(
+    fun: _Fun,
+    x0: _ToFloatOr1D,
+    method: Literal["2-point", "3-point", "cs"] = "3-point",
+    rel_step: _ToFloatOr1D | None = None,
+    abs_step: _ToFloatOr1D | None = None,
+    f0: _ToFloatOr1D | None = None,
+    bounds: tuple[_ToFloatOr1D, _ToFloatOr1D] = ...,
+    sparsity: None = None,
+    as_linear_operator: Falsy = False,
+    args: tuple[object, ...] = (),
+    kwargs: Mapping[str, object] | None = None,
+    *,
+    full_output: Truthy,
+    workers: int | _DoesMap | None = None,
+) -> tuple[_Float1D | onp.Array2D[np.float64], _InfoDict]: ...
+@overload  # sparsity: <given>, as_linear_operator: False (default), full_output: True
+def approx_derivative(
+    fun: _Fun,
+    x0: _ToFloatOr1D,
+    method: Literal["2-point", "3-point", "cs"] = "3-point",
+    rel_step: _ToFloatOr1D | None = None,
+    abs_step: _ToFloatOr1D | None = None,
+    f0: _ToFloatOr1D | None = None,
+    bounds: tuple[_ToFloatOr1D, _ToFloatOr1D] = ...,
+    *,
+    sparsity: _Sparsity,
+    as_linear_operator: Falsy = False,
+    args: tuple[object, ...] = (),
+    kwargs: Mapping[str, object] | None = None,
+    full_output: Truthy,
+    workers: int | _DoesMap | None = None,
+) -> tuple[csr_array, _InfoDict]: ...
+@overload  # as_linear_operator: True, full_output: True
+def approx_derivative(
+    fun: _Fun,
+    x0: _ToFloatOr1D,
+    method: Literal["2-point", "3-point", "cs"] = "3-point",
+    rel_step: _ToFloatOr1D | None = None,
+    abs_step: _ToFloatOr1D | None = None,
+    f0: _ToFloatOr1D | None = None,
+    bounds: tuple[_ToFloatOr1D, _ToFloatOr1D] = ...,
+    sparsity: _Sparsity | None = None,
+    *,
+    as_linear_operator: Truthy,
+    args: tuple[object, ...] = (),
+    kwargs: Mapping[str, object] | None = None,
+    full_output: Truthy,
+    workers: int | _DoesMap | None = None,
+) -> tuple[LinearOperator, _InfoDict]: ...
 
 #
 def check_derivative(


### PR DESCRIPTION
The private `scipy.optimize._numdiff.approx_derivative` function has gotten two new parameters: `full_output` and `workers`.