### PR TITLE
👽️ scipy 1.16 changes for `optimize.fmin_l_bfgs_b`

### DIFF
--- a/.mypyignore
+++ b/.mypyignore
@@ -1,8 +1,3 @@
-# TODO: 1.16.0rc2 -> 1.16.0 changes
-scipy.optimize.fmin_l_bfgs_b
-scipy.optimize._lbfgsb_py.fmin_l_bfgs_b
-
-
 # scipy-stubs internal helper types (typecheck-only)
 scipy(\.\w+)?\._typing
 

--- a/scipy-stubs/optimize/_lbfgsb_py.pyi
+++ b/scipy-stubs/optimize/_lbfgsb_py.pyi
@@ -1,7 +1,9 @@
 from collections.abc import Callable, Sequence
-from typing import Concatenate, Final, Literal, TypeAlias, TypedDict, type_check_only
+from typing import Concatenate, Final, Literal, TypeAlias, TypedDict, overload, type_check_only
+from typing_extensions import deprecated
 
 import numpy as np
+import optype as op
 import optype.numpy as onp
 
 from scipy.sparse.linalg import LinearOperator
@@ -9,6 +11,7 @@ from scipy.sparse.linalg import LinearOperator
 __all__ = ["LbfgsInvHessProduct", "fmin_l_bfgs_b"]
 
 _Ignored: TypeAlias = object
+_NoValueType: TypeAlias = op.JustObject
 
 @type_check_only
 class _InfoDict(TypedDict):
@@ -29,6 +32,7 @@ class LbfgsInvHessProduct(LinearOperator[np.float64]):
     def __init__(self, /, sk: onp.ToFloat2D, yk: onp.ToFloat2D) -> None: ...
     def todense(self, /) -> onp.Array2D[np.float64]: ...
 
+@overload
 def fmin_l_bfgs_b(
     func: Callable[Concatenate[onp.Array1D[np.float64], ...], onp.ToFloat],
     x0: onp.ToFloat | onp.ToFloat1D,
@@ -40,10 +44,73 @@ def fmin_l_bfgs_b(
     factr: onp.ToFloat = 1e7,
     pgtol: onp.ToFloat = 1e-5,
     epsilon: onp.ToFloat = 1e-8,
-    iprint: onp.ToJustInt = -1,
+    iprint: _NoValueType = ...,
     maxfun: onp.ToJustInt = 15_000,
     maxiter: onp.ToJustInt = 15_000,
-    disp: onp.ToJustInt | None = None,
+    disp: _NoValueType = ...,
+    callback: Callable[[onp.Array1D[np.float64]], _Ignored] | None = None,
+    maxls: onp.ToJustInt = 20,
+) -> tuple[onp.Array1D[np.float64], float | np.float64, _InfoDict]: ...
+@overload
+@deprecated("The `iprint` keyword is deprecated and will be removed from SciPy 1.18.0.")
+def fmin_l_bfgs_b(
+    func: Callable[Concatenate[onp.Array1D[np.float64], ...], onp.ToFloat],
+    x0: onp.ToFloat | onp.ToFloat1D,
+    fprime: Callable[Concatenate[onp.Array1D[np.float64], ...], onp.ToFloat1D] | None = None,
+    args: tuple[object, ...] = (),
+    approx_grad: onp.ToBool = 0,
+    bounds: Sequence[tuple[onp.ToFloat, onp.ToFloat]] | None = None,
+    m: onp.ToJustInt = 10,
+    factr: onp.ToFloat = 1e7,
+    pgtol: onp.ToFloat = 1e-5,
+    epsilon: onp.ToFloat = 1e-8,
+    *,
+    iprint: int,
+    maxfun: onp.ToJustInt = 15_000,
+    maxiter: onp.ToJustInt = 15_000,
+    disp: _NoValueType = ...,
+    callback: Callable[[onp.Array1D[np.float64]], _Ignored] | None = None,
+    maxls: onp.ToJustInt = 20,
+) -> tuple[onp.Array1D[np.float64], float | np.float64, _InfoDict]: ...
+@overload
+@deprecated("The `disp` keyword is deprecated and will be removed from SciPy 1.18.0.")
+def fmin_l_bfgs_b(
+    func: Callable[Concatenate[onp.Array1D[np.float64], ...], onp.ToFloat],
+    x0: onp.ToFloat | onp.ToFloat1D,
+    fprime: Callable[Concatenate[onp.Array1D[np.float64], ...], onp.ToFloat1D] | None = None,
+    args: tuple[object, ...] = (),
+    approx_grad: onp.ToBool = 0,
+    bounds: Sequence[tuple[onp.ToFloat, onp.ToFloat]] | None = None,
+    m: onp.ToJustInt = 10,
+    factr: onp.ToFloat = 1e7,
+    pgtol: onp.ToFloat = 1e-5,
+    epsilon: onp.ToFloat = 1e-8,
+    iprint: _NoValueType = ...,
+    maxfun: onp.ToJustInt = 15_000,
+    maxiter: onp.ToJustInt = 15_000,
+    *,
+    disp: int,
+    callback: Callable[[onp.Array1D[np.float64]], _Ignored] | None = None,
+    maxls: onp.ToJustInt = 20,
+) -> tuple[onp.Array1D[np.float64], float | np.float64, _InfoDict]: ...
+@overload
+@deprecated("The `iprint` and `disp` keywords are deprecated and will be removed from SciPy 1.18.0.")
+def fmin_l_bfgs_b(
+    func: Callable[Concatenate[onp.Array1D[np.float64], ...], onp.ToFloat],
+    x0: onp.ToFloat | onp.ToFloat1D,
+    fprime: Callable[Concatenate[onp.Array1D[np.float64], ...], onp.ToFloat1D] | None = None,
+    args: tuple[object, ...] = (),
+    approx_grad: onp.ToBool = 0,
+    bounds: Sequence[tuple[onp.ToFloat, onp.ToFloat]] | None = None,
+    m: onp.ToJustInt = 10,
+    factr: onp.ToFloat = 1e7,
+    pgtol: onp.ToFloat = 1e-5,
+    epsilon: onp.ToFloat = 1e-8,
+    *,
+    iprint: int,
+    maxfun: onp.ToJustInt = 15_000,
+    maxiter: onp.ToJustInt = 15_000,
+    disp: int,
     callback: Callable[[onp.Array1D[np.float64]], _Ignored] | None = None,
     maxls: onp.ToJustInt = 20,
 ) -> tuple[onp.Array1D[np.float64], float | np.float64, _InfoDict]: ...


### PR DESCRIPTION
Follow-up of #642. 

This also adds deprecation overloads to `optimize.fmin_l_bfgs_b` in case `iprint` or `disp` are used. Apparently these were already deprecated since 1.15.0, but I apparently missed that (as did stubtest).