### PR TITLE
👽️ scipy 1.16 changes for `special._support_alternative_backends`

### DIFF
--- a/.mypyignore
+++ b/.mypyignore
@@ -32,6 +32,7 @@ scipy\.special\._support_alternative_backends\.xlogy
 scipy\.special\._support_alternative_backends\.chdtrc?
 scipy\.special\._support_alternative_backends\.(log_)?ndtri?
 scipy\.special\._support_alternative_backends\.stdtr
+scipy\.special\._support_alternative_backends\.stdtrit
 scipy\.special\._ufuncs\._(hypergeom|n?binom)_(pm|cd|pp|i?s)f
 scipy\.special\._ufuncs\._(hypergeom|nbinom|nc(f|t))_(mean|variance|skewness|kurtosis_excess)
 scipy\.special\._ufuncs\._(beta|cauchy|invgauss|landau|nc(f|t|x2)|skewnorm)_(pd|cd|pp|i?s)f

--- a/.mypyignore-todo
+++ b/.mypyignore-todo
@@ -1,6 +1,3 @@
-scipy.special._support_alternative_backends.__all__
-scipy.special._support_alternative_backends.stdtrit
-
 scipy.stats.Binomial
 scipy.stats.Mixture.logpmf
 scipy.stats.Mixture.pmf

--- a/scipy-stubs/special/_support_alternative_backends.pyi
+++ b/scipy-stubs/special/_support_alternative_backends.pyi
@@ -20,6 +20,7 @@ from ._ufuncs import (
     ndtri,
     rel_entr,
     stdtr,
+    stdtrit,
     xlogy,
 )
 
@@ -45,5 +46,6 @@ __all__ = [
     "ndtri",
     "rel_entr",
     "stdtr",
+    "stdtrit",
     "xlogy",
 ]


### PR DESCRIPTION
The private `scipy.special._support_alternative_backends` module was changed to additionally export the `stdtrit` ufunc through its `__all__`.