### PR TITLE
🐛 `sparse`: Transposition duality of CSR and CSC arrays

### DIFF
--- a/scipy-stubs/sparse/_csc.pyi
+++ b/scipy-stubs/sparse/_csc.pyi
@@ -8,6 +8,7 @@ import optype.numpy as onp
 
 from ._base import _spbase, sparray
 from ._compressed import _cs_matrix
+from ._csr import _csr_base, csr_array, csr_matrix
 from ._matrix import spmatrix
 from ._typing import Index1D, Numeric, ToShape2D
 
@@ -36,6 +37,13 @@ class _csc_base(_cs_matrix[_ScalarT_co, tuple[int, int]], Generic[_ScalarT_co]):
     def shape(self, /) -> tuple[int, int]: ...
 
     #
+    @override
+    def transpose(  # type: ignore[override]
+        self, /, axes: tuple[Literal[1, -1], Literal[0]] | None = None, copy: bool = False
+    ) -> _csr_base[_ScalarT_co, tuple[int, int]]: ...
+
+    #
+    @override
     @overload
     def count_nonzero(self, /, axis: None = None) -> np.intp: ...
     @overload
@@ -147,6 +155,12 @@ class csc_array(_csc_base[_ScalarT_co], sparray[_ScalarT_co, tuple[int, int]], G
         maxprint: int | None = None,
     ) -> None: ...
 
+    #
+    @override
+    def transpose(  # type: ignore[override]
+        self, /, axes: tuple[Literal[1, -1], Literal[0]] | None = None, copy: bool = False
+    ) -> csr_array[_ScalarT_co, tuple[int, int]]: ...
+
 class csc_matrix(_csc_base[_ScalarT_co], spmatrix[_ScalarT_co], Generic[_ScalarT_co]):
     # NOTE: These four methods do not exist at runtime.
     # See the relevant comment in `sparse._base._spbase` for more information.
@@ -254,6 +268,13 @@ class csc_matrix(_csc_base[_ScalarT_co], spmatrix[_ScalarT_co], Generic[_ScalarT
     ) -> None: ...
 
     #
+    @override
+    def transpose(  # type: ignore[override]
+        self, /, axes: tuple[Literal[1, -1], Literal[0]] | None = None, copy: bool = False
+    ) -> csr_matrix[_ScalarT_co]: ...
+
+    #
+    @override
     @overload
     def getnnz(self, /, axis: None = None) -> int: ...
     @overload

--- a/scipy-stubs/sparse/_csr.pyi
+++ b/scipy-stubs/sparse/_csr.pyi
@@ -10,6 +10,7 @@ import optype.numpy.compat as npc
 
 from ._base import _spbase, sparray
 from ._compressed import _cs_matrix
+from ._csc import csc_array, csc_matrix
 from ._matrix import spmatrix
 from ._typing import Numeric, ToShape1D, ToShape2D, ToShapeMax2D
 
@@ -46,6 +47,7 @@ class _csr_base(_cs_matrix[_ScalarT_co, _ShapeT_co], Generic[_ScalarT_co, _Shape
     def format(self, /) -> Literal["csr"]: ...
 
     #
+    @override
     @overload
     def count_nonzero(self, /, axis: None = None) -> np.intp: ...
     @overload
@@ -284,6 +286,17 @@ class csr_array(_csr_base[_ScalarT_co, _ShapeT_co], sparray[_ScalarT_co, _ShapeT
         maxprint: int | None = None,
     ) -> None: ...
 
+    #
+    @override  # type: ignore[override]
+    @overload
+    def transpose(
+        self: csr_array[_ScalarT, tuple[int, int]], /, axes: tuple[Literal[1, -1], Literal[0]] | None = None, copy: bool = False
+    ) -> csc_array[_ScalarT]: ...
+    @overload
+    def transpose(  # pyright: ignore[reportIncompatibleMethodOverride]
+        self: csr_array[_ScalarT, tuple[int]], /, axes: None = None, copy: bool = False
+    ) -> csr_array[_ScalarT, tuple[int]]: ...
+
 class csr_matrix(_csr_base[_ScalarT_co], spmatrix[_ScalarT_co], Generic[_ScalarT_co]):
     # NOTE: These four methods do not exist at runtime.
     # See the relevant comment in `sparse._base._spbase` for more information.
@@ -407,6 +420,13 @@ class csr_matrix(_csr_base[_ScalarT_co], spmatrix[_ScalarT_co], Generic[_ScalarT
     def ndim(self, /) -> Literal[2]: ...
 
     #
+    @override
+    def transpose(  # type: ignore[override]
+        self, /, axes: tuple[Literal[1, -1], Literal[0]] | None = None, copy: bool = False
+    ) -> csc_matrix[_ScalarT_co]: ...
+
+    #
+    @override
     @overload
     def getnnz(self, /, axis: None = None) -> int: ...
     @overload

--- a/tests/sparse/test_csr.pyi
+++ b/tests/sparse/test_csr.pyi
@@ -3,7 +3,7 @@ from typing import Literal, TypeAlias, assert_type
 import numpy as np
 
 from ._types import ScalarType, csr_arr, csr_mat, csr_vec
-from scipy.sparse import coo_array, csr_array, csr_matrix, isspmatrix
+from scipy.sparse import coo_array, csc_array, csc_matrix, csr_array, csr_matrix, isspmatrix
 
 ###
 
@@ -115,3 +115,13 @@ assert_type(csr_mat[seq_int], csr_matrix[ScalarType])
 assert_type(csr_mat[0, None], csr_matrix[ScalarType])
 assert_type(csr_mat[None, 0], csr_matrix[ScalarType])
 assert_type(csr_mat[seq_int, seq_int], np.matrix[tuple[int, int], np.dtype[ScalarType]])
+
+# T
+assert_type(csr_vec.T, csr_array[ScalarType, tuple[int]])
+assert_type(csr_arr.T, csc_array[ScalarType])
+assert_type(csr_mat.T, csc_matrix[ScalarType])
+
+# transpose
+assert_type(csr_vec.transpose(), csr_array[ScalarType, tuple[int]])
+assert_type(csr_arr.transpose(), csc_array[ScalarType])
+assert_type(csr_mat.transpose(), csc_matrix[ScalarType])

--- a/tests/sparse/test_dok.pyi
+++ b/tests/sparse/test_dok.pyi
@@ -82,3 +82,13 @@ dok_mat.get((0,))  # type: ignore[arg-type]  # pyright: ignore[reportArgumentTyp
 dok_vec.get((0, 1))  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
 assert_type(dok_arr.get((0, 0)), ScalarType | float)
 assert_type(dok_mat.get((0, 0)), ScalarType | float)
+
+# .T
+assert_type(dok_vec.T, dok_array[ScalarType, tuple[int]])
+assert_type(dok_arr.T, dok_array[ScalarType])
+assert_type(dok_mat.T, dok_matrix[ScalarType])
+
+# .transpose()
+assert_type(dok_vec.transpose(), dok_array[ScalarType, tuple[int]])
+assert_type(dok_arr.transpose(), dok_array[ScalarType])
+assert_type(dok_mat.transpose(), dok_matrix[ScalarType])


### PR DESCRIPTION
Transposing a 2d `csr_array`  (or `csr_matrix`) gives a `csc_array` (or `csc_matrix`) and vice-versa. Conversely, transposing a 1d `csr_array` yields itself.

---

Closes #668