### PR TITLE
👽️ scipy 1.16 expired deprecations for `sparse._dok`

### DIFF
--- a/.mypyignore-todo
+++ b/.mypyignore-todo
@@ -1,5 +1,3 @@
-scipy.sparse._dok._dok_base.conjtransp
-
 scipy.spatial.transform.RigidTransform
 scipy.spatial.transform.__all__
 scipy.spatial.transform._rotation.compose_quat

--- a/scipy-stubs/sparse/_dok.pyi
+++ b/scipy-stubs/sparse/_dok.pyi
@@ -203,9 +203,6 @@ class _dok_base(
     def get(self, /, key: _ToKey1D | _ToKey2D, default: float = 0.0) -> _SCT | float: ...
 
     #
-    def conjtransp(self, /) -> Self: ...
-
-    #
     @overload
     @classmethod
     def fromkeys(cls: type[_dok_base[_SCT, _2D]], iterable: _ToKeys2D, v: _SCT, /) -> _dok_base[_SCT, _2D]: ...


### PR DESCRIPTION
Relevant portion of the ]`1.16.0rc1 `release notes](https://github.com/scipy/scipy/releases/tag/v1.16.0rc1):

> `scipy.sparse.conjtransp` has been removed. Use `.T.conj()` instead.