### PR TITLE
👽️ scipy 1.16 expired deprecation for `stats.linregress`

### DIFF
--- a/scipy-stubs/stats/_stats_py.pyi
+++ b/scipy-stubs/stats/_stats_py.pyi
@@ -1114,14 +1114,7 @@ def rankdata(
 def expectile(a: onp.ToFloatND, alpha: float = 0.5, *, weights: onp.ToFloatND | None = None) -> np.float64: ...
 
 #
-@overload
 def linregress(x: onp.ToFloatND, y: onp.ToFloatND, alternative: Alternative = "two-sided") -> LinregressResult: ...
-@overload
-@deprecated(
-    "Inference of the two sets of measurements from a single argument `x` is deprecated will result in an error in SciPy 1.16.0; "
-    "the sets must be specified separately as `x` and `y`."
-)
-def linregress(x: onp.ToFloatND, y: None = None, alternative: Alternative = "two-sided") -> LinregressResult: ...
 
 #
 @deprecated(


### PR DESCRIPTION
From the [`1.16.0rc1` release notes](https://github.com/scipy/scipy/releases/tag/v1.16.0rc1):

> Support for inference of the two sets of measurements from the single
argument `x` has been removed from `scipy.stats.linregress`. The data
must be specified separately as `x` and `y`.