### PR TITLE
🐛 `cluster.vq`: Add missing `seed` parameter to `kmeans` and `kmeans2`

### DIFF
--- a/.mypyignore
+++ b/.mypyignore
@@ -11,6 +11,8 @@ scipy\.fft\._pocketfft\..*
 
 # https://github.com/scipy/scipy/issues/23216
 # https://github.com/scipy/scipy-stubs/issues/644
+scipy\.cluster\._?vq\.kmeans
+scipy\.cluster\._?vq\.kmeans2
 scipy\.stats\._?qmc\.QMCEngine\.__init__
 scipy\.stats\._?qmc\.Halton\.__init__
 scipy\.stats\._?qmc\.LatinHypercube\.__init__

--- a/scipy-stubs/cluster/vq.pyi
+++ b/scipy-stubs/cluster/vq.pyi
@@ -57,6 +57,7 @@ def kmeans(
     thresh: float = 1e-5,
     check_finite: bool = True,
     *,
+    seed: onp.random.ToRNG | None = None,
     rng: onp.random.ToRNG | None = None,
 ) -> tuple[onp.Array2D[np.float64], np.float64]: ...
 @overload  # float32
@@ -67,6 +68,7 @@ def kmeans(
     thresh: float = 1e-5,
     check_finite: bool = True,
     *,
+    seed: onp.random.ToRNG | None = None,
     rng: onp.random.ToRNG | None = None,
 ) -> tuple[onp.Array2D[np.float32], np.float32]: ...
 @overload  # floating
@@ -77,6 +79,7 @@ def kmeans(
     thresh: float = 1e-5,
     check_finite: bool = True,
     *,
+    seed: onp.random.ToRNG | None = None,
     rng: onp.random.ToRNG | None = None,
 ) -> tuple[onp.Array2D[npc.floating], npc.floating]: ...
 
@@ -111,6 +114,7 @@ def kmeans2(
     missing: _MissingMethod = "warn",
     check_finite: bool = True,
     *,
+    seed: onp.random.ToRNG | None = None,
     rng: onp.random.ToRNG | None = None,
 ) -> tuple[onp.Array2D[np.float64], onp.Array1D[np.int32]]: ...
 @overload  # float32
@@ -123,6 +127,7 @@ def kmeans2(
     missing: _MissingMethod = "warn",
     check_finite: bool = True,
     *,
+    seed: onp.random.ToRNG | None = None,
     rng: onp.random.ToRNG | None = None,
 ) -> tuple[onp.Array2D[np.float32], onp.Array1D[np.int32]]: ...
 @overload  # floating
@@ -135,5 +140,6 @@ def kmeans2(
     missing: _MissingMethod = "warn",
     check_finite: bool = True,
     *,
+    seed: onp.random.ToRNG | None = None,
     rng: onp.random.ToRNG | None = None,
 ) -> tuple[onp.Array2D[npc.floating], onp.Array1D[np.int32]]: ...


### PR DESCRIPTION
Towards #648