### PR TITLE
👽️ scipy 1.16 new internal module `_lib._sparse`

### DIFF
--- a/scipy-stubs/_lib/_sparse.pyi
+++ b/scipy-stubs/_lib/_sparse.pyi
@@ -1,0 +1,8 @@
+from abc import ABC
+from typing_extensions import TypeIs
+
+__all__ = ["SparseABC", "issparse"]
+
+class SparseABC(ABC): ...
+
+def issparse(x: object) -> TypeIs[SparseABC]: ...


### PR DESCRIPTION
Related to

> The internal dependency of `scipy._lib` on `scipy.sparse` was removed,
which reduces the import time of a number of other SciPy submodules.

from https://github.com/scipy/scipy/releases/tag/v1.16.0rc1