### PR TITLE
✨ `sparse`: Improved shape-typing support for CSR and DOK arrays

### DIFF
--- a/scipy-stubs/sparse/_csr.pyi
+++ b/scipy-stubs/sparse/_csr.pyi
@@ -11,7 +11,7 @@ import optype.numpy.compat as npc
 from ._base import _spbase, sparray
 from ._compressed import _cs_matrix
 from ._matrix import spmatrix
-from ._typing import Index1D, Numeric, ToShape1D, ToShape2D, ToShapeMin1D
+from ._typing import Numeric, ToShape1D, ToShape2D, ToShapeMax2D
 
 __all__ = ["csr_array", "csr_matrix", "isspmatrix_csr"]
 
@@ -53,7 +53,7 @@ class _csr_base(_cs_matrix[_ScalarT_co, _ShapeT_co], Generic[_ScalarT_co, _Shape
     @overload
     def count_nonzero(self: csr_array[Any, tuple[int]], /, axis: op.CanIndex) -> np.intp: ...  # type: ignore[misc]
     @overload
-    def count_nonzero(self: _csr_base[Any], /, axis: op.CanIndex) -> onp.Array1D[np.intp]: ...
+    def count_nonzero(self: _csr_base[Any, tuple[int, int]], /, axis: op.CanIndex) -> onp.Array1D[np.intp]: ...
     @overload
     def count_nonzero(self: csr_array[Any, Any], /, axis: op.CanIndex) -> onp.Array1D[np.intp] | Any: ...  # type: ignore[misc]
 
@@ -100,7 +100,7 @@ class csr_array(_csr_base[_ScalarT_co, _ShapeT_co], sparray[_ScalarT_co, _ShapeT
     def __init__(
         self: csr_array[_ScalarT, tuple[int, int]],
         /,
-        arg1: Sequence[Sequence[_ScalarT]] | Sequence[onp.CanArrayND[_ScalarT]],  # assumes max. 2-d
+        arg1: Sequence[Sequence[_ScalarT] | onp.CanArrayND[_ScalarT]],  # assumes max. 2-d
         shape: ToShape2D | None = None,
         dtype: onp.ToDType[_ScalarT] | None = None,
         copy: bool = False,
@@ -109,11 +109,11 @@ class csr_array(_csr_base[_ScalarT_co, _ShapeT_co], sparray[_ScalarT_co, _ShapeT
     ) -> None: ...
     @overload  # matrix-like (known dtype), dtype: None
     def __init__(
-        self,
+        self: csr_array[_ScalarT, tuple[Any, ...]],
         /,
-        arg1: _ToMatrix[_ScalarT_co] | _ToData[_ScalarT_co],
-        shape: ToShapeMin1D | None = None,
-        dtype: onp.ToDType[_ScalarT_co] | None = None,
+        arg1: _ToMatrix[_ScalarT] | _ToData[_ScalarT],
+        shape: ToShapeMax2D | None = None,
+        dtype: onp.ToDType[_ScalarT] | None = None,
         copy: bool = False,
         *,
         maxprint: int | None = None,
@@ -144,7 +144,7 @@ class csr_array(_csr_base[_ScalarT_co, _ShapeT_co], sparray[_ScalarT_co, _ShapeT
     def __init__(
         self: csr_array[np.bool_, tuple[int]],
         /,
-        arg1: Sequence[bool],
+        arg1: onp.ToJustBoolStrict1D,
         shape: ToShape1D | None = None,
         dtype: onp.AnyBoolDType | None = None,
         copy: bool = False,
@@ -155,7 +155,7 @@ class csr_array(_csr_base[_ScalarT_co, _ShapeT_co], sparray[_ScalarT_co, _ShapeT
     def __init__(
         self: csr_array[np.bool_, tuple[int, int]],
         /,
-        arg1: Sequence[Sequence[bool]],
+        arg1: onp.ToJustBoolStrict2D,
         shape: ToShape2D | None = None,
         dtype: onp.AnyBoolDType | None = None,
         copy: bool = False,
@@ -164,10 +164,10 @@ class csr_array(_csr_base[_ScalarT_co, _ShapeT_co], sparray[_ScalarT_co, _ShapeT
     ) -> None: ...
     @overload  # 1-d array-like ~int, dtype: type[int] | None
     def __init__(
-        self: csr_array[np.int_, tuple[int]],
+        self: csr_array[np.int64, tuple[int]],
         /,
-        arg1: Sequence[op.JustInt],
-        shape: ToShapeMin1D | None = None,
+        arg1: onp.ToJustInt64Strict1D,
+        shape: ToShape1D | None = None,
         dtype: onp.AnyIntDType | None = None,
         copy: bool = False,
         *,
@@ -175,10 +175,10 @@ class csr_array(_csr_base[_ScalarT_co, _ShapeT_co], sparray[_ScalarT_co, _ShapeT
     ) -> None: ...
     @overload  # 2-d array-like ~int, dtype: type[int] | None
     def __init__(
-        self: csr_array[np.int_, tuple[int, int]],
+        self: csr_array[np.int64, tuple[int, int]],
         /,
-        arg1: Sequence[Sequence[op.JustInt]],
-        shape: ToShapeMin1D | None = None,
+        arg1: onp.ToJustInt64Strict2D,
+        shape: ToShape2D | None = None,
         dtype: onp.AnyIntDType | None = None,
         copy: bool = False,
         *,
@@ -188,8 +188,8 @@ class csr_array(_csr_base[_ScalarT_co, _ShapeT_co], sparray[_ScalarT_co, _ShapeT
     def __init__(
         self: csr_array[np.float64, tuple[int]],
         /,
-        arg1: Sequence[op.JustFloat],
-        shape: ToShapeMin1D | None = None,
+        arg1: onp.ToJustFloat64Strict1D,
+        shape: ToShapeMax2D | None = None,
         dtype: onp.AnyFloat64DType | None = None,
         copy: bool = False,
         *,
@@ -199,8 +199,8 @@ class csr_array(_csr_base[_ScalarT_co, _ShapeT_co], sparray[_ScalarT_co, _ShapeT
     def __init__(
         self: csr_array[np.float64, tuple[int, int]],
         /,
-        arg1: Sequence[Sequence[op.JustFloat]],
-        shape: ToShapeMin1D | None = None,
+        arg1: onp.ToJustFloat64Strict2D,
+        shape: ToShapeMax2D | None = None,
         dtype: onp.AnyFloat64DType | None = None,
         copy: bool = False,
         *,
@@ -210,8 +210,8 @@ class csr_array(_csr_base[_ScalarT_co, _ShapeT_co], sparray[_ScalarT_co, _ShapeT
     def __init__(
         self: csr_array[np.complex128, tuple[int]],
         /,
-        arg1: Sequence[op.JustComplex],
-        shape: ToShapeMin1D | None = None,
+        arg1: onp.ToJustComplex128Strict1D,
+        shape: ToShapeMax2D | None = None,
         dtype: onp.AnyComplex128DType | None = None,
         copy: bool = False,
         *,
@@ -221,8 +221,8 @@ class csr_array(_csr_base[_ScalarT_co, _ShapeT_co], sparray[_ScalarT_co, _ShapeT
     def __init__(
         self: csr_array[np.complex128, tuple[int, int]],
         /,
-        arg1: Sequence[Sequence[op.JustComplex]],
-        shape: ToShapeMin1D | None = None,
+        arg1: onp.ToJustComplex128Strict2D,
+        shape: ToShapeMax2D | None = None,
         dtype: onp.AnyComplex128DType | None = None,
         copy: bool = False,
         *,
@@ -277,7 +277,7 @@ class csr_array(_csr_base[_ScalarT_co, _ShapeT_co], sparray[_ScalarT_co, _ShapeT
         self,
         /,
         arg1: onp.ToComplex1D | onp.ToComplex2D,
-        shape: ToShapeMin1D | None = None,
+        shape: ToShapeMax2D | None = None,
         dtype: npt.DTypeLike | None = ...,
         copy: bool = False,
         *,
@@ -303,11 +303,11 @@ class csr_matrix(_csr_base[_ScalarT_co], spmatrix[_ScalarT_co], Generic[_ScalarT
     # NOTE: keep in sync with `csc_matrix.__init__`
     @overload  # matrix-like (known dtype), dtype: None
     def __init__(
-        self,
+        self: csr_matrix[_ScalarT],  # this self annotation works around a mypy bug
         /,
-        arg1: _ToMatrix[_ScalarT_co],
+        arg1: _ToMatrix[_ScalarT],
         shape: ToShape2D | None = None,
-        dtype: onp.ToDType[_ScalarT_co] | None = None,
+        dtype: onp.ToDType[_ScalarT] | None = None,
         copy: bool = False,
         *,
         maxprint: int | None = None,
@@ -327,7 +327,7 @@ class csr_matrix(_csr_base[_ScalarT_co], spmatrix[_ScalarT_co], Generic[_ScalarT
     def __init__(
         self: csr_matrix[np.bool_],
         /,
-        arg1: Sequence[Sequence[bool]],
+        arg1: onp.ToJustBoolStrict2D,
         shape: ToShape2D | None = None,
         dtype: onp.AnyBoolDType | None = None,
         copy: bool = False,
@@ -336,9 +336,9 @@ class csr_matrix(_csr_base[_ScalarT_co], spmatrix[_ScalarT_co], Generic[_ScalarT
     ) -> None: ...
     @overload  # 2-d array-like ~int, dtype: type[int] | None
     def __init__(
-        self: csr_matrix[np.int_],
+        self: csr_matrix[np.int64],
         /,
-        arg1: Sequence[Sequence[op.JustInt]],
+        arg1: onp.ToJustInt64Strict2D,
         shape: ToShape2D | None = None,
         dtype: onp.AnyIntDType | None = None,
         copy: bool = False,
@@ -349,7 +349,7 @@ class csr_matrix(_csr_base[_ScalarT_co], spmatrix[_ScalarT_co], Generic[_ScalarT
     def __init__(
         self: csr_matrix[np.float64],
         /,
-        arg1: Sequence[Sequence[op.JustFloat]],
+        arg1: onp.ToJustFloat64Strict2D,
         shape: ToShape2D | None = None,
         dtype: onp.AnyFloat64DType | None = None,
         copy: bool = False,
@@ -360,7 +360,7 @@ class csr_matrix(_csr_base[_ScalarT_co], spmatrix[_ScalarT_co], Generic[_ScalarT
     def __init__(
         self: csr_matrix[np.complex128],
         /,
-        arg1: Sequence[Sequence[op.JustComplex]],
+        arg1: onp.ToJustComplex128Strict2D,
         shape: ToShape2D | None = None,
         dtype: onp.AnyComplex128DType | None = None,
         copy: bool = False,
@@ -371,7 +371,7 @@ class csr_matrix(_csr_base[_ScalarT_co], spmatrix[_ScalarT_co], Generic[_ScalarT
     def __init__(
         self,
         /,
-        arg1: onp.ToComplexStrict2D,
+        arg1: onp.ToComplex2D,
         shape: ToShape2D | None,
         dtype: onp.ToDType[_ScalarT_co],
         copy: bool = False,
@@ -382,18 +382,34 @@ class csr_matrix(_csr_base[_ScalarT_co], spmatrix[_ScalarT_co], Generic[_ScalarT
     def __init__(
         self,
         /,
-        arg1: onp.ToComplexStrict2D,
+        arg1: onp.ToComplex2D,
         shape: ToShape2D | None = None,
         *,
         dtype: onp.ToDType[_ScalarT_co],
         copy: bool = False,
         maxprint: int | None = None,
     ) -> None: ...
+    @overload  # dtype: <unknown>
+    def __init__(
+        self,
+        /,
+        arg1: onp.ToComplex2D,
+        shape: ToShape2D | None = None,
+        dtype: npt.DTypeLike | None = None,
+        copy: bool = False,
+        *,
+        maxprint: int | None = None,
+    ) -> None: ...
+
+    #
+    @property
+    @override
+    def ndim(self, /) -> Literal[2]: ...
 
     #
     @overload
     def getnnz(self, /, axis: None = None) -> int: ...
     @overload
-    def getnnz(self, /, axis: op.CanIndex) -> Index1D: ...
+    def getnnz(self, /, axis: Literal[0, 1, -1, -2]) -> onp.Array1D[np.intp]: ...
 
 def isspmatrix_csr(x: object) -> TypeIs[csr_matrix]: ...

--- a/scipy-stubs/sparse/_dok.pyi
+++ b/scipy-stubs/sparse/_dok.pyi
@@ -102,7 +102,7 @@ class _dok_base(  # pyright: ignore[reportIncompatibleMethodOverride]
     @overload
     def count_nonzero(self, /, axis: None = None) -> int: ...
     @overload
-    def count_nonzero(self, /, axis: op.CanIndex) -> onp.Array1D[np.intp]: ...  # pyright: ignore[reportIncompatibleMethodOverride]
+    def count_nonzero(self: _dok_base[Any, _2D], /, axis: Literal[0, 1, -1, -2]) -> onp.Array1D[np.intp]: ...  # pyright: ignore[reportIncompatibleMethodOverride]
 
     #
     @override
@@ -480,7 +480,7 @@ class dok_matrix(_dok_base[_ScalarT_co, _2D], spmatrix[_ScalarT_co], Generic[_Sc
         /,
         arg1: _ToMatrix[_ScalarT],
         shape: ToShape2D | None = None,
-        dtype: None = None,
+        dtype: onp.ToDType[_ScalarT] | None = None,
         copy: bool = False,
         *,
         maxprint: int | None = None,
@@ -490,8 +490,8 @@ class dok_matrix(_dok_base[_ScalarT_co, _2D], spmatrix[_ScalarT_co], Generic[_Sc
         self: dok_matrix[np.float64],
         /,
         arg1: ToShape2D,
-        shape: None = None,
-        dtype: None = None,
+        shape: ToShape2D | None = None,
+        dtype: onp.AnyFloat64DType | None = None,
         copy: bool = False,
         *,
         maxprint: int | None = None,
@@ -573,6 +573,11 @@ class dok_matrix(_dok_base[_ScalarT_co, _2D], spmatrix[_ScalarT_co], Generic[_Sc
         *,
         maxprint: int | None = None,
     ) -> None: ...
+
+    #
+    @property
+    @override
+    def ndim(self, /) -> Literal[2]: ...
 
     #
     @override

--- a/scipy-stubs/sparse/_dok.pyi
+++ b/scipy-stubs/sparse/_dok.pyi
@@ -14,7 +14,7 @@ from ._base import _spbase, sparray
 from ._coo import coo_array, coo_matrix
 from ._index import IndexMixin
 from ._matrix import spmatrix
-from ._typing import Numeric, ToShape2D, ToShapeMin1D
+from ._typing import Numeric, ToShape1D, ToShape2D, ToShapeMax2D
 
 __all__ = ["dok_array", "dok_matrix", "isspmatrix_dok"]
 
@@ -28,7 +28,8 @@ _ShapeT_co = TypeVar("_ShapeT_co", bound=tuple[int] | tuple[int, int], default=t
 _1D: TypeAlias = tuple[int]  # noqa: PYI042
 _2D: TypeAlias = tuple[int, int]  # noqa: PYI042
 # workaround for the typing-spec non-conformance regarding overload behavior of mypy and pyright
-_NeitherD: TypeAlias = tuple[Never] | tuple[Never, Never]
+_NoD: TypeAlias = tuple[Never] | tuple[Never, Never]
+_AnyD: TypeAlias = tuple[Any, ...]
 
 _ToMatrix: TypeAlias = _spbase[_ScalarT] | onp.CanArrayND[_ScalarT] | Sequence[onp.CanArrayND[_ScalarT]] | _ToMatrixPy[_ScalarT]
 _ToMatrixPy: TypeAlias = Sequence[_T] | Sequence[Sequence[_T]]
@@ -70,7 +71,7 @@ class _dok_base(  # pyright: ignore[reportIncompatibleMethodOverride]
         self,
         /,
         arg1: onp.ToComplexND,
-        shape: ToShapeMin1D | None = None,
+        shape: ToShapeMax2D | None = None,
         dtype: npt.DTypeLike | None = None,
         copy: bool = False,
         *,
@@ -163,8 +164,8 @@ class _dok_base(  # pyright: ignore[reportIncompatibleMethodOverride]
     @overload
     @classmethod
     def fromkeys(
-        cls: type[_dok_base[np.complex128, _NeitherD]], iterable: _ToKeys, v: op.JustComplex, /
-    ) -> _dok_base[np.complex128, tuple[Any, ...]]: ...
+        cls: type[_dok_base[np.complex128, _NoD]], iterable: _ToKeys, v: op.JustComplex, /
+    ) -> _dok_base[np.complex128, _AnyD]: ...
     @overload
     @classmethod
     def fromkeys(cls: type[_C2T], iterable: _ToKeys2, v: op.JustComplex, /) -> _C2T: ...
@@ -176,111 +177,225 @@ class _dok_base(  # pyright: ignore[reportIncompatibleMethodOverride]
 
 #
 class dok_array(_dok_base[_ScalarT_co, _ShapeT_co], sparray[_ScalarT_co, _ShapeT_co], Generic[_ScalarT_co, _ShapeT_co]):
-    # NOTE: These two methods do not exist at runtime.
+    # NOTE: These four methods do not exist at runtime.
     # See the relevant comment in `sparse._base._spbase` for more information.
     @override
     @type_check_only
-    def __assoc_stacked__(self, /) -> coo_array[_ScalarT_co, tuple[int, int]]: ...
+    def __assoc_stacked__(self, /) -> coo_array[_ScalarT_co, _2D]: ...
     @override
     @type_check_only
-    def __assoc_stacked_as__(self, sctype: _ScalarT, /) -> coo_array[_ScalarT, tuple[int, int]]: ...
+    def __assoc_stacked_as__(self, sctype: _ScalarT, /) -> coo_array[_ScalarT, _2D]: ...
+    @type_check_only
+    def __assoc_as_float32__(self, /) -> dok_array[np.float32, _ShapeT_co]: ...
+    @type_check_only
+    def __assoc_as_float64__(self, /) -> dok_array[np.float64, _ShapeT_co]: ...
 
     # NOTE: keep the 2d overloads in sync with `dok_matrix.__init__`
     # TODO(jorenham): Overloads for specific shape types.
-    @overload  # matrix-like (known dtype), dtype: None
+    @overload  # sparse or dense (know dtype & shape), dtype: None
     def __init__(
         self,
         /,
-        arg1: _ToMatrix[_ScalarT_co],
-        shape: ToShapeMin1D | None = None,
-        dtype: None = None,
+        arg1: _spbase[_ScalarT_co, _ShapeT_co] | onp.CanArrayND[_ScalarT_co, _ShapeT_co],
+        shape: _ShapeT_co | None = None,
+        dtype: onp.ToDType[_ScalarT_co] | None = None,
+        copy: bool = False,
+        *,
+        maxprint: int | None = None,
+    ) -> None: ...
+    @overload  # 1-d array-like (know dtype), dtype: None
+    def __init__(
+        self: dok_array[_ScalarT, _1D],
+        /,
+        arg1: Sequence[_ScalarT],
+        shape: ToShape1D | None = None,
+        dtype: onp.ToDType[_ScalarT] | None = None,
+        copy: bool = False,
+        *,
+        maxprint: int | None = None,
+    ) -> None: ...
+    @overload  # 2-d array-like (know dtype), dtype: None
+    def __init__(
+        self: dok_array[_ScalarT, _2D],
+        /,
+        arg1: Sequence[Sequence[_ScalarT] | onp.CanArrayND[_ScalarT]],  # assumes max. 2-d
+        shape: ToShape2D | None = None,
+        dtype: onp.ToDType[_ScalarT] | None = None,
+        copy: bool = False,
+        *,
+        maxprint: int | None = None,
+    ) -> None: ...
+    @overload  # matrix-like (known dtype), dtype: None
+    def __init__(
+        self: dok_array[_ScalarT, _AnyD],
+        /,
+        arg1: _ToMatrix[_ScalarT],
+        shape: ToShapeMax2D | None = None,
+        dtype: onp.ToDType[_ScalarT] | None = None,
+        copy: bool = False,
+        *,
+        maxprint: int | None = None,
+    ) -> None: ...
+    @overload  # 1-d shape-like, dtype: None
+    def __init__(
+        self: dok_array[np.float64, _1D],
+        /,
+        arg1: ToShape1D,
+        shape: ToShape1D | None = None,
+        dtype: onp.AnyFloat64DType | None = None,
         copy: bool = False,
         *,
         maxprint: int | None = None,
     ) -> None: ...
     @overload  # 2-d shape-like, dtype: None
     def __init__(
-        self: dok_array[np.float64],
+        self: dok_array[np.float64, _2D],
         /,
-        arg1: ToShapeMin1D,
-        shape: None = None,
-        dtype: None = None,
-        copy: bool = False,
-        *,
-        maxprint: int | None = None,
-    ) -> None: ...
-    @overload  # matrix-like builtins.bool, dtype: type[bool] | None
-    def __init__(
-        self: dok_array[np.bool_],
-        /,
-        arg1: _ToMatrixPy[bool],
-        shape: ToShapeMin1D | None = None,
-        dtype: onp.AnyBoolDType | None = None,
-        copy: bool = False,
-        *,
-        maxprint: int | None = None,
-    ) -> None: ...
-    @overload  # matrix-like builtins.int, dtype: type[int] | None
-    def __init__(
-        self: dok_array[np.int_],
-        /,
-        arg1: _ToMatrixPy[op.JustInt],
-        shape: ToShapeMin1D | None = None,
-        dtype: onp.AnyIntDType | None = None,
-        copy: bool = False,
-        *,
-        maxprint: int | None = None,
-    ) -> None: ...
-    @overload  # matrix-like builtins.float, dtype: type[float] | None
-    def __init__(
-        self: dok_array[np.float64],
-        /,
-        arg1: _ToMatrixPy[op.JustFloat],
-        shape: ToShapeMin1D | None = None,
+        arg1: ToShape2D,
+        shape: ToShape2D | None = None,
         dtype: onp.AnyFloat64DType | None = None,
         copy: bool = False,
         *,
         maxprint: int | None = None,
     ) -> None: ...
-    @overload  # matrix-like builtins.complex, dtype: type[complex] | None
+    @overload  # 1-d array-like bool, dtype: type[bool] | None
     def __init__(
-        self: dok_array[np.complex128],
+        self: dok_array[np.bool_, _1D],
         /,
-        arg1: _ToMatrixPy[op.JustComplex],
-        shape: ToShapeMin1D | None = None,
+        arg1: onp.ToJustBoolStrict1D,
+        shape: ToShape1D | None = None,
+        dtype: onp.AnyBoolDType | None = None,
+        copy: bool = False,
+        *,
+        maxprint: int | None = None,
+    ) -> None: ...
+    @overload  # 2-d array-like bool, dtype: type[bool] | None
+    def __init__(
+        self: dok_array[np.bool_, _2D],
+        /,
+        arg1: onp.ToJustBoolStrict2D,
+        shape: ToShape2D | None = None,
+        dtype: onp.AnyBoolDType | None = None,
+        copy: bool = False,
+        *,
+        maxprint: int | None = None,
+    ) -> None: ...
+    @overload  # 1-d array-like ~int, dtype: type[int] | None
+    def __init__(
+        self: dok_array[np.int64, _1D],
+        /,
+        arg1: onp.ToJustInt64Strict1D,
+        shape: ToShape1D | None = None,
+        dtype: onp.AnyIntDType | None = None,
+        copy: bool = False,
+        *,
+        maxprint: int | None = None,
+    ) -> None: ...
+    @overload  # 2-d array-like ~int, dtype: type[int] | None
+    def __init__(
+        self: dok_array[np.int64, _2D],
+        /,
+        arg1: onp.ToJustInt64Strict2D,
+        shape: ToShape2D | None = None,
+        dtype: onp.AnyIntDType | None = None,
+        copy: bool = False,
+        *,
+        maxprint: int | None = None,
+    ) -> None: ...
+    @overload  # 1-d array-like ~float, dtype: type[float] | None
+    def __init__(
+        self: dok_array[np.float64, _1D],
+        /,
+        arg1: onp.ToJustFloat64Strict1D,
+        shape: ToShape1D | None = None,
+        dtype: onp.AnyFloat64DType | None = None,
+        copy: bool = False,
+        *,
+        maxprint: int | None = None,
+    ) -> None: ...
+    @overload  # 2-d array-like ~float, dtype: type[float] | None
+    def __init__(
+        self: dok_array[np.float64, _2D],
+        /,
+        arg1: onp.ToJustFloat64Strict2D,
+        shape: ToShape2D | None = None,
+        dtype: onp.AnyFloat64DType | None = None,
+        copy: bool = False,
+        *,
+        maxprint: int | None = None,
+    ) -> None: ...
+    @overload  # 1-d array-like ~complex, dtype: type[complex] | None
+    def __init__(
+        self: dok_array[np.complex128, _1D],
+        /,
+        arg1: onp.ToJustComplex128Strict1D,
+        shape: ToShape1D | None = None,
         dtype: onp.AnyComplex128DType | None = None,
         copy: bool = False,
         *,
         maxprint: int | None = None,
     ) -> None: ...
-    @overload  # dtype: <known> (positional)
+    @overload  # 2-d array-like ~complex, dtype: type[complex] | None
     def __init__(
-        self,
+        self: dok_array[np.complex128, _2D],
         /,
-        arg1: onp.ToComplexND,
-        shape: ToShapeMin1D | None,
-        dtype: onp.ToDType[_ScalarT_co],
+        arg1: onp.ToJustComplex128Strict2D,
+        shape: ToShape2D | None = None,
+        dtype: onp.AnyComplex128DType | None = None,
         copy: bool = False,
         *,
         maxprint: int | None = None,
     ) -> None: ...
-    @overload  # dtype: <known> (keyword)
+    @overload  # 1-D, dtype: <known> (positional)
     def __init__(
-        self,
+        self: dok_array[_ScalarT, _1D],
         /,
-        arg1: onp.ToComplexND,
-        shape: ToShapeMin1D | None = None,
+        arg1: onp.ToComplexStrict1D,
+        shape: ToShape1D | None,
+        dtype: onp.ToDType[_ScalarT],
+        copy: bool = False,
         *,
-        dtype: onp.ToDType[_ScalarT_co],
+        maxprint: int | None = None,
+    ) -> None: ...
+    @overload  # 1-D, dtype: <known> (keyword)
+    def __init__(
+        self: dok_array[_ScalarT, _1D],
+        /,
+        arg1: onp.ToComplexStrict1D,
+        shape: ToShape1D | None = None,
+        *,
+        dtype: onp.ToDType[_ScalarT],
+        copy: bool = False,
+        maxprint: int | None = None,
+    ) -> None: ...
+    @overload  # 2-D, dtype: <known> (positional)
+    def __init__(
+        self: dok_array[_ScalarT, _2D],
+        /,
+        arg1: onp.ToComplexStrict2D,
+        shape: ToShape2D | None,
+        dtype: onp.ToDType[_ScalarT],
+        copy: bool = False,
+        *,
+        maxprint: int | None = None,
+    ) -> None: ...
+    @overload  # 2-D, dtype: <known> (keyword)
+    def __init__(
+        self: dok_array[_ScalarT, _2D],
+        /,
+        arg1: onp.ToComplexStrict2D,
+        shape: ToShape2D | None = None,
+        *,
+        dtype: onp.ToDType[_ScalarT],
         copy: bool = False,
         maxprint: int | None = None,
     ) -> None: ...
     @overload  # dtype: <unknown>
     def __init__(
-        self,
+        self: dok_array[Any, _AnyD],
         /,
-        arg1: onp.ToComplexND,
-        shape: ToShapeMin1D | None = None,
+        arg1: onp.ToComplex1D | onp.ToComplex2D,
+        shape: ToShapeMax2D | None = None,
         dtype: npt.DTypeLike | None = None,
         copy: bool = False,
         *,
@@ -291,9 +406,7 @@ class dok_array(_dok_base[_ScalarT_co, _ShapeT_co], sparray[_ScalarT_co, _ShapeT
     # https://github.com/python/typing/issues/548
     @overload
     @classmethod
-    def fromkeys(
-        cls: type[dok_array[np.bool_, _NeitherD]], iterable: _ToKeys, v: onp.ToBool, /
-    ) -> dok_array[np.bool_, tuple[Any, ...]]: ...
+    def fromkeys(cls: type[dok_array[np.bool_, _NoD]], iterable: _ToKeys, v: onp.ToBool, /) -> dok_array[np.bool_, _AnyD]: ...
     @overload
     @classmethod
     def fromkeys(cls: type[dok_array[np.bool_, _2D]], iterable: _ToKeys2, v: onp.ToBool, /) -> dok_array[np.bool_, _2D]: ...
@@ -302,9 +415,7 @@ class dok_array(_dok_base[_ScalarT_co, _ShapeT_co], sparray[_ScalarT_co, _ShapeT
     def fromkeys(cls: type[dok_array[np.bool_, _1D]], iterable: _ToKeys1, v: onp.ToBool, /) -> dok_array[np.bool_, _1D]: ...
     @overload
     @classmethod
-    def fromkeys(
-        cls: type[dok_array[_ScalarT, _NeitherD]], iterable: _ToKeys, v: _ScalarT, /
-    ) -> dok_array[_ScalarT, tuple[Any, ...]]: ...
+    def fromkeys(cls: type[dok_array[_ScalarT, _NoD]], iterable: _ToKeys, v: _ScalarT, /) -> dok_array[_ScalarT, _AnyD]: ...
     @overload
     @classmethod
     def fromkeys(cls: type[dok_array[_ScalarT, _2D]], iterable: _ToKeys2, v: _ScalarT, /) -> dok_array[_ScalarT, _2D]: ...
@@ -313,9 +424,7 @@ class dok_array(_dok_base[_ScalarT_co, _ShapeT_co], sparray[_ScalarT_co, _ShapeT
     def fromkeys(cls: type[dok_array[_ScalarT, _1D]], iterable: _ToKeys1, v: _ScalarT, /) -> dok_array[_ScalarT, _1D]: ...
     @overload
     @classmethod
-    def fromkeys(
-        cls: type[dok_array[np.int_, _NeitherD]], iterable: _ToKeys, v: op.JustInt = 1, /
-    ) -> dok_array[np.int_, tuple[Any, ...]]: ...
+    def fromkeys(cls: type[dok_array[np.int_, _NoD]], iterable: _ToKeys, v: op.JustInt = 1, /) -> dok_array[np.int_, _AnyD]: ...
     @overload
     @classmethod
     def fromkeys(cls: type[dok_array[np.int_, _2D]], iterable: _ToKeys2, v: op.JustInt = 1, /) -> dok_array[np.int_, _2D]: ...
@@ -325,8 +434,8 @@ class dok_array(_dok_base[_ScalarT_co, _ShapeT_co], sparray[_ScalarT_co, _ShapeT
     @overload
     @classmethod
     def fromkeys(
-        cls: type[dok_array[np.float64, _NeitherD]], iterable: _ToKeys, v: op.JustFloat, /
-    ) -> dok_array[np.float64, tuple[Any, ...]]: ...
+        cls: type[dok_array[np.float64, _NoD]], iterable: _ToKeys, v: op.JustFloat, /
+    ) -> dok_array[np.float64, _AnyD]: ...
     @overload
     @classmethod
     def fromkeys(cls: type[dok_array[np.float64, _2D]], iterable: _ToKeys2, v: op.JustFloat, /) -> dok_array[np.float64, _2D]: ...
@@ -336,8 +445,8 @@ class dok_array(_dok_base[_ScalarT_co, _ShapeT_co], sparray[_ScalarT_co, _ShapeT
     @overload
     @classmethod
     def fromkeys(
-        cls: type[dok_array[np.complex128, _NeitherD]], iterable: _ToKeys, v: op.JustComplex, /
-    ) -> dok_array[np.complex128, tuple[Any, ...]]: ...
+        cls: type[dok_array[np.complex128, _NoD]], iterable: _ToKeys, v: op.JustComplex, /
+    ) -> dok_array[np.complex128, _AnyD]: ...
     @overload
     @classmethod
     def fromkeys(
@@ -351,7 +460,7 @@ class dok_array(_dok_base[_ScalarT_co, _ShapeT_co], sparray[_ScalarT_co, _ShapeT
 
 #
 class dok_matrix(_dok_base[_ScalarT_co, _2D], spmatrix[_ScalarT_co], Generic[_ScalarT_co]):
-    # NOTE: These two methods do not exist at runtime.
+    # NOTE: These four methods do not exist at runtime.
     # See the relevant comment in `sparse._base._spbase` for more information.
     @override
     @type_check_only
@@ -359,13 +468,17 @@ class dok_matrix(_dok_base[_ScalarT_co, _2D], spmatrix[_ScalarT_co], Generic[_Sc
     @override
     @type_check_only
     def __assoc_stacked_as__(self, sctype: _ScalarT, /) -> coo_matrix[_ScalarT]: ...
+    @type_check_only
+    def __assoc_as_float32__(self, /) -> dok_matrix[np.float32]: ...
+    @type_check_only
+    def __assoc_as_float64__(self, /) -> dok_matrix[np.float64]: ...
 
     # NOTE: keep the in sync with `dok_array.__init__`
     @overload  # matrix-like (known dtype), dtype: None
     def __init__(
-        self,
+        self: dok_matrix[_ScalarT],  # this self annotation works around a mypy bug
         /,
-        arg1: _ToMatrix[_ScalarT_co],
+        arg1: _ToMatrix[_ScalarT],
         shape: ToShape2D | None = None,
         dtype: None = None,
         copy: bool = False,
@@ -387,7 +500,7 @@ class dok_matrix(_dok_base[_ScalarT_co, _2D], spmatrix[_ScalarT_co], Generic[_Sc
     def __init__(
         self: dok_matrix[np.bool_],
         /,
-        arg1: _ToMatrixPy[bool],
+        arg1: onp.ToJustBoolStrict2D,
         shape: ToShape2D | None = None,
         dtype: onp.AnyBoolDType | None = None,
         copy: bool = False,
@@ -396,9 +509,9 @@ class dok_matrix(_dok_base[_ScalarT_co, _2D], spmatrix[_ScalarT_co], Generic[_Sc
     ) -> None: ...
     @overload  # matrix-like builtins.int, dtype: type[int] | None
     def __init__(
-        self: dok_matrix[np.int_],
+        self: dok_matrix[np.int64],
         /,
-        arg1: _ToMatrixPy[op.JustInt],
+        arg1: onp.ToJustInt64Strict2D,
         shape: ToShape2D | None = None,
         dtype: onp.AnyIntDType | None = None,
         copy: bool = False,
@@ -409,7 +522,7 @@ class dok_matrix(_dok_base[_ScalarT_co, _2D], spmatrix[_ScalarT_co], Generic[_Sc
     def __init__(
         self: dok_matrix[np.float64],
         /,
-        arg1: _ToMatrixPy[op.JustFloat],
+        arg1: onp.ToJustFloat64Strict2D,
         shape: ToShape2D | None = None,
         dtype: onp.AnyFloat64DType | None = None,
         copy: bool = False,
@@ -420,7 +533,7 @@ class dok_matrix(_dok_base[_ScalarT_co, _2D], spmatrix[_ScalarT_co], Generic[_Sc
     def __init__(
         self: dok_matrix[np.complex128],
         /,
-        arg1: _ToMatrixPy[op.JustComplex],
+        arg1: onp.ToJustComplex128Strict2D,
         shape: ToShape2D | None = None,
         dtype: onp.AnyComplex128DType | None = None,
         copy: bool = False,

--- a/scipy-stubs/sparse/_typing.pyi
+++ b/scipy-stubs/sparse/_typing.pyi
@@ -12,8 +12,8 @@ __all__ = (
     "Numeric",
     "SPFormat",
     "ToShape1D",
-    "ToShape1D",
     "ToShape2D",
+    "ToShapeMax2D",
     "ToShapeMin1D",
     "ToShapeMin3D",
     "_CanStack",
@@ -29,6 +29,7 @@ Index1D: TypeAlias = onp.Array1D[np.int32]
 
 ToShape1D: TypeAlias = tuple[SupportsIndex]  # ndim == 1
 ToShape2D: TypeAlias = tuple[SupportsIndex, SupportsIndex]  # ndim == 2
+ToShapeMax2D: TypeAlias = ToShape1D | ToShape2D  # ndim <= 2
 ToShapeMin1D: TypeAlias = tuple[SupportsIndex, *tuple[SupportsIndex, ...]]  # ndim >= 1
 ToShapeMin3D: TypeAlias = tuple[SupportsIndex, SupportsIndex, SupportsIndex, *tuple[SupportsIndex, ...]]  # ndim >= 2
 

--- a/tests/sparse/_types.pyi
+++ b/tests/sparse/_types.pyi
@@ -39,3 +39,7 @@ any_arr: (
     | sparse.dok_array[ScalarType, tuple[int, int]]
     | sparse.lil_array[ScalarType]
 )
+
+coo_vec: sparse.coo_array[ScalarType, tuple[int]]
+csr_vec: sparse.csr_array[ScalarType, tuple[int]]
+dok_vec: sparse.dok_array[ScalarType, tuple[int]]

--- a/tests/sparse/test_csr.pyi
+++ b/tests/sparse/test_csr.pyi
@@ -1,0 +1,78 @@
+from typing import Literal, TypeAlias, assert_type
+
+import numpy as np
+
+from ._types import csr_arr, csr_mat, csr_vec
+from scipy.sparse import csr_array, csr_matrix, isspmatrix
+
+###
+
+seq_bool: list[bool]
+seq_int: list[int]
+seq_float: list[float]
+seq_complex: list[complex]
+
+seq_seq_bool: list[list[bool]]
+seq_seq_int: list[list[int]]
+seq_seq_float: list[list[float]]
+seq_seq_complex: list[list[complex]]
+
+###
+# NOTE: Keep these tests in sync with the `dok` tests.
+
+csr_array(1)  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType, reportCallIssue]
+csr_matrix(1)  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType, reportCallIssue]
+
+assert_type(csr_array((2,)), csr_array[np.float64, tuple[int]])
+assert_type(csr_array((2, 3)), csr_array[np.float64, tuple[int, int]])
+assert_type(csr_matrix((2, 3)), csr_matrix[np.float64])
+
+assert_type(csr_array(seq_bool), csr_array[np.bool_, tuple[int]])
+assert_type(csr_array(seq_int), csr_array[np.int64, tuple[int]])
+assert_type(csr_array(seq_float), csr_array[np.float64, tuple[int]])
+assert_type(csr_array(seq_complex), csr_array[np.complex128, tuple[int]])
+
+assert_type(csr_array(seq_seq_bool), csr_array[np.bool_, tuple[int, int]])
+assert_type(csr_array(seq_seq_int), csr_array[np.int64, tuple[int, int]])
+assert_type(csr_array(seq_seq_float), csr_array[np.float64, tuple[int, int]])
+assert_type(csr_array(seq_seq_complex), csr_array[np.complex128, tuple[int, int]])
+
+assert_type(csr_matrix(seq_seq_bool), csr_matrix[np.bool_])
+assert_type(csr_matrix(seq_seq_int), csr_matrix[np.int64])
+assert_type(csr_matrix(seq_seq_float), csr_matrix[np.float64])
+assert_type(csr_matrix(seq_seq_complex), csr_matrix[np.complex128])
+
+###
+# CSR-specific tests
+
+_Index1D: TypeAlias = np.ndarray[tuple[int], np.dtype[np.intp]]
+
+# .format
+assert_type(csr_arr.format, Literal["csr"])
+assert_type(csr_mat.format, Literal["csr"])
+
+# .ndim
+assert_type(csr_arr.ndim, Literal[1, 2])
+assert_type(csr_mat.ndim, Literal[2])
+
+# .count_nonzero() (defined in `_csr_base`), so no need to check for `csr_matrix`
+assert_type(csr_vec.count_nonzero(), np.intp)
+assert_type(csr_arr.count_nonzero(), np.intp)
+assert_type(csr_vec.count_nonzero(0), np.intp)
+assert_type(csr_arr.count_nonzero(0), _Index1D)
+assert_type(csr_vec.count_nonzero(axis=0), np.intp)
+assert_type(csr_arr.count_nonzero(axis=0), _Index1D)
+
+# .getnnz() (only matrix)
+assert_type(csr_mat.getnnz(), int)
+assert_type(csr_mat.getnnz(None), int)
+assert_type(csr_mat.getnnz(1), _Index1D)
+assert_type(csr_mat.getnnz(0), _Index1D)
+assert_type(csr_mat.getnnz(-1), _Index1D)
+assert_type(csr_mat.getnnz(-2), _Index1D)
+csr_mat.getnnz(2)  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType, reportCallIssue]
+csr_mat.getnnz(-3)  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType, reportCallIssue]
+
+assert_type(isspmatrix(csr_arr), bool)
+assert_type(isspmatrix(csr_mat), bool)
+assert_type(isspmatrix(object()), bool)

--- a/tests/sparse/test_dok.pyi
+++ b/tests/sparse/test_dok.pyi
@@ -1,8 +1,10 @@
-from typing import assert_type
+from typing import Literal, assert_type
 
 import numpy as np
 
+from ._types import ScalarType, dok_arr, dok_mat, dok_vec
 from scipy.sparse import dok_array, dok_matrix
+from scipy.sparse._coo import coo_array
 
 ###
 
@@ -17,6 +19,7 @@ seq_seq_float: list[list[float]]
 seq_seq_complex: list[list[complex]]
 
 ###
+# NOTE: Keep these tests in sync with the `csr` tests.
 
 dok_array(1)  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType, reportCallIssue]
 dok_matrix(1)  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType, reportCallIssue]
@@ -39,3 +42,43 @@ assert_type(dok_matrix(seq_seq_bool), dok_matrix[np.bool_])
 assert_type(dok_matrix(seq_seq_int), dok_matrix[np.int64])
 assert_type(dok_matrix(seq_seq_float), dok_matrix[np.float64])
 assert_type(dok_matrix(seq_seq_complex), dok_matrix[np.complex128])
+
+###
+# DOK-specific tests
+
+# __len__
+assert_type(len(dok_vec), int)
+assert_type(len(dok_arr), int)
+assert_type(len(dok_mat), int)
+
+# __getitem__
+assert_type(dok_vec[0], ScalarType)
+assert_type(dok_arr[0], coo_array[ScalarType, tuple[int]])
+assert_type(dok_mat[0], dok_matrix[ScalarType])
+dok_vec[0, 0]  # type: ignore[index]  # pyright: ignore[reportArgumentType, reportCallIssue]
+assert_type(dok_arr[0, 0], ScalarType)
+assert_type(dok_mat[0, 0], ScalarType)
+
+# .format
+assert_type(dok_arr.format, Literal["dok"])
+assert_type(dok_mat.format, Literal["dok"])
+
+# .ndim
+assert_type(dok_arr.ndim, Literal[1, 2])
+assert_type(dok_mat.ndim, Literal[2])
+
+# .count_nonzero() (defined in `_dok_base`), so no need to check for `dok_matrix`
+assert_type(dok_vec.count_nonzero(), int)
+assert_type(dok_arr.count_nonzero(), int)
+dok_vec.count_nonzero(0)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
+dok_arr.count_nonzero(0)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
+dok_vec.count_nonzero(axis=0)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
+dok_arr.count_nonzero(axis=0)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
+
+# .get()
+assert_type(dok_vec.get((0,)), ScalarType | float)
+dok_arr.get((0,))  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
+dok_mat.get((0,))  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
+dok_vec.get((0, 1))  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
+assert_type(dok_arr.get((0, 0)), ScalarType | float)
+assert_type(dok_mat.get((0, 0)), ScalarType | float)

--- a/tests/sparse/test_dok.pyi
+++ b/tests/sparse/test_dok.pyi
@@ -1,0 +1,41 @@
+from typing import assert_type
+
+import numpy as np
+
+from scipy.sparse import dok_array, dok_matrix
+
+###
+
+seq_bool: list[bool]
+seq_int: list[int]
+seq_float: list[float]
+seq_complex: list[complex]
+
+seq_seq_bool: list[list[bool]]
+seq_seq_int: list[list[int]]
+seq_seq_float: list[list[float]]
+seq_seq_complex: list[list[complex]]
+
+###
+
+dok_array(1)  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType, reportCallIssue]
+dok_matrix(1)  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType, reportCallIssue]
+
+assert_type(dok_array((2,)), dok_array[np.float64, tuple[int]])
+assert_type(dok_array((2, 3)), dok_array[np.float64, tuple[int, int]])
+assert_type(dok_matrix((2, 3)), dok_matrix[np.float64])
+
+assert_type(dok_array(seq_bool), dok_array[np.bool_, tuple[int]])
+assert_type(dok_array(seq_int), dok_array[np.int64, tuple[int]])
+assert_type(dok_array(seq_float), dok_array[np.float64, tuple[int]])
+assert_type(dok_array(seq_complex), dok_array[np.complex128, tuple[int]])
+
+assert_type(dok_array(seq_seq_bool), dok_array[np.bool_, tuple[int, int]])
+assert_type(dok_array(seq_seq_int), dok_array[np.int64, tuple[int, int]])
+assert_type(dok_array(seq_seq_float), dok_array[np.float64, tuple[int, int]])
+assert_type(dok_array(seq_seq_complex), dok_array[np.complex128, tuple[int, int]])
+
+assert_type(dok_matrix(seq_seq_bool), dok_matrix[np.bool_])
+assert_type(dok_matrix(seq_seq_int), dok_matrix[np.int64])
+assert_type(dok_matrix(seq_seq_float), dok_matrix[np.float64])
+assert_type(dok_matrix(seq_seq_complex), dok_matrix[np.complex128])


### PR DESCRIPTION
... and a bunch of other improvements, as well as type-tests for both formats.

---

Closes #622