### PR TITLE
👽️ scipy 1.16 changes for `stats.f_oneway`

### DIFF
--- a/.mypyignore-todo
+++ b/.mypyignore-todo
@@ -6,7 +6,6 @@ scipy\.stats\.(_?morestats\.)?boxcox_llf
 scipy\.stats\.(_?kde\.)?gaussian_kde\.integrate_box
 scipy\.stats\.mstats\.chisquare
 scipy\.stats\.(stats\.|_stats_py\.)?chisquare
-scipy\.stats\.(stats\.|_stats_py\.)?f_oneway
 scipy\.stats\.(stats\.|_stats_py\.)?gstd
 scipy\.stats\.(stats\.|_stats_py\.)?kendalltau
 scipy\.stats\.(stats\.|_stats_py\.)?linregress

--- a/scipy-stubs/stats/_stats_py.pyi
+++ b/scipy-stubs/stats/_stats_py.pyi
@@ -636,6 +636,7 @@ def trim_mean(a: onp.ToFloatND, proportiontocut: float, axis: int | None = 0) ->
 def f_oneway(
     *samples: onp.ToFloatND,
     nan_policy: NanPolicy = "propagate",
+    equal_var: bool = True,
     axis: int | None = 0,
     keepdims: bool = False,
 ) -> F_onewayResult: ...

--- a/scipy-stubs/stats/stats.pyi
+++ b/scipy-stubs/stats/stats.pyi
@@ -281,7 +281,13 @@ def trim1(a: object, proportiontocut: object, tail: object = ..., axis: object =
 @deprecated("will be removed in SciPy v2.0.0")
 def trim_mean(a: object, proportiontocut: object, axis: object = ...) -> object: ...
 @deprecated("will be removed in SciPy v2.0.0")
-def f_oneway(*samples: object, axis: object = ..., nan_policy: object = ..., keepdims: object = ...) -> object: ...
+def f_oneway(
+    *samples: object,
+    axis: object = ...,
+    equal_var: object = ...,
+    nan_policy: object = ...,
+    keepdims: object = ...,
+) -> object: ...
 @deprecated("will be removed in SciPy v2.0.0")
 def alexandergovern(*samples: object, nan_policy: object = ..., axis: object = ..., keepdims: object = ...) -> object: ...
 @deprecated("will be removed in SciPy v2.0.0")
@@ -289,13 +295,7 @@ def pearsonr(x: object, y: object, *, alternative: object = ..., method: object 
 @deprecated("will be removed in SciPy v2.0.0")
 def fisher_exact(table: object, alternative: object = ..., *, method: object = ...) -> object: ...
 @deprecated("will be removed in SciPy v2.0.0")
-def spearmanr(
-    a: object,
-    b: object = ...,
-    axis: object = ...,
-    nan_policy: object = ...,
-    alternative: object = ...,
-) -> object: ...
+def spearmanr(a: object, b: object = ..., axis: object = ..., nan_policy: object = ..., alternative: object = ...) -> object: ...
 @deprecated("will be removed in SciPy v2.0.0")
 def pointbiserialr(x: object, y: object) -> object: ...
 @deprecated("will be removed in SciPy v2.0.0")


### PR DESCRIPTION
From the [`1.16.0rc1` release notes](https://github.com/scipy/scipy/releases/tag/v1.16.0rc1):

> An `equal_var` keyword was added to (...) `scipy.stats.f_oneway` (enables Welch ANOVA).