### PR TITLE
✨ `sparse`: simplified gradual `load_npz` return type

### DIFF
--- a/scipy-stubs/sparse/_matrix_io.pyi
+++ b/scipy-stubs/sparse/_matrix_io.pyi
@@ -1,24 +1,18 @@
-from typing import Final, Literal, Protocol, TypeAlias, TypedDict, type_check_only
+from typing import Any, Final, Literal, Protocol, TypedDict, final, type_check_only
 
 import optype as op
 
-from ._bsr import bsr_array, bsr_matrix
-from ._coo import coo_array, coo_matrix
-from ._csc import csc_array, csc_matrix
-from ._csr import csr_array, csr_matrix
 from ._data import _data_matrix
-from ._dia import dia_array, dia_matrix
 
 __all__ = ["load_npz", "save_npz"]
 
-_DataArrayOut: TypeAlias = bsr_array | coo_array | csc_array | csr_array | dia_array
-_DataMatrixOut: TypeAlias = bsr_matrix | coo_matrix | csc_matrix | csr_matrix | dia_matrix
-
+@final
 @type_check_only
 class _CanReadAndSeekBytes(Protocol):
     def read(self, length: int = ..., /) -> bytes: ...
     def seek(self, offset: int, whence: int, /) -> object: ...
 
+@final
 @type_check_only
 class _PickleKwargs(TypedDict):
     allow_pickle: Literal[False]
@@ -27,5 +21,5 @@ class _PickleKwargs(TypedDict):
 
 PICKLE_KWARGS: Final[_PickleKwargs] = ...
 
-def load_npz(file: op.io.ToPath | _CanReadAndSeekBytes) -> _DataArrayOut | _DataMatrixOut: ...
+def load_npz(file: op.io.ToPath | _CanReadAndSeekBytes) -> _data_matrix | Any: ...
 def save_npz(file: op.io.ToPath[str] | op.io.CanWrite[bytes], matrix: _data_matrix, compressed: op.CanBool = True) -> None: ...

--- a/tests/sparse/test_matrix_io.pyi
+++ b/tests/sparse/test_matrix_io.pyi
@@ -1,0 +1,59 @@
+import io
+from pathlib import Path
+from typing import Any, assert_type
+
+from ._types import (
+    bsr_arr,
+    bsr_mat,
+    coo_arr,
+    coo_mat,
+    csc_arr,
+    csc_mat,
+    csr_arr,
+    csr_mat,
+    dia_arr,
+    dia_mat,
+    dok_arr,
+    dok_mat,
+    lil_arr,
+    lil_mat,
+)
+from scipy import sparse
+from scipy.sparse._data import _data_matrix
+
+###
+# save_npz
+
+assert_type(sparse.save_npz("", bsr_mat), None)
+assert_type(sparse.save_npz("", coo_mat), None)
+assert_type(sparse.save_npz("", csc_mat), None)
+assert_type(sparse.save_npz("", csr_mat), None)
+assert_type(sparse.save_npz("", dia_mat), None)
+sparse.save_npz("", dok_mat)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
+sparse.save_npz("", lil_mat)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
+
+assert_type(sparse.save_npz("", bsr_arr), None)
+assert_type(sparse.save_npz("", coo_arr), None)
+assert_type(sparse.save_npz("", csc_arr), None)
+assert_type(sparse.save_npz("", csr_arr), None)
+assert_type(sparse.save_npz("", dia_arr), None)
+sparse.save_npz("", dok_arr)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
+sparse.save_npz("", lil_arr)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
+
+sparse.save_npz(b"", coo_arr)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
+assert_type(sparse.save_npz(Path(), coo_arr), None)
+assert_type(sparse.save_npz(io.BytesIO(), coo_arr), None)
+assert_type(sparse.save_npz("", coo_arr, False), None)
+assert_type(sparse.save_npz("", coo_arr, False), None)
+assert_type(sparse.save_npz("", coo_arr, True), None)
+assert_type(sparse.save_npz("", coo_arr, compressed=False), None)
+assert_type(sparse.save_npz("", matrix=coo_arr, compressed=True), None)
+assert_type(sparse.save_npz(file="", matrix=coo_arr, compressed=True), None)
+
+###
+# load_npz
+
+assert_type(sparse.load_npz(""), _data_matrix | Any)
+assert_type(sparse.load_npz(b""), _data_matrix | Any)
+assert_type(sparse.load_npz(Path()), _data_matrix | Any)
+assert_type(sparse.load_npz(io.BytesIO()), _data_matrix | Any)


### PR DESCRIPTION
This also adds type-tests for `save_npz` and `load_npz`.