### PR TITLE
👽️ scipy 1.16 changes for `optimize.slsqp`

### DIFF
--- a/.mypyignore-todo
+++ b/.mypyignore-todo
@@ -1,6 +1,3 @@
-scipy.optimize.slsqp.__all__
-scipy.optimize.slsqp.zeros
-
 scipy.signal.ShortTimeFFT.from_win_equals_dual
 scipy.signal.__all__
 scipy.signal._fir_filter_design.__all__

--- a/scipy-stubs/optimize/_slsqp_py.pyi
+++ b/scipy-stubs/optimize/_slsqp_py.pyi
@@ -1,8 +1,9 @@
 from collections.abc import Callable, Sequence
-from typing import Concatenate, Final, Literal, TypeAlias, TypeVar, overload
+from typing import Any, Concatenate, Final, Literal, TypeAlias, TypedDict, TypeVar, overload, type_check_only
 
 import numpy as np
 import optype.numpy as onp
+import optype.numpy.compat as npc
 from scipy._typing import Falsy, Truthy
 
 __all__ = ["approx_jacobian", "fmin_slsqp"]
@@ -31,6 +32,17 @@ _ExitDesc: TypeAlias = Literal[
     "Positive directional derivative for linesearch",  # 8
     "Iteration limit reached",  # 9
 ]
+
+@type_check_only
+class _ConDict(TypedDict):
+    fun: Callable[..., onp.ToFloat]
+    jac: Callable[..., onp.ToFloat2D] | None
+    args: tuple[Any, ...]
+
+@type_check_only
+class _ConsDict(TypedDict):
+    eq: tuple[_ConDict, ...]
+    ineq: tuple[_ConDict, ...]
 
 ###
 
@@ -83,3 +95,7 @@ def fmin_slsqp(
     epsilon: onp.ToFloat = ...,  # = np.sqrt(np.finfo(float).eps)
     callback: Callable[[onp.Array1D[np.float64]], _Ignored] | None = None,
 ) -> tuple[onp.Array1D[np.float64], float | np.float64, int, _ExitMode, _ExitDesc]: ...
+
+#
+def _eval_constraint(d: onp.Array1D[np.float64], x: onp.Array1D[npc.floating], cons: _ConsDict, m: int, meq: int) -> None: ...
+def _eval_con_normals(C: onp.Array2D[np.float64], x: onp.Array1D[npc.floating], cons: _ConsDict, m: int, meq: int) -> None: ...

--- a/scipy-stubs/optimize/slsqp.pyi
+++ b/scipy-stubs/optimize/slsqp.pyi
@@ -4,17 +4,8 @@ from collections.abc import Callable
 from typing import Any
 from typing_extensions import deprecated
 
-__all__ = ["OptimizeResult", "fmin_slsqp", "slsqp", "zeros"]
+__all__ = ["OptimizeResult", "fmin_slsqp", "slsqp"]
 
-@deprecated("will be removed in SciPy v2.0.0")
-def zeros(
-    shape: object,
-    dtype: object = ...,
-    order: object = ...,
-    *,
-    device: object = ...,
-    like: object = ...,
-) -> object: ...
 @deprecated("will be removed in SciPy v2.0.0")
 class OptimizeResult(Any): ...
 
@@ -38,7 +29,6 @@ def fmin_slsqp(
     full_output: object = ...,
     epsilon: object = ...,
     callback: object = ...,
-) -> object: ...
+) -> Any: ...  # noqa: ANN401
 
-# Deprecated
-slsqp: Callable[..., object]
+slsqp: Callable[..., Any] = ...  # deprecated


### PR DESCRIPTION
The deprecated `scipy.optimize.slsqp.zeros` function has been removed. 

**The [1.16.0rc1 release notes](https://github.com/scipy/scipy/releases/tag/v1.16.0rc1) do not mention this.**