### PR TITLE
💥 `interpolate`: consistent `RBFInterpolator` generic type parameter ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,23 +160,23 @@ All generic type parameters are optional and can be omitted if not needed.
 
 ### `scipy.interpolate`
 
-| generic type                                               |                                                                                                                |
-| ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| `AAA[T: inexact]`                                          | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.AAA.html)                        |
-| `BarycentricInterpolator[T: float64 \| complex128]`        | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.BarycentricInterpolator.html)    |
-| `BPoly[T: float64 \| complex128]`                          | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.BPoly.html)                      |
-| `BSpline[T: float64 \| complex128]`                        | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.BSpline.html)                    |
-| `CubicHermiteSpline[T: float64 \| complex128]`             | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.CubicHermiteSpline.html)         |
-| `CubicSpline[T: float64 \| complex128]`                    | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.CubicSpline.html)                |
-| `FloaterHormannInterpolator[T: float64 \| complex128]`     | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.FloaterHormannInterpolator.html) |
-| `KroghInterpolator[T: float64 \| complex128]`              | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.KroghInterpolator.html)          |
-| `LinearNDInterpolator[T: float64 \| complex128]`           | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.LinearNDInterpolator.html)       |
-| `NdBSpline[T: float64 \| complex128]`                      | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.NdBSpline.html)                  |
-| `NdPPoly[T: float64 \| complex128]`                        | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.NdPPoly.html)                    |
-| `NearestNDInterpolator[T: float64 \| complex128]`          | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.NearestNDInterpolator.html)      |
-| `PPoly[T: float64 \| complex128]`                          | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.PPoly.html)                      |
-| `RBFInterpolator[S: (int, ...), T: float64 \| complex128]` | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.RBFInterpolator.html)            |
-| `RegularGridInterpolator[T: float64 \| complex128]`        | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.RegularGridInterpolator.html)    |
+| generic type                                                 |                                                                                                                |
+| ------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------- |
+| `AAA[T: inexact]`                                            | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.AAA.html)                        |
+| `BarycentricInterpolator[T: float64 \| complex128]`          | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.BarycentricInterpolator.html)    |
+| `BPoly[T: float64 \| complex128]`                            | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.BPoly.html)                      |
+| `BSpline[T: float64 \| complex128]`                          | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.BSpline.html)                    |
+| `CubicHermiteSpline[T: float64 \| complex128]`               | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.CubicHermiteSpline.html)         |
+| `CubicSpline[T: float64 \| complex128]`                      | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.CubicSpline.html)                |
+| `FloaterHormannInterpolator[T: float64 \| complex128]`       | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.FloaterHormannInterpolator.html) |
+| `KroghInterpolator[T: float64 \| complex128, S: (int, ...)]` | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.KroghInterpolator.html)          |
+| `LinearNDInterpolator[T: float64 \| complex128]`             | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.LinearNDInterpolator.html)       |
+| `NdBSpline[T: float64 \| complex128]`                        | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.NdBSpline.html)                  |
+| `NdPPoly[T: float64 \| complex128]`                          | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.NdPPoly.html)                    |
+| `NearestNDInterpolator[T: float64 \| complex128]`            | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.NearestNDInterpolator.html)      |
+| `PPoly[T: float64 \| complex128]`                            | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.PPoly.html)                      |
+| `RBFInterpolator[T: float64 \| complex128, S: (int, ...)]`   | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.RBFInterpolator.html)            |
+| `RegularGridInterpolator[T: float64 \| complex128]`          | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.RegularGridInterpolator.html)    |
 
 ### `scipy.optimize`
 
@@ -221,11 +221,11 @@ All generic type parameters are optional and can be omitted if not needed.
 
 #### `scipy.sparse.linalg`
 
-| generic type                        |                                                                                                      |
-| ----------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `LaplacianNd[T: real]`              | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.LaplacianNd.html)    |
-| `LinearOperator[T: scalar]`         | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.LinearOperator.html) |
-| `SuperLU[T: inexact]` | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.SuperLU.html)        |
+| generic type                |                                                                                                      |
+| --------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `LaplacianNd[T: real]`      | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.LaplacianNd.html)    |
+| `LinearOperator[T: scalar]` | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.LinearOperator.html) |
+| `SuperLU[T: inexact]`       | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.SuperLU.html)        |
 
 ### `scipy.stats`
 

--- a/scipy-stubs/interpolate/_rbfinterp.pyi
+++ b/scipy-stubs/interpolate/_rbfinterp.pyi
@@ -17,12 +17,12 @@ _Kernel: TypeAlias = Literal[
     "gaussian",
 ]  # fmt: skip
 
+_Inexact64T_co = TypeVar("_Inexact64T_co", bound=np.float64 | np.complex128, default=np.float64, covariant=True)
 _ShapeT_co = TypeVar("_ShapeT_co", bound=onp.AtLeast0D, default=onp.AtLeast0D[Any], covariant=True)
-_SCT_co = TypeVar("_SCT_co", bound=np.float64 | np.complex128, default=np.float64, covariant=True)
 
 ###
 
-class RBFInterpolator(Generic[_ShapeT_co, _SCT_co]):
+class RBFInterpolator(Generic[_Inexact64T_co, _ShapeT_co]):
     y: onp.Array2D[np.float64]
     d: onp.Array[_ShapeT_co, np.float64]
     d_shape: _ShapeT_co
@@ -35,7 +35,7 @@ class RBFInterpolator(Generic[_ShapeT_co, _SCT_co]):
 
     @overload
     def __init__(
-        self: RBFInterpolator[tuple[int], np.float64],
+        self: RBFInterpolator[np.float64, tuple[int]],
         /,
         y: onp.ToFloat2D,
         d: onp.ToFloatStrict1D,
@@ -47,7 +47,7 @@ class RBFInterpolator(Generic[_ShapeT_co, _SCT_co]):
     ) -> None: ...
     @overload
     def __init__(
-        self: RBFInterpolator[tuple[int], np.complex128],
+        self: RBFInterpolator[np.complex128, tuple[int]],
         /,
         y: onp.ToFloat2D,
         d: onp.ToJustComplexStrict1D,
@@ -59,7 +59,7 @@ class RBFInterpolator(Generic[_ShapeT_co, _SCT_co]):
     ) -> None: ...
     @overload
     def __init__(
-        self: RBFInterpolator[tuple[int], Any],
+        self: RBFInterpolator[Any, tuple[int]],
         /,
         y: onp.ToFloat2D,
         d: onp.ToComplexStrict1D,
@@ -71,7 +71,7 @@ class RBFInterpolator(Generic[_ShapeT_co, _SCT_co]):
     ) -> None: ...
     @overload
     def __init__(
-        self: RBFInterpolator[tuple[int, int], np.float64],
+        self: RBFInterpolator[np.float64, tuple[int, int]],
         /,
         y: onp.ToFloat2D,
         d: onp.ToFloatStrict2D,
@@ -83,7 +83,7 @@ class RBFInterpolator(Generic[_ShapeT_co, _SCT_co]):
     ) -> None: ...
     @overload
     def __init__(
-        self: RBFInterpolator[tuple[int, int], np.complex128],
+        self: RBFInterpolator[np.complex128, tuple[int, int]],
         /,
         y: onp.ToFloat2D,
         d: onp.ToJustComplexStrict2D,
@@ -95,7 +95,7 @@ class RBFInterpolator(Generic[_ShapeT_co, _SCT_co]):
     ) -> None: ...
     @overload
     def __init__(
-        self: RBFInterpolator[tuple[int, int], Any],
+        self: RBFInterpolator[Any, tuple[int, int]],
         /,
         y: onp.ToFloat2D,
         d: onp.ToComplexStrict2D,
@@ -107,7 +107,7 @@ class RBFInterpolator(Generic[_ShapeT_co, _SCT_co]):
     ) -> None: ...
     @overload
     def __init__(
-        self: RBFInterpolator[tuple[int, int, int], np.float64],
+        self: RBFInterpolator[np.float64, tuple[int, int, int]],
         /,
         y: onp.ToFloat2D,
         d: onp.ToFloatStrict3D,
@@ -119,7 +119,7 @@ class RBFInterpolator(Generic[_ShapeT_co, _SCT_co]):
     ) -> None: ...
     @overload
     def __init__(
-        self: RBFInterpolator[tuple[int, int, int], np.complex128],
+        self: RBFInterpolator[np.complex128, tuple[int, int, int]],
         /,
         y: onp.ToFloat2D,
         d: onp.ToJustComplexStrict3D,
@@ -131,7 +131,7 @@ class RBFInterpolator(Generic[_ShapeT_co, _SCT_co]):
     ) -> None: ...
     @overload
     def __init__(
-        self: RBFInterpolator[tuple[int, int, int], Any],
+        self: RBFInterpolator[Any, tuple[int, int, int]],
         /,
         y: onp.ToFloat2D,
         d: onp.ToComplexStrict3D,
@@ -143,7 +143,7 @@ class RBFInterpolator(Generic[_ShapeT_co, _SCT_co]):
     ) -> None: ...
     @overload
     def __init__(
-        self: RBFInterpolator[onp.AtLeast1D, np.float64],
+        self: RBFInterpolator[np.float64],
         /,
         y: onp.ToFloat2D,
         d: onp.ToFloatND,
@@ -155,7 +155,7 @@ class RBFInterpolator(Generic[_ShapeT_co, _SCT_co]):
     ) -> None: ...
     @overload
     def __init__(
-        self: RBFInterpolator[onp.AtLeast1D, np.complex128],
+        self: RBFInterpolator[np.complex128],
         /,
         y: onp.ToFloat2D,
         d: onp.ToJustComplexND,
@@ -167,7 +167,7 @@ class RBFInterpolator(Generic[_ShapeT_co, _SCT_co]):
     ) -> None: ...
     @overload
     def __init__(
-        self: RBFInterpolator[onp.AtLeast1D, Any],
+        self: RBFInterpolator[Any],
         /,
         y: onp.ToFloat2D,
         d: onp.ToComplexND,
@@ -179,4 +179,4 @@ class RBFInterpolator(Generic[_ShapeT_co, _SCT_co]):
     ) -> None: ...
 
     # TODO(jorenham): Return `onp.Array[tuple[int, Unpack[_ShapeT_co]], _SCT_co]` once mypy supports it (if ever)
-    def __call__(self, /, x: onp.ToFloat2D) -> onp.ArrayND[_SCT_co]: ...
+    def __call__(self, /, x: onp.ToFloat2D) -> onp.ArrayND[_Inexact64T_co]: ...


### PR DESCRIPTION
I'ts an annoying breaking change, but I'm hoping that at this point we're still able to get away with it. 

If this causes issues for you, please open an issue or comment below, so that we can figure out how to best deal with it.