### PR TITLE
🐛 `spatial.transform`: Add missing `random_state` kwarg to `Rotation.random`

### DIFF
--- a/.mypyignore
+++ b/.mypyignore
@@ -23,6 +23,7 @@ scipy\.sparse(\._construct)?\.random
 scipy\.sparse(\._construct)?\.rand
 scipy\.sparse\.linalg(\._eigen(\._svds)?)?\.svds
 scipy\.spatial\.distance\.directed_hausdorff
+scipy\.spatial\.transform(\._?rotation|\._rigid_transform)?\.Rotation\.random
 scipy\.stats\._?qmc\.QMCEngine\.__init__
 scipy\.stats\._?qmc\.Halton\.__init__
 scipy\.stats\._?qmc\.LatinHypercube\.__init__

--- a/scipy-stubs/spatial/transform/_rotation.pyi
+++ b/scipy-stubs/spatial/transform/_rotation.pyi
@@ -8,8 +8,6 @@ import numpy as np
 import optype as op
 import optype.numpy as onp
 
-from scipy._typing import ToRNG
-
 _Float1D: TypeAlias = onp.Array1D[np.float64]
 _Float2D: TypeAlias = onp.Array2D[np.float64]
 _Float3D: TypeAlias = onp.Array3D[np.float64]
@@ -113,7 +111,9 @@ class Rotation:
     @classmethod
     def identity(cls, num: int | None = None) -> Self: ...
     @classmethod
-    def random(cls, num: int | None = None, rng: ToRNG = None) -> Self: ...
+    def random(
+        cls, num: int | None = None, rng: onp.random.ToRNG | None = None, *, random_state: onp.random.ToRNG | None = None
+    ) -> Self: ...
     #
     @overload
     @classmethod


### PR DESCRIPTION
Towards #648