### PR TITLE
✨ `cluster.vq`: improved dtype annotations

### DIFF
--- a/scipy-stubs/cluster/vq.pyi
+++ b/scipy-stubs/cluster/vq.pyi
@@ -1,20 +1,18 @@
-from typing import Any, Literal, TypeAlias, overload
+from collections.abc import Callable
+from types import ModuleType
+from typing import Final, Literal, TypeAlias, overload
 from typing_extensions import TypeVar
 
 import numpy as np
 import optype.numpy as onp
-
-from scipy._typing import ToRNG
+import optype.numpy.compat as npc
 
 __all__ = ["kmeans", "kmeans2", "vq", "whiten"]
 
 _InitMethod: TypeAlias = Literal["random", "points", "++", "matrix"]
 _MissingMethod: TypeAlias = Literal["warn", "raise"]
 
-_Floating: TypeAlias = np.floating[Any]
-_Inexact: TypeAlias = np.inexact[Any]
-
-_InexactT = TypeVar("_InexactT", bound=_Inexact)
+_InexactT = TypeVar("_InexactT", bound=npc.inexact)
 
 ###
 
@@ -22,56 +20,90 @@ class ClusterError(Exception): ...
 
 #
 @overload
-def whiten(obs: onp.ArrayND[np.bool_ | np.integer[Any]], check_finite: bool | None = None) -> onp.Array2D[np.float64]: ...
+def whiten(obs: onp.ArrayND[np.bool_ | npc.integer], check_finite: bool | None = None) -> onp.Array2D[np.float64]: ...
 @overload
 def whiten(obs: onp.ArrayND[_InexactT], check_finite: bool | None = None) -> onp.Array2D[_InexactT]: ...
 
 #
-@overload
+@overload  # float64
 def vq(
-    obs: onp.ToFloat2D, code_book: onp.ToFloat2D, check_finite: bool = True
-) -> tuple[onp.Array1D[np.int32 | np.intp], onp.Array1D[_Floating]]: ...
-@overload
+    obs: onp.ToJustFloat64_2D, code_book: onp.ToInt2D | onp.ToFloat64_2D, check_finite: bool = True
+) -> tuple[onp.Array1D[np.int32], onp.Array1D[np.float64]]: ...
+@overload  # float32
 def vq(
-    obs: onp.ToComplex2D, code_book: onp.ToComplex2D, check_finite: bool = True
-) -> tuple[onp.Array1D[np.int32 | np.intp], onp.Array1D[_Inexact]]: ...
+    obs: onp.CanArrayND[np.float32], code_book: onp.ToInt2D | onp.CanArrayND[np.float16 | np.float32], check_finite: bool = True
+) -> tuple[onp.Array1D[np.int32], onp.Array1D[np.float32]]: ...
+@overload  # floating
+def vq(
+    obs: onp.ToJustFloat2D, code_book: onp.ToFloat2D, check_finite: bool = True
+) -> tuple[onp.Array1D[np.int32], onp.Array1D[npc.floating]]: ...
 
 #
-@overload
+@overload  # float64
+def py_vq(
+    obs: onp.ToFloat64_2D, code_book: onp.ToFloat64_2D, check_finite: bool = True
+) -> tuple[onp.Array1D[np.intp], onp.Array1D[np.float64]]: ...
+@overload  # floating
 def py_vq(
     obs: onp.ToFloat2D, code_book: onp.ToFloat2D, check_finite: bool = True
-) -> tuple[onp.Array1D[np.intp], onp.Array1D[_Floating]]: ...
-@overload
-def py_vq(
-    obs: onp.ToComplex2D, code_book: onp.ToComplex2D, check_finite: bool = True
-) -> tuple[onp.Array1D[np.intp], onp.Array1D[_Inexact]]: ...
+) -> tuple[onp.Array1D[np.intp], onp.Array1D[npc.floating]]: ...
 
 #
-@overload  # real
+@overload  # float64
 def kmeans(
-    obs: onp.ToFloat2D,
+    obs: onp.ToJustFloat64_2D,
+    k_or_guess: onp.ToJustInt | onp.ToFloat64_ND,
+    iter: int = 20,
+    thresh: float = 1e-5,
+    check_finite: bool = True,
+    *,
+    rng: onp.random.ToRNG | None = None,
+) -> tuple[onp.Array2D[np.float64], np.float64]: ...
+@overload  # float32
+def kmeans(
+    obs: onp.CanArrayND[np.float32],
     k_or_guess: onp.ToJustInt | onp.ToFloatND,
     iter: int = 20,
     thresh: float = 1e-5,
     check_finite: bool = True,
     *,
-    rng: ToRNG = None,
-) -> tuple[onp.Array2D[_Floating], float]: ...
-@overload  # complex
+    rng: onp.random.ToRNG | None = None,
+) -> tuple[onp.Array2D[np.float32], np.float32]: ...
+@overload  # floating
 def kmeans(
-    obs: onp.ToComplex2D,
+    obs: onp.ToJustFloat2D,
     k_or_guess: onp.ToJustInt | onp.ToFloatND,
     iter: int = 20,
     thresh: float = 1e-5,
     check_finite: bool = True,
     *,
-    rng: ToRNG = None,
-) -> tuple[onp.Array2D[_Inexact], float]: ...
+    rng: onp.random.ToRNG | None = None,
+) -> tuple[onp.Array2D[npc.floating], npc.floating]: ...
 
 #
-@overload  # real
+def _kpoints(
+    data: onp.ArrayND[_InexactT], k: int, rng: onp.random.ToRNG, xp: ModuleType
+) -> onp.Array2D[_InexactT]: ...  # undocumented
+def _krandinit(
+    data: onp.ArrayND[npc.inexact], k: int, rng: onp.random.ToRNG, xp: ModuleType
+) -> onp.Array2D[np.float64]: ...  # undocumented
+def _kpp(
+    data: onp.ArrayND[npc.inexact], k: int, rng: onp.random.ToRNG, xp: ModuleType
+) -> onp.Array2D[np.float64]: ...  # undocumented
+
+_valid_init_meth: Final[
+    dict[str, Callable[[onp.ArrayND[npc.inexact], int, onp.random.ToRNG, ModuleType], onp.Array2D[npc.inexact]]]
+] = ...  # undocumented
+
+def _missing_warn() -> None: ...  # undocumented
+def _missing_raise() -> None: ...  # undocumented
+
+_valid_miss_meth: Final[dict[str, Callable[[], None]]] = ...  # undocumented
+
+#
+@overload  # float64
 def kmeans2(
-    data: onp.ToFloat1D | onp.ToFloat2D,
+    data: onp.ToJustFloat64_1D | onp.ToJustFloat64_2D,
     k: onp.ToJustInt | onp.ToFloatND,
     iter: int = 10,
     thresh: float = 1e-5,
@@ -79,11 +111,11 @@ def kmeans2(
     missing: _MissingMethod = "warn",
     check_finite: bool = True,
     *,
-    rng: ToRNG = None,
-) -> tuple[onp.Array2D[_Floating], onp.Array1D[np.int32]]: ...
-@overload  # complex
+    rng: onp.random.ToRNG | None = None,
+) -> tuple[onp.Array2D[np.float64], onp.Array1D[np.int32]]: ...
+@overload  # float32
 def kmeans2(
-    data: onp.ToComplex1D | onp.ToComplex2D,
+    data: onp.CanArrayND[np.float32],
     k: onp.ToJustInt | onp.ToFloatND,
     iter: int = 10,
     thresh: float = 1e-5,
@@ -91,5 +123,17 @@ def kmeans2(
     missing: _MissingMethod = "warn",
     check_finite: bool = True,
     *,
-    rng: ToRNG = None,
-) -> tuple[onp.Array2D[_Inexact], onp.Array1D[np.int32]]: ...
+    rng: onp.random.ToRNG | None = None,
+) -> tuple[onp.Array2D[np.float32], onp.Array1D[np.int32]]: ...
+@overload  # floating
+def kmeans2(
+    data: onp.ToJustFloat1D | onp.ToJustFloat2D,
+    k: onp.ToJustInt | onp.ToFloatND,
+    iter: int = 10,
+    thresh: float = 1e-5,
+    minit: _InitMethod = "random",
+    missing: _MissingMethod = "warn",
+    check_finite: bool = True,
+    *,
+    rng: onp.random.ToRNG | None = None,
+) -> tuple[onp.Array2D[npc.floating], onp.Array1D[np.int32]]: ...

--- a/tests/cluster/test_vq.pyi
+++ b/tests/cluster/test_vq.pyi
@@ -1,0 +1,47 @@
+from typing import Any, assert_type
+
+import numpy as np
+import optype.numpy as onp
+
+from scipy.cluster import vq
+
+i64_2d: np.ndarray[tuple[int, int], np.dtype[np.int64]]
+f32_2d: onp.Array2D[np.float32]
+f64_2d: onp.Array2D[np.float64]
+floating_2d: onp.Array2D[np.float32 | np.float64]
+c128_2d: np.ndarray[tuple[int, int], np.dtype[np.complex128]]
+
+###
+
+# whiten
+assert_type(vq.whiten(i64_2d), onp.Array2D[np.float64])
+assert_type(vq.whiten(f64_2d), onp.Array2D[np.float64])
+assert_type(vq.whiten(c128_2d), onp.Array2D[np.complex128])
+
+# vq
+vq.vq(i64_2d, i64_2d)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType, reportCallIssue]
+assert_type(vq.vq(f32_2d, f32_2d), tuple[onp.Array1D[np.int32], onp.Array1D[np.float32]])
+assert_type(vq.vq(f64_2d, f64_2d), tuple[onp.Array1D[np.int32], onp.Array1D[np.float64]])
+assert_type(vq.vq(floating_2d, floating_2d), tuple[onp.Array1D[np.int32], onp.Array1D[np.floating[Any]]])
+vq.vq(c128_2d, f64_2d)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType, reportCallIssue]
+
+# py_vq
+assert_type(vq.py_vq(i64_2d, i64_2d), tuple[onp.Array1D[np.intp], onp.Array1D[np.float64]])
+assert_type(vq.py_vq(f32_2d, f32_2d), tuple[onp.Array1D[np.intp], onp.Array1D[np.float64]])
+assert_type(vq.py_vq(f64_2d, f64_2d), tuple[onp.Array1D[np.intp], onp.Array1D[np.float64]])
+assert_type(vq.py_vq(floating_2d, floating_2d), tuple[onp.Array1D[np.intp], onp.Array1D[np.float64]])
+vq.py_vq(c128_2d, f64_2d)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType, reportCallIssue]
+
+# kmeans
+vq.kmeans(i64_2d, 2)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType, reportCallIssue]
+assert_type(vq.kmeans(f32_2d, 2), tuple[onp.Array2D[np.float32], np.float32])
+assert_type(vq.kmeans(f64_2d, 2), tuple[onp.Array2D[np.float64], np.float64])
+assert_type(vq.kmeans(floating_2d, 2), tuple[onp.Array2D[np.floating[Any]], np.floating[Any]])
+vq.kmeans(c128_2d, 2)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType, reportCallIssue]
+
+# kmeans2
+vq.kmeans2(i64_2d, 2)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType, reportCallIssue]
+assert_type(vq.kmeans2(f32_2d, 2), tuple[onp.Array2D[np.float32], onp.Array1D[np.int32]])
+assert_type(vq.kmeans2(f64_2d, 2), tuple[onp.Array2D[np.float64], onp.Array1D[np.int32]])
+assert_type(vq.kmeans2(floating_2d, 2), tuple[onp.Array2D[np.floating[Any]], onp.Array1D[np.int32]])
+vq.kmeans2(c128_2d, 2)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType, reportCallIssue]


### PR DESCRIPTION
This affects the following public `scipy..cluster.vq` methods:

- `whiten`
- `vq`
- `kmeans`
- `kmeans2`