### PR TITLE
👽️ scipy 1.16 changes for `stats.power_divergence` and `stats.chisquare`

### DIFF
--- a/.mypyignore-todo
+++ b/.mypyignore-todo
@@ -1,8 +1,4 @@
-scipy\.stats\.mstats\.chisquare
-scipy\.stats\.(stats\.|_stats_py\.)?chisquare
-scipy\.stats\.(stats\.|_stats_py\.)?power_divergence
 scipy\.stats\.(stats\.|_stats_py\.)?linregress
-
 scipy\.stats\.(stats\.|_stats_py\.)?pointbiserialr
 scipy\.stats\.(stats\.|_stats_py\.)?kendalltau
 scipy\.stats\.(stats\.|_stats_py\.)?weightedtau

--- a/scipy-stubs/stats/_stats_py.pyi
+++ b/scipy-stubs/stats/_stats_py.pyi
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from collections.abc import Callable, Sequence
 from types import ModuleType
-from typing import Generic, Literal as L, Protocol, Self, TypeAlias, overload, type_check_only
+from typing import Any, Generic, Literal as L, Protocol, Self, TypeAlias, overload, type_check_only
 from typing_extensions import NamedTuple, TypeVar, deprecated
 
 import numpy as np
@@ -865,15 +865,97 @@ def ttest_rel(
 ) -> TtestResult: ...
 
 #
+@overload
+def power_divergence(
+    f_obs: onp.ToFloatStrict1D,
+    f_exp: onp.ToFloatStrict1D | None = None,
+    ddof: int = 0,
+    axis: int | None = 0,
+    lambda_: PowerDivergenceStatistic | float | None = None,
+    *,
+    keepdims: L[False] = False,
+    nan_policy: NanPolicy = "propagate",
+) -> Power_divergenceResult[np.float64]: ...
+@overload
+def power_divergence(
+    f_obs: onp.ToFloatND,
+    f_exp: onp.ToFloatND | None,
+    ddof: int,
+    axis: None,
+    lambda_: PowerDivergenceStatistic | float | None = None,
+    *,
+    keepdims: L[False] = False,
+    nan_policy: NanPolicy = "propagate",
+) -> Power_divergenceResult[np.float64]: ...
+@overload
+def power_divergence(
+    f_obs: onp.ToFloatND,
+    f_exp: onp.ToFloatND | None = None,
+    ddof: int = 0,
+    *,
+    axis: None,
+    lambda_: PowerDivergenceStatistic | float | None = None,
+    keepdims: L[False] = False,
+    nan_policy: NanPolicy = "propagate",
+) -> Power_divergenceResult[np.float64]: ...
+@overload
 def power_divergence(
     f_obs: onp.ToFloatND,
     f_exp: onp.ToFloatND | None = None,
     ddof: int = 0,
     axis: int | None = 0,
     lambda_: PowerDivergenceStatistic | float | None = None,
-) -> Power_divergenceResult: ...
+    *,
+    keepdims: L[True],
+    nan_policy: NanPolicy = "propagate",
+) -> Power_divergenceResult[onp.ArrayND[np.float64]]: ...
+@overload
+def power_divergence(
+    f_obs: onp.ToFloatND,
+    f_exp: onp.ToFloatND | None = None,
+    ddof: int = 0,
+    axis: int | None = 0,
+    lambda_: PowerDivergenceStatistic | float | None = None,
+    *,
+    keepdims: bool = False,
+    nan_policy: NanPolicy = "propagate",
+) -> Power_divergenceResult[np.float64 | Any]: ...
 
 #
+@overload
+def chisquare(
+    f_obs: onp.ToFloatStrict1D,
+    f_exp: onp.ToFloatStrict1D | None = None,
+    ddof: int = 0,
+    axis: int | None = 0,
+    *,
+    sum_check: bool = True,
+    keepdims: L[False] = False,
+    nan_policy: NanPolicy = "propagate",
+) -> Power_divergenceResult[np.float64]: ...
+@overload
+def chisquare(
+    f_obs: onp.ToFloatND,
+    f_exp: onp.ToFloatND | None,
+    ddof: int,
+    axis: None,
+    *,
+    sum_check: bool = True,
+    keepdims: L[False] = False,
+    nan_policy: NanPolicy = "propagate",
+) -> Power_divergenceResult[np.float64]: ...
+@overload
+def chisquare(
+    f_obs: onp.ToFloatND,
+    f_exp: onp.ToFloatND | None = None,
+    ddof: int = 0,
+    *,
+    axis: None,
+    sum_check: bool = True,
+    keepdims: L[False] = False,
+    nan_policy: NanPolicy = "propagate",
+) -> Power_divergenceResult[np.float64]: ...
+@overload
 def chisquare(
     f_obs: onp.ToFloatND,
     f_exp: onp.ToFloatND | None = None,
@@ -881,7 +963,20 @@ def chisquare(
     axis: int | None = 0,
     *,
     sum_check: bool = True,
-) -> Power_divergenceResult: ...
+    keepdims: L[True],
+    nan_policy: NanPolicy = "propagate",
+) -> Power_divergenceResult[onp.ArrayND[np.float64]]: ...
+@overload
+def chisquare(
+    f_obs: onp.ToFloatND,
+    f_exp: onp.ToFloatND | None = None,
+    ddof: int = 0,
+    axis: int | None = 0,
+    *,
+    sum_check: bool = True,
+    keepdims: bool = False,
+    nan_policy: NanPolicy = "propagate",
+) -> Power_divergenceResult[np.float64 | Any]: ...
 
 #
 def ks_1samp(

--- a/scipy-stubs/stats/stats.pyi
+++ b/scipy-stubs/stats/stats.pyi
@@ -363,9 +363,21 @@ def power_divergence(
     ddof: object = ...,
     axis: object = ...,
     lambda_: object = ...,
+    *,
+    keepdims: object = ...,
+    nan_policy: object = ...,
 ) -> object: ...
 @deprecated("will be removed in SciPy v2.0.0")
-def chisquare(f_obs: object, f_exp: object = ..., ddof: object = ..., axis: object = ..., *, sum_check: bool = ...) -> object: ...
+def chisquare(
+    f_obs: object,
+    f_exp: object = ...,
+    ddof: object = ...,
+    axis: object = ...,
+    *,
+    sum_check: bool = ...,
+    keepdims: object = ...,
+    nan_policy: object = ...,
+) -> object: ...
 @deprecated("will be removed in SciPy v2.0.0")
 def ks_1samp(
     x: object,


### PR DESCRIPTION
From the [`1.16.0rc1` release notes](https://github.com/scipy/scipy/releases/tag/v1.16.0rc1):

> Support for `axis`, `nan_policy`, and `keepdims` keywords was added to `scipy.stats.power_divergence`, `scipy.stats.chisquare` (...)
