### PR TITLE
⬆️ bump basedpyright to 1.29.4 (pyright 1.1.402)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ type = [
     {include-group = "extras"},
     {include-group = "ci"},
     "mypy[faster-cache]==1.16.0",
-    "basedpyright>=1.29.2",
+    "basedpyright>=1.29.4",
 ]
 dev = [
     {include-group = "lint"},
@@ -125,12 +125,7 @@ always_true = ["NP125", "NP126", "NP20", "NP21", "NP22", "NP23"]
 
 [tool.pyright]
 include = ["scipy-stubs", "scripts", "tests"]
-ignore = [
-    ".venv",
-    # https://github.com/jakebailey/pyright-action/issues/188
-    # https://github.com/microsoft/pyright/issues/10484
-    "/opt/hostedtoolcache/pyright/",
-]
+ignore = [".venv"]
 stubPath = "."
 pythonPlatform = "All"
 typeCheckingMode = "strict"
@@ -184,7 +179,7 @@ reportUnsafeMultipleInheritance = true # base
     NP20 = true
     NP21 = true
     NP22 = true
-    NP23 = false
+    NP23 = true
 
 [tool.repo-review]
 ignore = [

--- a/uv.lock
+++ b/uv.lock
@@ -4,14 +4,14 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "basedpyright"
-version = "1.29.2"
+version = "1.29.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodejs-wheel-binaries" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0c/db/fcfced6e89a49b52694d51078c2cf626b3fe9d097c1145bb8424337d7ae6/basedpyright-1.29.2.tar.gz", hash = "sha256:12c49186003b9f69a028615da883ef97035ea2119a9e3f93a00091b3a27088a6", size = 21966851, upload-time = "2025-05-21T11:45:43.03Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/80/fb/bd92196a07e3b4ccee4ff2761a26a05bff77d4da089b67b4b1a547868099/basedpyright-1.29.4.tar.gz", hash = "sha256:2df1976f8591eedf4b4ce8f9d123f43e810cc8cb7cc83c53eec0e2f8044073d0", size = 21961481, upload-time = "2025-06-11T22:25:55.173Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/b7/8307208ab517ac6e5d0331ad7347624fe8b250fb6e659ba3bd081d82c890/basedpyright-1.29.2-py3-none-any.whl", hash = "sha256:f389e2997de33d038c5065fd85bff351fbdc62fa6d6371c7b947fc3bce8d437d", size = 11472099, upload-time = "2025-05-21T11:45:38.785Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/dc/180fe721a2574fb3aad4051adcca196ac2d18adaf75122f5eeb47436cca2/basedpyright-1.29.4-py3-none-any.whl", hash = "sha256:e087513979972f83010639c6c1a1c13dd3b1d24ee45f8ecff747962cc2063d6f", size = 11476859, upload-time = "2025-06-11T22:25:52.01Z" },
 ]
 
 [[package]]
@@ -548,7 +548,7 @@ provides-extras = ["scipy"]
 [package.metadata.requires-dev]
 ci = [{ name = "packaging", specifier = ">=25.0" }]
 dev = [
-    { name = "basedpyright", specifier = ">=1.29.2" },
+    { name = "basedpyright", specifier = ">=1.29.4" },
     { name = "mdformat", specifier = ">=0.7.22" },
     { name = "mdformat-gfm", specifier = ">=0.4.1" },
     { name = "mdformat-gfm-alerts", specifier = ">=2.0.0" },
@@ -573,7 +573,7 @@ mdformat = [
     { name = "mdformat-gfm-alerts", specifier = ">=2.0.0" },
 ]
 type = [
-    { name = "basedpyright", specifier = ">=1.29.2" },
+    { name = "basedpyright", specifier = ">=1.29.4" },
     { name = "mypy", extras = ["faster-cache"], specifier = "==1.16.0" },
     { name = "packaging", specifier = ">=25.0" },
     { name = "scipy-stubs", extras = ["scipy"] },


### PR DESCRIPTION
https://github.com/DetachHead/basedpyright/releases/tag/v1.29.4
https://github.com/microsoft/pyright/releases/tag/1.1.402