### PR TITLE
🐛 `sparse`: distinguish between different values for argument `which` in `eigs` and `eigsh`

### DIFF
--- a/scipy-stubs/sparse/linalg/_eigen/arpack/arpack.pyi
+++ b/scipy-stubs/sparse/linalg/_eigen/arpack/arpack.pyi
@@ -15,7 +15,8 @@ _KT = TypeVar("_KT")
 _ToRealMatrix: TypeAlias = onp.ToFloat2D | LinearOperator[np.floating[Any] | np.integer[Any]] | _spbase
 _ToComplexMatrix: TypeAlias = onp.ToComplex2D | LinearOperator | _spbase
 
-_Which: TypeAlias = Literal["LM", "SM", "LR", "SR", "LI", "SI"]
+_Which_eigs: TypeAlias = Literal["LM", "SM", "LR", "SR", "LI", "SI"]
+_Which_eigsh: TypeAlias = Literal["LM", "SM", "LA", "SA", "BE"]
 _OPpart: TypeAlias = Literal["r", "i"]
 _Mode: TypeAlias = Literal["normal", "buckling", "cayley"]
 
@@ -38,7 +39,7 @@ def eigs(
     k: int = 6,
     M: _ToRealMatrix | None = None,
     sigma: onp.ToComplex | None = None,
-    which: _Which = "LM",
+    which: _Which_eigs = "LM",
     v0: onp.ToFloat1D | None = None,
     ncv: int | None = None,
     maxiter: int | None = None,
@@ -54,7 +55,7 @@ def eigs(
     k: int,
     M: _ToRealMatrix | None,
     sigma: onp.ToComplex | None,
-    which: _Which,
+    which: _Which_eigs,
     v0: onp.ToFloat1D | None,
     ncv: int | None,
     maxiter: int | None,
@@ -70,7 +71,7 @@ def eigs(
     k: int = 6,
     M: _ToRealMatrix | None = None,
     sigma: onp.ToComplex | None = None,
-    which: _Which = "LM",
+    which: _Which_eigs = "LM",
     v0: onp.ToFloat1D | None = None,
     ncv: int | None = None,
     maxiter: int | None = None,
@@ -89,7 +90,7 @@ def eigsh(
     k: int = 6,
     M: _ToRealMatrix | None = None,
     sigma: onp.ToComplex | None = None,
-    which: _Which = "LM",
+    which: _Which_eigsh = "LM",
     v0: onp.ToFloat1D | None = None,
     ncv: int | None = None,
     maxiter: int | None = None,
@@ -105,7 +106,7 @@ def eigsh(
     k: int,
     M: _ToRealMatrix | None,
     sigma: onp.ToComplex | None,
-    which: _Which,
+    which: _Which_eigsh,
     v0: onp.ToFloat1D | None,
     ncv: int | None,
     maxiter: int | None,
@@ -121,7 +122,7 @@ def eigsh(
     k: int = 6,
     M: _ToRealMatrix | None = None,
     sigma: onp.ToComplex | None = None,
-    which: _Which = "LM",
+    which: _Which_eigsh = "LM",
     v0: onp.ToFloat1D | None = None,
     ncv: int | None = None,
     maxiter: int | None = None,


### PR DESCRIPTION
The two routines accept different sets of eigenvalue selection method for the `which` argument, but so far both are set to the possible values for `eigs`. This PR just adds the set for `eigsh`.

Passed all checks and when I install my fork from git I get no complaints anymore when using e.g.
```python
sp.sparse.linalg.eigsh(x, which='LA')
```
given that `LA` wasn't mentioned before as an option for `eigsh`.

Here are the docs for [`eigs`](https://docs.scipy.org/doc/scipy-1.15.3/reference/generated/scipy.sparse.linalg.eigs.html) and [`eigsh`](https://docs.scipy.org/doc/scipy-1.15.3/reference/generated/scipy.sparse.linalg.eigsh.html) to check.
