### PR TITLE
🐛✨ `sparse`: fix and improve `get_index_type` return type

### DIFF
--- a/scipy-stubs/sparse/_sputils.pyi
+++ b/scipy-stubs/sparse/_sputils.pyi
@@ -114,7 +114,7 @@ def getdata(
 #
 def get_index_dtype(
     arrays: tuple[onp.ToInt | onp.ToIntND, ...] = (), maxval: onp.ToFloat | None = None, check_contents: op.CanBool = False
-) -> _IntP: ...
+) -> type[_IntP]: ...
 
 # NOTE: The inline annotations (`(np.dtype) -> np.dtype`) are incorrect.
 @overload

--- a/scipy-stubs/sparse/_sputils.pyi
+++ b/scipy-stubs/sparse/_sputils.pyi
@@ -111,9 +111,29 @@ def getdata(
     obj: onp.ToArrayND[_ScalarT, _ScalarT], dtype: onp.ToDType[_ScalarT] | None = None, copy: bool = False
 ) -> onp.ArrayND[_ScalarT]: ...
 
+_CoInt32: TypeAlias = np.bool_ | np.int8 | np.uint8 | np.int16 | np.uint16 | np.int32
+_ContraInt32: TypeAlias = np.uint32 | np.int64 | np.uint64
+
 #
+@overload
 def get_index_dtype(
-    arrays: tuple[onp.ToInt | onp.ToIntND, ...] = (), maxval: onp.ToFloat | None = None, check_contents: op.CanBool = False
+    arrays: tuple[()] = (), maxval: onp.ToFloat | None = None, check_contents: op.CanBool = False
+) -> type[np.int32]: ...
+@overload
+def get_index_dtype(
+    arrays: tuple[onp.CanArrayND[_CoInt32], *tuple[onp.CanArrayND[_CoInt32], ...]],
+    maxval: onp.ToFloat | None = None,
+    check_contents: op.CanBool = False,
+) -> type[np.int32]: ...
+@overload
+def get_index_dtype(
+    arrays: tuple[onp.CanArrayND[_ContraInt32], *tuple[onp.CanArrayND[_ContraInt32], ...]],
+    maxval: onp.ToFloat | None = None,
+    check_contents: op.CanBool = False,
+) -> type[np.int64]: ...
+@overload
+def get_index_dtype(
+    arrays: tuple[onp.ToInt | onp.ToIntND, ...], maxval: onp.ToFloat | None = None, check_contents: op.CanBool = False
 ) -> type[_IntP]: ...
 
 # NOTE: The inline annotations (`(np.dtype) -> np.dtype`) are incorrect.

--- a/tests/sparse/test_sputils.pyi
+++ b/tests/sparse/test_sputils.pyi
@@ -1,0 +1,34 @@
+from typing import assert_type
+
+import numpy as np
+import optype.numpy as onp
+
+from ._types import bsr_arr, bsr_mat, coo_arr, coo_mat, csc_arr, csc_mat, csr_arr, csr_mat, dia_arr, dia_mat
+from scipy import sparse
+
+i16_1d: onp.Array1D[np.int16]
+i32_1d: onp.Array1D[np.int32]
+u32_1d: onp.Array1D[np.uint32]
+i64_1d: onp.Array1D[np.int64]
+
+# get_index_dtype
+
+assert_type(sparse.get_index_dtype(), type[np.int32])
+assert_type(sparse.get_index_dtype((i16_1d, i16_1d)), type[np.int32])
+assert_type(sparse.get_index_dtype((i32_1d, i32_1d)), type[np.int32])
+assert_type(sparse.get_index_dtype((u32_1d, u32_1d)), type[np.int64])
+assert_type(sparse.get_index_dtype((i64_1d, i64_1d)), type[np.int64])
+assert_type(sparse.get_index_dtype((i32_1d, i64_1d)), type[np.int32 | np.int64])
+
+# safely_cast_index_arrays
+
+assert_type(sparse.safely_cast_index_arrays(bsr_arr), tuple[onp.Array1D[np.int32], onp.Array1D[np.int32]])
+assert_type(sparse.safely_cast_index_arrays(bsr_mat), tuple[onp.Array1D[np.int32], onp.Array1D[np.int32]])
+assert_type(sparse.safely_cast_index_arrays(csc_arr), tuple[onp.Array1D[np.int32], onp.Array1D[np.int32]])
+assert_type(sparse.safely_cast_index_arrays(csc_mat), tuple[onp.Array1D[np.int32], onp.Array1D[np.int32]])
+assert_type(sparse.safely_cast_index_arrays(csr_arr), tuple[onp.Array1D[np.int32], onp.Array1D[np.int32]])
+assert_type(sparse.safely_cast_index_arrays(csr_mat), tuple[onp.Array1D[np.int32], onp.Array1D[np.int32]])
+assert_type(sparse.safely_cast_index_arrays(coo_arr), tuple[onp.Array1D[np.int32], onp.Array1D[np.int32]])
+assert_type(sparse.safely_cast_index_arrays(coo_mat), tuple[onp.Array1D[np.int32], onp.Array1D[np.int32]])
+assert_type(sparse.safely_cast_index_arrays(dia_arr), onp.Array1D[np.int32])
+assert_type(sparse.safely_cast_index_arrays(dia_mat), onp.Array1D[np.int32])


### PR DESCRIPTION
This also adds type-tests for `get_index_dtype` and  `safely_cast_index_arrays`.