### PR TITLE
🐛 `linalg`: Add missing `seed` kwarg to `clarkson_woodruff_transform`

### DIFF
--- a/.mypyignore
+++ b/.mypyignore
@@ -14,6 +14,7 @@ scipy\.fft\._pocketfft\..*
 scipy\.cluster\._?vq\.kmeans
 scipy\.cluster\._?vq\.kmeans2
 scipy\.interpolate(\._?polyint)?\.BarycentricInterpolator\.__init__
+scipy\.linalg(\._sketches)?\.clarkson_woodruff_transform
 scipy\.stats\._?qmc\.QMCEngine\.__init__
 scipy\.stats\._?qmc\.Halton\.__init__
 scipy\.stats\._?qmc\.LatinHypercube\.__init__

--- a/scipy-stubs/linalg/_sketches.pyi
+++ b/scipy-stubs/linalg/_sketches.pyi
@@ -3,31 +3,52 @@ from typing import overload
 import numpy as np
 import optype.numpy as onp
 
-from scipy._typing import ToRNG
 from scipy.sparse import csc_matrix
 
 __all__ = ["clarkson_woodruff_transform"]
 
 ###
 
-def cwt_matrix(n_rows: onp.ToInt, n_columns: onp.ToInt, rng: ToRNG = None) -> csc_matrix[np.int_]: ...
+def cwt_matrix(n_rows: onp.ToInt, n_columns: onp.ToInt, rng: onp.random.ToRNG | None = None) -> csc_matrix[np.int_]: ...
 
 #
 @overload
-def clarkson_woodruff_transform(input_matrix: onp.ToIntND, sketch_size: onp.ToInt, rng: ToRNG = None) -> onp.ArrayND[np.int_]: ...
+def clarkson_woodruff_transform(
+    input_matrix: onp.ToIntND,
+    sketch_size: onp.ToInt,
+    rng: onp.random.ToRNG | None = None,
+    *,
+    seed: onp.random.ToRNG | None = None,
+) -> onp.ArrayND[np.int_]: ...
 @overload
 def clarkson_woodruff_transform(
-    input_matrix: onp.ToJustFloat64_ND, sketch_size: onp.ToInt, rng: ToRNG = None
+    input_matrix: onp.ToJustFloat64_ND,
+    sketch_size: onp.ToInt,
+    rng: onp.random.ToRNG | None = None,
+    *,
+    seed: onp.random.ToRNG | None = None,
 ) -> onp.ArrayND[np.float64]: ...
 @overload
 def clarkson_woodruff_transform(
-    input_matrix: onp.ToJustFloatND, sketch_size: onp.ToInt, rng: ToRNG = None
+    input_matrix: onp.ToJustFloatND,
+    sketch_size: onp.ToInt,
+    rng: onp.random.ToRNG | None = None,
+    *,
+    seed: onp.random.ToRNG | None = None,
 ) -> onp.ArrayND[np.float64 | np.longdouble]: ...
 @overload
 def clarkson_woodruff_transform(
-    input_matrix: onp.ToJustComplex128_ND, sketch_size: onp.ToInt, rng: ToRNG = None
+    input_matrix: onp.ToJustComplex128_ND,
+    sketch_size: onp.ToInt,
+    rng: onp.random.ToRNG | None = None,
+    *,
+    seed: onp.random.ToRNG | None = None,
 ) -> onp.ArrayND[np.complex128]: ...
 @overload
 def clarkson_woodruff_transform(
-    input_matrix: onp.ToJustComplexND, sketch_size: onp.ToInt, rng: ToRNG = None
+    input_matrix: onp.ToJustComplexND,
+    sketch_size: onp.ToInt,
+    rng: onp.random.ToRNG | None = None,
+    *,
+    seed: onp.random.ToRNG | None = None,
 ) -> onp.ArrayND[np.complex128 | np.clongdouble]: ...


### PR DESCRIPTION
Towards #648