### PR TITLE
✨ `sparse.linalg`: Improved linear solver function annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,22 +221,23 @@ All generic type parameters are optional and can be omitted if not needed.
 
 #### `scipy.sparse.linalg`
 
-| generic type                |                                                                                                      |
-| --------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `LaplacianNd[T: real]`      | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.LaplacianNd.html)    |
-| `LinearOperator[T: scalar]` | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.LinearOperator.html) |
+| generic type                        |                                                                                                      |
+| ----------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `LaplacianNd[T: real]`              | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.LaplacianNd.html)    |
+| `LinearOperator[T: scalar]`         | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.LinearOperator.html) |
+| `SuperLU[T: inexact]` | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.SuperLU.html)        |
 
 ### `scipy.stats`
 
-| generic type                                   |                                                                                               |
-| ---------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| `Covariance[T: real]`                          | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.Covariance.html)      |
-| `Uniform[S: (int, ...), T: floating]`          | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.Uniform.html)         |
-| `Normal[S: (int, ...), T: floating]`           | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.Normal.html)          |
-| `Binomial[S: (int, ...), T: floating]`         | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.Binomial.html)        |
-| `Mixture[T: floating]`                         | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.Mixture.html)         |
-| `rv_frozen[D: rv_generic, T: scalar or array]` | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.rv_frozen.html)       |
-| `multi_rv_frozen[D: rv_generic]`               | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.multi_rv_frozen.html) |
+| generic type                                   |                                                                                          |
+| ---------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `Covariance[T: real]`                          | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.Covariance.html) |
+| `Uniform[S: (int, ...), T: floating]`          | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.Uniform.html)    |
+| `Normal[S: (int, ...), T: floating]`           | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.Normal.html)     |
+| `Binomial[S: (int, ...), T: floating]`         | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.Binomial.html)   |
+| `Mixture[T: floating]`                         | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.Mixture.html)    |
+| `rv_frozen[D: rv_generic, T: scalar or array]` |                                                                                          |
+| `multi_rv_frozen[D: rv_generic]`               |                                                                                          |
 
 ## Contributing
 

--- a/scipy-stubs/sparse/linalg/_dsolve/_superlu.pyi
+++ b/scipy-stubs/sparse/linalg/_dsolve/_superlu.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Callable, Mapping
-from typing import Final, Generic, Literal, TypeAlias, final, overload
+from typing import Any, Final, Generic, Literal, TypeAlias, final, overload
 from typing_extensions import TypeVar
 
 import numpy as np
@@ -9,7 +9,7 @@ import optype.numpy.compat as npc
 
 from scipy.sparse import csc_array, csc_matrix, csr_matrix
 
-_Inexact64T_co = TypeVar("_Inexact64T_co", bound=np.float64 | np.complex128, default=np.float64 | np.complex128, covariant=True)
+_InexactT_co = TypeVar("_InexactT_co", bound=np.float32 | np.float64 | np.complex64 | np.complex128, default=Any, covariant=True)
 
 _Int1D: TypeAlias = onp.Array1D[np.int32]
 _Float1D: TypeAlias = onp.Array1D[np.float64]
@@ -23,13 +23,13 @@ _Real: TypeAlias = npc.integer | npc.floating
 ###
 
 @final
-class SuperLU(Generic[_Inexact64T_co]):
+class SuperLU(Generic[_InexactT_co]):
     shape: Final[tuple[int, int]]
     nnz: Final[int]
     perm_r: Final[onp.Array1D[np.intp]]
     perm_c: Final[onp.Array1D[np.intp]]
-    L: csc_array[_Inexact64T_co]  # readonly
-    U: csc_array[_Inexact64T_co]  # readonly
+    L: csc_array[_InexactT_co]  # readonly
+    U: csc_array[_InexactT_co]  # readonly
 
     @overload
     def solve(self, /, rhs: onp.Array1D[_Real]) -> _Float1D: ...

--- a/scipy-stubs/sparse/linalg/_dsolve/linsolve.pyi
+++ b/scipy-stubs/sparse/linalg/_dsolve/linsolve.pyi
@@ -31,12 +31,19 @@ _Float2D: TypeAlias = onp.Array2D[np.float64]
 _Complex1D: TypeAlias = onp.Array1D[np.complex128]
 _Complex2D: TypeAlias = onp.Array2D[np.complex128]
 
+_ToF32Mat: TypeAlias = _spbase[np.float32, tuple[int, int]] | onp.CanArray[tuple[Any, ...], np.dtype[np.float32]]
+_ToF64Mat: TypeAlias = _spbase[np.float64 | npc.integer, tuple[int, int]] | onp.ToInt2D | onp.ToJustFloat64_2D
+_ToC64Mat: TypeAlias = _spbase[np.complex64, tuple[int, int]] | onp.CanArray[tuple[Any, ...], np.dtype[np.complex64]]
+_ToC128Mat: TypeAlias = _spbase[np.complex128, tuple[int, int]] | onp.ToJustComplex128_2D
+
 _ToFloatMat: TypeAlias = _spbase[npc.floating | npc.integer | np.bool_, tuple[int, int]] | onp.ToFloat2D
 _ToFloatMatStrict: TypeAlias = _spbase[npc.floating | npc.integer | np.bool_, tuple[int, int]] | onp.ToFloatStrict2D
 _ToComplexMat: TypeAlias = _spbase[npc.complexfloating, tuple[int, int]] | onp.ToJustComplex2D
-_ToInexactMat: TypeAlias = _spbase[Any, tuple[int, int]] | onp.ToComplex2D
-_ToInexactMatStrict: TypeAlias = _spbase[Any, tuple[int, int]] | onp.ToComplexStrict2D
+_ToInexactMat: TypeAlias = _spbase[Any, tuple[int, int]] | onp.ToComplex128_2D
+_ToInexactMatStrict: TypeAlias = _spbase[Any, tuple[int, int]] | onp.ToComplex128Strict2D
 
+# TODO(jorenham): make generic (because safe casting rules apply, i.e. the current annotations are incorrect)
+# https://github.com/scipy/scipy-stubs/issues/677
 @type_check_only
 class _Solve(Protocol):
     @overload
@@ -158,8 +165,45 @@ def spsolve_triangular(
     unit_diagonal: bool = False,
 ) -> onp.ArrayND[np.float64 | np.complex128]: ...
 
-#
-@overload
+# NOTE: keep in sync with `spilu`
+# NOTE: the mypy ignores work around a mypy bug in overload overlap checking
+@overload  # float64
+def splu(  # type: ignore[overload-overlap]
+    A: _ToF64Mat,
+    permc_spec: _PermcSpec | None = None,
+    diag_pivot_thresh: onp.ToFloat | None = None,
+    relax: int | None = None,
+    panel_size: int | None = None,
+    options: Mapping[str, object] | None = None,
+) -> SuperLU[np.float64]: ...
+@overload  # complex128
+def splu(  # type: ignore[overload-overlap]
+    A: _ToC128Mat,
+    permc_spec: _PermcSpec | None = None,
+    diag_pivot_thresh: onp.ToFloat | None = None,
+    relax: int | None = None,
+    panel_size: int | None = None,
+    options: Mapping[str, object] | None = None,
+) -> SuperLU[np.complex128]: ...
+@overload  # float32
+def splu(
+    A: _ToF32Mat,
+    permc_spec: _PermcSpec | None = None,
+    diag_pivot_thresh: onp.ToFloat | None = None,
+    relax: int | None = None,
+    panel_size: int | None = None,
+    options: Mapping[str, object] | None = None,
+) -> SuperLU[np.float32]: ...
+@overload  # complex64
+def splu(
+    A: _ToC64Mat,
+    permc_spec: _PermcSpec | None = None,
+    diag_pivot_thresh: onp.ToFloat | None = None,
+    relax: int | None = None,
+    panel_size: int | None = None,
+    options: Mapping[str, object] | None = None,
+) -> SuperLU[np.complex64]: ...
+@overload  # floating
 def splu(
     A: _ToFloatMat,
     permc_spec: _PermcSpec | None = None,
@@ -167,8 +211,8 @@ def splu(
     relax: int | None = None,
     panel_size: int | None = None,
     options: Mapping[str, object] | None = None,
-) -> SuperLU[np.float64]: ...
-@overload
+) -> SuperLU[np.float32 | np.float64]: ...
+@overload  # complexfloating
 def splu(
     A: _ToComplexMat,
     permc_spec: _PermcSpec | None = None,
@@ -176,8 +220,8 @@ def splu(
     relax: int | None = None,
     panel_size: int | None = None,
     options: Mapping[str, object] | None = None,
-) -> SuperLU[np.complex128]: ...
-@overload
+) -> SuperLU[np.complex64 | np.complex128]: ...
+@overload  # unknown
 def splu(
     A: _ToInexactMat,
     permc_spec: _PermcSpec | None = None,
@@ -185,10 +229,58 @@ def splu(
     relax: int | None = None,
     panel_size: int | None = None,
     options: Mapping[str, object] | None = None,
-) -> SuperLU[np.float64 | np.complex128]: ...
+) -> SuperLU: ...
 
-#
-@overload
+# NOTE: keep in sync with `splu`
+@overload  # float64
+def spilu(  # type: ignore[overload-overlap]
+    A: _ToF64Mat,
+    drop_tol: onp.ToFloat | None = None,
+    fill_factor: onp.ToFloat | None = None,
+    drop_rule: str | None = None,
+    permc_spec: _PermcSpec | None = None,
+    diag_pivot_thresh: onp.ToFloat | None = None,
+    relax: int | None = None,
+    panel_size: int | None = None,
+    options: Mapping[str, object] | None = None,
+) -> SuperLU[np.float64]: ...
+@overload  # complex128
+def spilu(  # type: ignore[overload-overlap]
+    A: _ToC128Mat,
+    drop_tol: onp.ToFloat | None = None,
+    fill_factor: onp.ToFloat | None = None,
+    drop_rule: str | None = None,
+    permc_spec: _PermcSpec | None = None,
+    diag_pivot_thresh: onp.ToFloat | None = None,
+    relax: int | None = None,
+    panel_size: int | None = None,
+    options: Mapping[str, object] | None = None,
+) -> SuperLU[np.complex128]: ...
+@overload  # float32
+def spilu(
+    A: _ToF32Mat,
+    drop_tol: onp.ToFloat | None = None,
+    fill_factor: onp.ToFloat | None = None,
+    drop_rule: str | None = None,
+    permc_spec: _PermcSpec | None = None,
+    diag_pivot_thresh: onp.ToFloat | None = None,
+    relax: int | None = None,
+    panel_size: int | None = None,
+    options: Mapping[str, object] | None = None,
+) -> SuperLU[np.float32]: ...
+@overload  # complex64
+def spilu(
+    A: _ToC64Mat,
+    drop_tol: onp.ToFloat | None = None,
+    fill_factor: onp.ToFloat | None = None,
+    drop_rule: str | None = None,
+    permc_spec: _PermcSpec | None = None,
+    diag_pivot_thresh: onp.ToFloat | None = None,
+    relax: int | None = None,
+    panel_size: int | None = None,
+    options: Mapping[str, object] | None = None,
+) -> SuperLU[np.complex64]: ...
+@overload  # floating
 def spilu(
     A: _ToFloatMat,
     drop_tol: onp.ToFloat | None = None,
@@ -199,8 +291,8 @@ def spilu(
     relax: int | None = None,
     panel_size: int | None = None,
     options: Mapping[str, object] | None = None,
-) -> SuperLU[np.float64]: ...
-@overload
+) -> SuperLU[np.float32 | np.float64]: ...
+@overload  # complexfloating
 def spilu(
     A: _ToComplexMat,
     drop_tol: onp.ToFloat | None = None,
@@ -211,7 +303,7 @@ def spilu(
     relax: int | None = None,
     panel_size: int | None = None,
     options: Mapping[str, object] | None = None,
-) -> SuperLU[np.complex128]: ...
+) -> SuperLU[np.complex64 | np.complex128]: ...
 @overload
 def spilu(
     A: _ToInexactMat,
@@ -223,7 +315,7 @@ def spilu(
     relax: int | None = None,
     panel_size: int | None = None,
     options: Mapping[str, object] | None = None,
-) -> SuperLU[np.float64 | np.complex128]: ...
+) -> SuperLU: ...
 
 #
 @overload

--- a/scipy-stubs/sparse/linalg/_dsolve/linsolve.pyi
+++ b/scipy-stubs/sparse/linalg/_dsolve/linsolve.pyi
@@ -4,6 +4,7 @@ from typing_extensions import deprecated
 
 import numpy as np
 import optype.numpy as onp
+import optype.numpy.compat as npc
 
 from ._superlu import SuperLU
 from scipy.sparse._base import SparseEfficiencyWarning, _spbase
@@ -30,66 +31,166 @@ _Float2D: TypeAlias = onp.Array2D[np.float64]
 _Complex1D: TypeAlias = onp.Array1D[np.complex128]
 _Complex2D: TypeAlias = onp.Array2D[np.complex128]
 
+_ToFloatMat: TypeAlias = _spbase[npc.floating | npc.integer | np.bool_, tuple[int, int]] | onp.ToFloat2D
+_ToFloatMatStrict: TypeAlias = _spbase[npc.floating | npc.integer | np.bool_, tuple[int, int]] | onp.ToFloatStrict2D
+_ToComplexMat: TypeAlias = _spbase[npc.complexfloating, tuple[int, int]] | onp.ToJustComplex2D
+_ToInexactMat: TypeAlias = _spbase[Any, tuple[int, int]] | onp.ToComplex2D
+_ToInexactMatStrict: TypeAlias = _spbase[Any, tuple[int, int]] | onp.ToComplexStrict2D
+
 @type_check_only
 class _Solve(Protocol):
     @overload
-    def __call__(self, b: onp.Array1D[np.integer[Any] | np.floating[Any]], /) -> _Float1D: ...
+    def __call__(self, b: onp.Array1D[npc.integer | npc.floating], /) -> _Float1D: ...
     @overload
-    def __call__(self, b: onp.Array1D[np.complexfloating[Any, Any]], /) -> _Complex1D: ...
+    def __call__(self, b: onp.Array1D[npc.complexfloating], /) -> _Complex1D: ...
     @overload
-    def __call__(self, b: onp.Array2D[np.integer[Any] | np.floating[Any]], /) -> _Float2D: ...
+    def __call__(self, b: onp.Array2D[npc.integer | npc.floating], /) -> _Float2D: ...
     @overload
-    def __call__(self, b: onp.Array2D[np.complexfloating[Any, Any]], /) -> _Complex2D: ...
+    def __call__(self, b: onp.Array2D[npc.complexfloating], /) -> _Complex2D: ...
     @overload
-    def __call__(self, b: onp.ArrayND[np.integer[Any] | np.floating[Any]], /) -> _Float1D | _Float2D: ...
+    def __call__(self, b: onp.ArrayND[npc.integer | npc.floating], /) -> _Float1D | _Float2D: ...
     @overload
-    def __call__(self, b: onp.ArrayND[np.complexfloating[Any, Any]], /) -> _Complex1D | _Complex2D: ...
+    def __call__(self, b: onp.ArrayND[npc.complexfloating], /) -> _Complex1D | _Complex2D: ...
     @overload
-    def __call__(self, b: onp.ArrayND[np.number[Any]], /) -> _Float1D | _Complex1D | _Float2D | _Complex2D: ...
+    def __call__(self, b: onp.ArrayND[npc.number], /) -> _Float1D | _Complex1D | _Float2D | _Complex2D: ...
 
 ###
 
 class MatrixRankWarning(UserWarning): ...
 
 def use_solver(*, useUmfpack: bool = ..., assumeSortedIndices: bool = ...) -> None: ...
-def factorized(A: _spbase | onp.ToComplex2D) -> _Solve: ...
+def factorized(A: _ToInexactMat) -> _Solve: ...
 
 #
-@overload
+@overload  # 2d float, sparse 2d
+def spsolve(A: _ToInexactMat, b: _SparseT, permc_spec: _PermcSpec | None = None, use_umfpack: bool = True) -> _SparseT: ...
+@overload  # 2d float, 1d float
 def spsolve(
-    A: _spbase | onp.ToComplex2D, b: _SparseT, permc_spec: _PermcSpec | None = None, use_umfpack: bool = True
-) -> _SparseT: ...
-@overload
+    A: _ToFloatMat, b: onp.ToFloatStrict1D, permc_spec: _PermcSpec | None = None, use_umfpack: bool = True
+) -> onp.Array1D[np.float64]: ...
+@overload  # 2d float, 2d float
 def spsolve(
-    A: _spbase | onp.ToComplex2D,
-    b: onp.ToComplex2D | onp.ToComplex1D,
-    permc_spec: _PermcSpec | None = None,
-    use_umfpack: bool = True,
-) -> _Float1D | _Complex1D | _Float2D | _Complex2D: ...
+    A: _ToFloatMat, b: onp.ToFloatStrict2D, permc_spec: _PermcSpec | None = None, use_umfpack: bool = True
+) -> onp.Array2D[np.float64]: ...
+@overload  # 2d float, 1d or 2d float
+def spsolve(
+    A: _ToFloatMat, b: onp.ToFloat2D | onp.ToFloat1D, permc_spec: _PermcSpec | None = None, use_umfpack: bool = True
+) -> onp.ArrayND[np.float64]: ...
+@overload  # 2d complex, 1d complex
+def spsolve(
+    A: _ToComplexMat, b: onp.ToComplexStrict1D, permc_spec: _PermcSpec | None = None, use_umfpack: bool = True
+) -> onp.Array1D[np.complex128]: ...
+@overload  # 2d complex, 2d complex
+def spsolve(
+    A: _ToComplexMat, b: onp.ToComplexStrict2D, permc_spec: _PermcSpec | None = None, use_umfpack: bool = True
+) -> onp.Array2D[np.complex128]: ...
+@overload  # 2d complex, 1d or 2d complex
+def spsolve(
+    A: _ToComplexMat, b: onp.ToComplex2D | onp.ToComplex1D, permc_spec: _PermcSpec | None = None, use_umfpack: bool = True
+) -> onp.ArrayND[np.complex128]: ...
+@overload  # 2d inexact, 1d or 2d inexact
+def spsolve(
+    A: _ToInexactMat, b: onp.ToComplex2D | onp.ToComplex1D, permc_spec: _PermcSpec | None = None, use_umfpack: bool = True
+) -> onp.ArrayND[np.float64 | np.complex128]: ...
 
 #
+@overload  # 2d float, 1d float
 def spsolve_triangular(
-    A: _spbase | onp.ToComplex2D,
-    b: _spbase | onp.ToComplex2D | onp.ToComplex1D,
+    A: _ToFloatMat,
+    b: onp.ToFloatStrict1D,
     lower: bool = True,
     overwrite_A: bool = False,
     overwrite_b: bool = False,
     unit_diagonal: bool = False,
-) -> _Float1D | _Complex1D | _Float2D | _Complex2D: ...
+) -> onp.Array1D[np.float64]: ...
+@overload  # 2d float, 2d float
+def spsolve_triangular(
+    A: _ToFloatMat,
+    b: _ToFloatMatStrict,
+    lower: bool = True,
+    overwrite_A: bool = False,
+    overwrite_b: bool = False,
+    unit_diagonal: bool = False,
+) -> onp.Array2D[np.float64]: ...
+@overload  # 2d float, 1d or 2d float
+def spsolve_triangular(
+    A: _ToFloatMat,
+    b: _ToFloatMat | onp.ToFloat1D,
+    lower: bool = True,
+    overwrite_A: bool = False,
+    overwrite_b: bool = False,
+    unit_diagonal: bool = False,
+) -> onp.ArrayND[np.float64]: ...
+@overload  # 2d complex, 1d complex
+def spsolve_triangular(
+    A: _ToComplexMat,
+    b: onp.ToComplexStrict1D,
+    lower: bool = True,
+    overwrite_A: bool = False,
+    overwrite_b: bool = False,
+    unit_diagonal: bool = False,
+) -> onp.Array1D[np.complex128]: ...
+@overload  # 2d complex, 2d complex
+def spsolve_triangular(
+    A: _ToComplexMat,
+    b: _ToInexactMatStrict,
+    lower: bool = True,
+    overwrite_A: bool = False,
+    overwrite_b: bool = False,
+    unit_diagonal: bool = False,
+) -> onp.Array2D[np.complex128]: ...
+@overload  # 2d complex, 1d or 2d complex
+def spsolve_triangular(
+    A: _ToComplexMat,
+    b: _ToInexactMat | onp.ToComplex1D,
+    lower: bool = True,
+    overwrite_A: bool = False,
+    overwrite_b: bool = False,
+    unit_diagonal: bool = False,
+) -> onp.ArrayND[np.complex128]: ...
+@overload  # 2d inexact, 1d or 2d inexact
+def spsolve_triangular(
+    A: _ToInexactMat,
+    b: _ToInexactMat | onp.ToComplex1D,
+    lower: bool = True,
+    overwrite_A: bool = False,
+    overwrite_b: bool = False,
+    unit_diagonal: bool = False,
+) -> onp.ArrayND[np.float64 | np.complex128]: ...
 
 #
+@overload
 def splu(
-    A: _spbase | onp.ToComplex2D,
+    A: _ToFloatMat,
     permc_spec: _PermcSpec | None = None,
     diag_pivot_thresh: onp.ToFloat | None = None,
     relax: int | None = None,
     panel_size: int | None = None,
     options: Mapping[str, object] | None = None,
-) -> SuperLU: ...
+) -> SuperLU[np.float64]: ...
+@overload
+def splu(
+    A: _ToComplexMat,
+    permc_spec: _PermcSpec | None = None,
+    diag_pivot_thresh: onp.ToFloat | None = None,
+    relax: int | None = None,
+    panel_size: int | None = None,
+    options: Mapping[str, object] | None = None,
+) -> SuperLU[np.complex128]: ...
+@overload
+def splu(
+    A: _ToInexactMat,
+    permc_spec: _PermcSpec | None = None,
+    diag_pivot_thresh: onp.ToFloat | None = None,
+    relax: int | None = None,
+    panel_size: int | None = None,
+    options: Mapping[str, object] | None = None,
+) -> SuperLU[np.float64 | np.complex128]: ...
 
 #
+@overload
 def spilu(
-    A: _spbase | onp.ToComplex2D,
+    A: _ToFloatMat,
     drop_tol: onp.ToFloat | None = None,
     fill_factor: onp.ToFloat | None = None,
     drop_rule: str | None = None,
@@ -98,7 +199,31 @@ def spilu(
     relax: int | None = None,
     panel_size: int | None = None,
     options: Mapping[str, object] | None = None,
-) -> SuperLU: ...
+) -> SuperLU[np.float64]: ...
+@overload
+def spilu(
+    A: _ToComplexMat,
+    drop_tol: onp.ToFloat | None = None,
+    fill_factor: onp.ToFloat | None = None,
+    drop_rule: str | None = None,
+    permc_spec: _PermcSpec | None = None,
+    diag_pivot_thresh: onp.ToFloat | None = None,
+    relax: int | None = None,
+    panel_size: int | None = None,
+    options: Mapping[str, object] | None = None,
+) -> SuperLU[np.complex128]: ...
+@overload
+def spilu(
+    A: _ToInexactMat,
+    drop_tol: onp.ToFloat | None = None,
+    fill_factor: onp.ToFloat | None = None,
+    drop_rule: str | None = None,
+    permc_spec: _PermcSpec | None = None,
+    diag_pivot_thresh: onp.ToFloat | None = None,
+    relax: int | None = None,
+    panel_size: int | None = None,
+    options: Mapping[str, object] | None = None,
+) -> SuperLU[np.float64 | np.complex128]: ...
 
 #
 @overload

--- a/tests/sparse/sparse/test_dsolve.pyi
+++ b/tests/sparse/sparse/test_dsolve.pyi
@@ -1,0 +1,47 @@
+from typing import assert_type
+
+import numpy as np
+
+from scipy.sparse._csc import csc_array
+from scipy.sparse.linalg import SuperLU, spilu, splu, use_solver
+
+i16_mat: csc_array[np.int16] | np.ndarray[tuple[int, int], np.dtype[np.int16]]
+f32_mat: csc_array[np.float32] | np.ndarray[tuple[int, int], np.dtype[np.float32]]
+f64_mat: csc_array[np.float64] | np.ndarray[tuple[int, int], np.dtype[np.float64]]
+c64_mat: csc_array[np.complex64] | np.ndarray[tuple[int, int], np.dtype[np.complex64]]
+c128_mat: csc_array[np.complex128] | np.ndarray[tuple[int, int], np.dtype[np.complex128]]
+
+# use_solver
+assert_type(use_solver(useUmfpack=False), None)
+assert_type(use_solver(useUmfpack=True), None)
+assert_type(use_solver(), None)
+
+# factorized
+# TODO(jorenham): type-tests, see https://github.com/scipy/scipy-stubs/issues/677
+
+# spsolve
+# TODO(jorenham): type-tests
+
+# spsolve_triangular
+# TODO(jorenham): type-tests
+
+# splu
+assert_type(splu(i16_mat), SuperLU[np.float64])
+assert_type(splu(f32_mat), SuperLU[np.float32])
+assert_type(splu(f64_mat), SuperLU[np.float64])
+assert_type(splu(c64_mat), SuperLU[np.complex64])
+assert_type(splu(c128_mat), SuperLU[np.complex128])
+
+# spilu
+assert_type(spilu(i16_mat), SuperLU[np.float64])
+assert_type(spilu(f32_mat), SuperLU[np.float32])
+assert_type(spilu(f64_mat), SuperLU[np.float64])
+assert_type(spilu(c64_mat), SuperLU[np.complex64])
+assert_type(spilu(c128_mat), SuperLU[np.complex128])
+
+# is_sptriangular
+# TODO(jorenham): type-tests
+
+# spbandwidth
+# TODO(jorenham): type-tests
+#


### PR DESCRIPTION
This affects the following public `scipy.sparse.linalg` functions:

- `spsolve`
- `spsolve_triangular`
- `splu`
- `spilu`

This additionally adds generic type parameters to `scipy.sparse.linalg.SuperLU` (returned by `splu` and `spilu`), making it a generic type.

---

Closes #670