### PR TITLE
👽️ scipy 1.16 changes for `sparse.csgraph._shortest_path`

### DIFF
--- a/.mypyignore-todo
+++ b/.mypyignore-todo
@@ -1,7 +1,5 @@
 scipy.sparse._dok._dok_base.conjtransp
 scipy.sparse._sputils.validateaxis
-scipy.sparse.csgraph._shortest_path.__reduce_cython__
-scipy.sparse.csgraph._shortest_path.__setstate_cython__
 
 scipy.spatial.transform.RigidTransform
 scipy.spatial.transform.__all__

--- a/scipy-stubs/sparse/csgraph/_shortest_path.pyi
+++ b/scipy-stubs/sparse/csgraph/_shortest_path.pyi
@@ -1,4 +1,4 @@
-from typing import Final, Literal, TypeAlias, overload
+from typing import Literal, TypeAlias, overload
 
 import numpy as np
 import optype.numpy as onp
@@ -17,8 +17,8 @@ _ShortestPathMethod: TypeAlias = Literal["auto", "FW", "D", "BF", "J"]
 
 ###
 
-DTYPE: Final[type[np.float64]] = ...
-ITYPE: Final[type[np.int32]] = ...
+def __setstate_cython__(self: object, pyx_state: object, /) -> None: ...  # undocumented
+def __reduce_cython__(self: object) -> None: ...  # undocumented
 
 class NegativeCycleError(Exception):
     def __init__(self, /, message: str = "") -> None: ...


### PR DESCRIPTION
The following functions have been added to the public namespace of the private `scipy.sparse.csgraph._shortest_path` submodule:

- `__reduce_cython__`
- `__setstate_cython__`

and the following constants were removed

- `DTYPE`
- `ITEM`
