### PR TITLE
👽️ scipy 1.16 changes for `stats.{kendall,weighted}tau`

### DIFF
--- a/.mypyignore-todo
+++ b/.mypyignore-todo
@@ -1,1 +1,0 @@
-scipy\.stats\.(stats\.|_stats_py\.)?weightedtau

--- a/.mypyignore-todo
+++ b/.mypyignore-todo
@@ -1,2 +1,1 @@
-scipy\.stats\.(stats\.|_stats_py\.)?kendalltau
 scipy\.stats\.(stats\.|_stats_py\.)?weightedtau

--- a/scipy-stubs/stats/_stats_py.pyi
+++ b/scipy-stubs/stats/_stats_py.pyi
@@ -772,15 +772,78 @@ def pointbiserialr(
 ) -> SignificanceResult[np.float64 | Any]: ...
 
 #
+@overload
 def kendalltau(
     x: onp.ToFloatND,
     y: onp.ToFloatND,
     *,
-    nan_policy: NanPolicy = "propagate",
     method: _KendallTauMethod = "auto",
     variant: _KendallTauVariant = "b",
     alternative: Alternative = "two-sided",
-) -> SignificanceResult[float]: ...
+    axis: None,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: L[False] = False,
+) -> SignificanceResult[np.float64]: ...
+@overload
+def kendalltau(
+    x: onp.ToFloatStrict1D,
+    y: onp.ToFloatStrict1D,
+    *,
+    method: _KendallTauMethod = "auto",
+    variant: _KendallTauVariant = "b",
+    alternative: Alternative = "two-sided",
+    axis: int | None = 0,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: L[False] = False,
+) -> SignificanceResult[np.float64]: ...
+@overload
+def kendalltau(
+    x: onp.ToFloatStrict2D,
+    y: onp.ToFloatStrict2D,
+    *,
+    method: _KendallTauMethod = "auto",
+    variant: _KendallTauVariant = "b",
+    alternative: Alternative = "two-sided",
+    axis: int = 0,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: L[False] = False,
+) -> SignificanceResult[onp.Array1D[np.float64]]: ...
+@overload
+def kendalltau(
+    x: onp.ToFloatStrict3D,
+    y: onp.ToFloatStrict3D,
+    *,
+    method: _KendallTauMethod = "auto",
+    variant: _KendallTauVariant = "b",
+    alternative: Alternative = "two-sided",
+    axis: int = 0,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: L[False] = False,
+) -> SignificanceResult[onp.Array2D[np.float64]]: ...
+@overload
+def kendalltau(
+    x: onp.ToFloatND,
+    y: onp.ToFloatND,
+    *,
+    method: _KendallTauMethod = "auto",
+    variant: _KendallTauVariant = "b",
+    alternative: Alternative = "two-sided",
+    axis: int | None = 0,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: L[True],
+) -> SignificanceResult[onp.ArrayND[np.float64]]: ...
+@overload
+def kendalltau(
+    x: onp.ToFloatND,
+    y: onp.ToFloatND,
+    *,
+    method: _KendallTauMethod = "auto",
+    variant: _KendallTauVariant = "b",
+    alternative: Alternative = "two-sided",
+    axis: int | None = 0,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: bool = False,
+) -> SignificanceResult[np.float64 | Any]: ...
 
 #
 def weightedtau(

--- a/scipy-stubs/stats/_stats_py.pyi
+++ b/scipy-stubs/stats/_stats_py.pyi
@@ -126,8 +126,8 @@ _RankMethod: TypeAlias = L["average", "min", "max", "dense", "ordinal"]
 
 _LMomentOrder: TypeAlias = L[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16] | npc.integer
 _LMomentOrder1D: TypeAlias = Sequence[_LMomentOrder] | onp.CanArrayND[npc.integer]
-
 _RealLimits: TypeAlias = tuple[float | _Real0D, float | _Real0D]
+_Weigher: TypeAlias = Callable[[int], float | _Real0D]
 
 @type_check_only
 class _RVSCallable(Protocol):
@@ -846,13 +846,78 @@ def kendalltau(
 ) -> SignificanceResult[np.float64 | Any]: ...
 
 #
+@overload
 def weightedtau(
     x: onp.ToFloatND,
     y: onp.ToFloatND,
     rank: onp.ToInt | onp.ToIntND = True,
-    weigher: Callable[[int], float | _Real0D] | None = None,
+    weigher: _Weigher | None = None,
     additive: bool = True,
-) -> SignificanceResult[float]: ...
+    *,
+    axis: None,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: L[False] = False,
+) -> SignificanceResult[np.float64]: ...
+@overload
+def weightedtau(
+    x: onp.ToFloatStrict1D,
+    y: onp.ToFloatStrict1D,
+    rank: onp.ToInt | onp.ToIntND = True,
+    weigher: _Weigher | None = None,
+    additive: bool = True,
+    *,
+    axis: int | None = 0,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: L[False] = False,
+) -> SignificanceResult[np.float64]: ...
+@overload
+def weightedtau(
+    x: onp.ToFloatStrict2D,
+    y: onp.ToFloatStrict2D,
+    rank: onp.ToInt | onp.ToIntND = True,
+    weigher: _Weigher | None = None,
+    additive: bool = True,
+    *,
+    axis: int = 0,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: L[False] = False,
+) -> SignificanceResult[onp.Array1D[np.float64]]: ...
+@overload
+def weightedtau(
+    x: onp.ToFloatStrict3D,
+    y: onp.ToFloatStrict3D,
+    rank: onp.ToInt | onp.ToIntND = True,
+    weigher: _Weigher | None = None,
+    additive: bool = True,
+    *,
+    axis: int = 0,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: L[False] = False,
+) -> SignificanceResult[onp.Array2D[np.float64]]: ...
+@overload
+def weightedtau(
+    x: onp.ToFloatND,
+    y: onp.ToFloatND,
+    rank: onp.ToInt | onp.ToIntND = True,
+    weigher: _Weigher | None = None,
+    additive: bool = True,
+    *,
+    axis: int | None = 0,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: L[True],
+) -> SignificanceResult[onp.ArrayND[np.float64]]: ...
+@overload
+def weightedtau(
+    x: onp.ToFloatND,
+    y: onp.ToFloatND,
+    rank: onp.ToInt | onp.ToIntND = True,
+    weigher: _Weigher | None = None,
+    additive: bool = True,
+    *,
+    axis: int | None = 0,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: bool = False,
+) -> SignificanceResult[np.float64 | Any]: ...
 
 #
 def pack_TtestResult(

--- a/scipy-stubs/stats/stats.pyi
+++ b/scipy-stubs/stats/stats.pyi
@@ -311,7 +311,17 @@ def kendalltau(
     keepdims: object = ...,
 ) -> object: ...
 @deprecated("will be removed in SciPy v2.0.0")
-def weightedtau(x: object, y: object, rank: object = ..., weigher: object = ..., additive: object = ...) -> object: ...
+def weightedtau(
+    x: object,
+    y: object,
+    rank: object = ...,
+    weigher: object = ...,
+    additive: object = ...,
+    *,
+    axis: object = ...,
+    nan_policy: object = ...,
+    keepdims: object = ...,
+) -> object: ...
 @deprecated("will be removed in SciPy v2.0.0")
 def ttest_1samp(
     a: object,

--- a/scipy-stubs/stats/stats.pyi
+++ b/scipy-stubs/stats/stats.pyi
@@ -303,10 +303,12 @@ def kendalltau(
     x: object,
     y: object,
     *,
-    nan_policy: object = ...,
     method: object = ...,
     variant: object = ...,
     alternative: object = ...,
+    axis: object = ...,
+    nan_policy: object = ...,
+    keepdims: object = ...,
 ) -> object: ...
 @deprecated("will be removed in SciPy v2.0.0")
 def weightedtau(x: object, y: object, rank: object = ..., weigher: object = ..., additive: object = ...) -> object: ...


### PR DESCRIPTION
From the [`1.16.0rc1` release notes](https://github.com/scipy/scipy/releases/tag/v1.16.0rc1):

> Support for `axis`, `nan_policy`, and `keepdims` keywords was added to (...) `scipy.stats.kendalltau`,
`scipy.stats.weightedtau`, (...)