### PR TITLE
🐛 `optimize`: fix false rejection of identity functions in `minimize`

### DIFF
--- a/scipy-stubs/optimize/_minimize.pyi
+++ b/scipy-stubs/optimize/_minimize.pyi
@@ -17,6 +17,8 @@ __all__ = ["minimize", "minimize_scalar"]
 ###
 
 _T = TypeVar("_T")
+_Float1DT = TypeVar("_Float1DT", bound=_Float1D)
+
 _Tuple2: TypeAlias = tuple[_T, _T]
 _Tuple3: TypeAlias = tuple[_T, _T, _T]
 _Args: TypeAlias = tuple[object, ...]
@@ -181,6 +183,21 @@ class OptimizeResult(_OptimizeResult):
     hess_inv: _Float2D | LinearOperator  # requires `hess` or `hessp`, depends on solver
     nhev: int  # requires `hess` or `hessp`
 
+@overload  # identity function with and one parameter, `jac` not truthy
+def minimize(
+    fun: Callable[Concatenate[_Float1DT, ...], _Float1DT],
+    x0: onp.ToFloat,
+    args: _Args = (),
+    method: MethodMimimize | _MinimizeMethodFun | None = None,
+    jac: _Fun1D[onp.ToFloat1D] | _FDMethod | Falsy | None = None,
+    hess: _Fun1D[onp.ToFloat2D] | _FDMethod | HessianUpdateStrategy | None = None,
+    hessp: _Fun1Dp[onp.ToFloat1D] | None = None,
+    bounds: Bounds | None = None,
+    constraints: Constraints = (),
+    tol: onp.ToFloat | None = None,
+    callback: _CallbackResult | _CallbackVector | None = None,
+    options: _MinimizeOptions | None = None,
+) -> OptimizeResult: ...
 @overload  # `fun` return scalar, `jac` not truthy
 def minimize(
     fun: _Fun1D[onp.ToFloat],

--- a/tests/optimize/minimize.pyi
+++ b/tests/optimize/minimize.pyi
@@ -12,3 +12,6 @@ def objective_function(CCT: NDArrayFloat, uv_: NDArrayFloat) -> np.float64: ...
 uv = np.atleast_1d([0.1978, 0.3124])
 
 minimize(objective_function, x0=6400, args=(uv,), method="Nelder-Mead", options={"fatol": 1e-10})
+
+# https://github.com/scipy/scipy-stubs/issues/635
+minimize(lambda x: x**2, 0.0)  # type: ignore[misc]


### PR DESCRIPTION
closes #635