### PR TITLE
👽️ scipy 1.16 additions for `spatial.transform._rotation`

### DIFF
--- a/.mypyignore-todo
+++ b/.mypyignore-todo
@@ -1,6 +1,6 @@
 scipy.spatial.transform.RigidTransform
 scipy.spatial.transform.__all__
-scipy.spatial.transform._rotation.compose_quat
+
 scipy.special._support_alternative_backends.__all__
 scipy.special._support_alternative_backends.stdtrit
 

--- a/scipy-stubs/spatial/transform/_rotation.pyi
+++ b/scipy-stubs/spatial/transform/_rotation.pyi
@@ -1,3 +1,5 @@
+# https://github.com/scipy/scipy/blob/maintenance/1.16.x/scipy/spatial/transform/_rotation.pyx
+
 from collections.abc import Sequence
 from typing import Final, Literal as L, Self, TypeAlias, overload
 from typing_extensions import TypeVar
@@ -170,3 +172,6 @@ class Slerp:
 
     def __init__(self, /, times: onp.ToFloat1D, rotations: Rotation) -> None: ...
     def __call__(self, /, times: onp.ToFloat1D) -> Rotation: ...
+
+# (double[:, :], double[:, :]) -> noexcept double[:, :]
+def compose_quat(p: onp.ArrayND[np.float64], q: onp.ArrayND[np.float64]) -> onp.Array2D[np.float64]: ...  # undocumented


### PR DESCRIPTION
A new public function has been added to the private `scipy.spatial.transform._rotation` module, `compose_quat`, with signature `(f64[:, :], f64[:, :]) -> f64[:, :]`.
