### PR TITLE
✨ preliminary support for Python 3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ maintainers = [
     {name = "SciPy Developers", email = "scipy-dev@python.org"},
 ]
 license = "BSD-3-Clause"
-keywords = ["scipy", "typing", "pep484"]
+keywords = ["scipy", "typing", "stubs", "mypy", "pyright", "pep484", "pep561", "scipy-stubs"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Typing :: Stubs Only",
 ]
 requires-python = ">=3.11"
@@ -54,13 +55,13 @@ type = [
     {include-group = "extras"},
     {include-group = "ci"},
     "basedpyright>=1.29.4",
-    "mypy[faster-cache]==1.16.1",
+    "mypy>=1.16.1",
+    "orjson>=3.10.18; python_version<'3.14'", # used by mypy
 ]
 dev = [
     {include-group = "lint"},
     {include-group = "type"},
 ]
-
 
 [tool.hatch.build]
 packages = ["scipy-stubs"]
@@ -232,7 +233,7 @@ preview = true
 [tool.tox]
 min_version = "4"
 requires = ["tox-uv>=1"]
-env_list = ["lint", "pyright", "mypy", "3.11", "3.12", "3.13"]
+env_list = ["lint", "pyright", "mypy", "3.11", "3.12", "3.13", "3.14"]
 
     [tool.tox.env_run_base]
     description = "stubtest with {base_python}"

--- a/scipy-stubs/_lib/_util.pyi
+++ b/scipy-stubs/_lib/_util.pyi
@@ -1,4 +1,5 @@
 import multiprocessing.pool as mpp
+import sys
 import types
 from collections.abc import Callable, Iterable, Sequence
 from typing import Any, Concatenate, Final, Generic, Literal, NamedTuple, Never, TypeAlias, overload
@@ -37,6 +38,11 @@ SeedType: TypeAlias = IntNumber | _RNG | None
 GeneratorType = TypeVar("GeneratorType", bound=_RNG)  # noqa: PYI001  # oof
 
 ###
+
+# mypy<=1.16.1 workaround
+if sys.version_info >= (3, 14):
+    # see https://github.com/python/cpython/pull/130935
+    __conditional_annotations__: Final[set[int]] = ...
 
 class AxisError(ValueError, IndexError):
     _msg: Final[str | None]

--- a/scipy-stubs/special/_add_newdocs.pyi
+++ b/scipy-stubs/special/_add_newdocs.pyi
@@ -1,6 +1,12 @@
+import sys
 from typing import Final, LiteralString
 
-docdict: Final[dict[str, str]]
+# mypy<=1.16.1 workaround
+if sys.version_info >= (3, 14):
+    # see https://github.com/python/cpython/pull/130935
+    __conditional_annotations__: Final[set[int]] = ...
+
+docdict: Final[dict[str, str]] = ...
 
 def get(name: LiteralString) -> str: ...
 def add_newdoc(name: LiteralString, doc: str) -> None: ...

--- a/uv.lock
+++ b/uv.lock
@@ -88,11 +88,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/cf/d3/53e684e78e07c1a2bf7105715e5edd09ce951fc3f47cf9ed095ec1b7a037/mypy-1.16.1-py3-none-any.whl", hash = "sha256:5fc2ac4027d0ef28d6ba69a0343737a23c4d1b83672bf38d1fe237bdc0643b37", size = 2265923, upload-time = "2025-06-16T16:48:02.366Z" },
 ]
 
-[package.optional-dependencies]
-faster-cache = [
-    { name = "orjson" },
-]
-
 [[package]]
 name = "mypy-extensions"
 version = "1.1.0"
@@ -441,7 +436,8 @@ ci = [
 ]
 dev = [
     { name = "basedpyright" },
-    { name = "mypy", extra = ["faster-cache"] },
+    { name = "mypy" },
+    { name = "orjson", marker = "python_full_version < '3.14'" },
     { name = "packaging" },
     { name = "ruff" },
     { name = "scipy-stubs", extra = ["scipy"] },
@@ -457,7 +453,8 @@ lint = [
 ]
 type = [
     { name = "basedpyright" },
-    { name = "mypy", extra = ["faster-cache"] },
+    { name = "mypy" },
+    { name = "orjson", marker = "python_full_version < '3.14'" },
     { name = "packaging" },
     { name = "scipy-stubs", extra = ["scipy"] },
 ]
@@ -473,7 +470,8 @@ provides-extras = ["scipy"]
 ci = [{ name = "packaging", specifier = ">=25.0" }]
 dev = [
     { name = "basedpyright", specifier = ">=1.29.4" },
-    { name = "mypy", extras = ["faster-cache"], specifier = "==1.16.1" },
+    { name = "mypy", specifier = ">=1.16.1" },
+    { name = "orjson", marker = "python_full_version < '3.14'", specifier = ">=3.10.18" },
     { name = "packaging", specifier = ">=25.0" },
     { name = "ruff", specifier = ">=0.11.13" },
     { name = "scipy-stubs", extras = ["scipy"] },
@@ -487,7 +485,8 @@ lint = [
 ]
 type = [
     { name = "basedpyright", specifier = ">=1.29.4" },
-    { name = "mypy", extras = ["faster-cache"], specifier = "==1.16.1" },
+    { name = "mypy", specifier = ">=1.16.1" },
+    { name = "orjson", marker = "python_full_version < '3.14'", specifier = ">=3.10.18" },
     { name = "packaging", specifier = ">=25.0" },
     { name = "scipy-stubs", extras = ["scipy"] },
 ]


### PR DESCRIPTION
After working around an obscure undocumented new dunder global that mypy doesn't support, stubtest passes:

```bash
$ tox run -e 3.14
3.14: uv-sync> uv sync --locked --python-preference system --no-default-groups --group type --no-editable --reinstall-package=scipy-stubs -p cpython3.14
3.14: commands[0]> stubtest --allowlist=.mypyignore --mypy-config-file=pyproject.toml scipy
Success: no issues found in 1061 modules
  3.14: OK (60.80=setup[0.26]+cmd[60.54] seconds)
  congratulations :) (60.83 seconds)
```

I did not include 3.14 in the CI testing matrix for performance reasons (no scipy and numpy wheels yet, so both have to be built manually).