### PR TITLE
🔨 dev script for listing all (private) unstubbed modules

### DIFF
--- a/scripts/unstubbed_modules.py
+++ b/scripts/unstubbed_modules.py
@@ -1,0 +1,66 @@
+"""
+Prints the names of all SciPy modules that are not stubbed.
+"""
+
+# ruff: noqa: T201, S101
+
+import types
+import warnings
+from pathlib import Path
+from typing import Any
+
+import scipy
+
+BUNDLED = "scipy._lib.array_api_compat", "scipy._lib.array_api_extra", "scipy.fft._pocketfft"
+
+
+def modules(mod: types.ModuleType, _seen: set[types.ModuleType] | None = None) -> list[str]:
+    seen = _seen or set()
+    out: list[str] = []
+
+    assert _seen is not None or mod.__spec__
+
+    # the `dir` + `getattr` ensures that lazily loaded modules are included in `vars`
+    mod_vars: dict[str, Any] = {}
+    for k in dir(mod):
+        mod_vars[k] = getattr(mod, k)
+
+    mod_vars |= vars(mod)
+
+    for k, v in mod_vars.items():
+        if isinstance(v, types.ModuleType) and v not in seen and v.__name__.startswith("scipy"):
+            seen.add(v)
+            fname = v.__spec__.name if v.__spec__ else k
+            if "." in fname:
+                out.append(fname)
+                out.extend(modules(v, _seen=seen))
+    return out
+
+
+def is_stubbed(mod: str) -> bool:
+    if not mod.startswith("scipy."):
+        return False
+
+    stubs_path = Path(__file__).parent.parent / "scipy-stubs"
+    if not stubs_path.is_dir():
+        raise FileNotFoundError(stubs_path)
+
+    _, *submods = mod.split(".")
+    if not submods:
+        return (stubs_path / "__init__.pyi").is_file()
+
+    *subpackages, submod = submods
+    subpackage_path = stubs_path.joinpath(*subpackages)
+    return (subpackage_path / f"{submod}.pyi").is_file() or (subpackage_path / submod / "__init__.pyi").is_file()
+
+
+if __name__ == "__main__":
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        warnings.simplefilter("ignore", FutureWarning)
+        module_list = modules(scipy)
+
+    module_list.sort()
+    for name in module_list:
+        if not any(map(name.startswith, BUNDLED)) and not is_stubbed(name):
+            print(name)


### PR DESCRIPTION
current output:

```
scipy._cyutility
scipy._lib._array_api
scipy._lib._array_api_compat_vendor
scipy._lib._ccallback_c
scipy.cluster._hierarchy
scipy.cluster._optimal_leaf_ordering
scipy.cluster._vq
scipy.integrate._dop
scipy.integrate._lsoda
scipy.integrate._odepack
scipy.integrate._quadpack
scipy.integrate._rules
scipy.integrate._rules._base
scipy.integrate._rules._gauss_kronrod
scipy.integrate._rules._gauss_legendre
scipy.integrate._rules._genz_malik
scipy.integrate._vode
scipy.interpolate._dierckx
scipy.interpolate._fitpack
scipy.interpolate._ppoly
scipy.interpolate._rgi_cython
scipy.io.matlab._mio5_utils
scipy.io.matlab._mio_utils
scipy.io.matlab._streams
scipy.linalg._linalg_pythran
scipy.linalg._matfuncs_schur_sqrtm
scipy.ndimage._nd_image
scipy.ndimage._ni_docstrings
scipy.ndimage._ni_label
scipy.ndimage._ni_support
scipy.ndimage._rank_filter_1d
scipy.optimize._bglu_dense
scipy.optimize._direct
scipy.optimize._highspy
scipy.optimize._highspy._core
scipy.optimize._highspy._highs_options
scipy.optimize._highspy._highs_wrapper
scipy.optimize._lbfgsb
scipy.optimize._minpack
scipy.optimize._moduleTNC
scipy.optimize._pava_pybind
scipy.optimize._remove_redundancy
scipy.optimize._zeros
scipy.signal._polyutils
scipy.signal._sigtools
scipy.signal._sosfilt
scipy.signal._upfirdn_apply
scipy.sparse._csparsetools
scipy.sparse._sparsetools
scipy.sparse.linalg._dsolve._add_newdocs
scipy.sparse.linalg._eigen.arpack._arpack
scipy.sparse.linalg._propack
scipy.sparse.linalg._propack._cpropack
scipy.sparse.linalg._propack._dpropack
scipy.sparse.linalg._propack._spropack
scipy.sparse.linalg._propack._zpropack
scipy.sparse.linalg._svdp
scipy.spatial._distance_pybind
scipy.spatial._distance_wrap
scipy.spatial._hausdorff
scipy.spatial.transform._rotation_groups
scipy.special._comb
scipy.special._ellip_harm_2
scipy.special._gufuncs
scipy.special._input_validation
scipy.special._specfun
scipy.special._special_ufuncs
scipy.special._ufuncs_cxx
scipy.stats._ansari_swilk_statistics
scipy.stats._constants
scipy.stats._finite_differences
scipy.stats._qmvnt_cy
scipy.stats._stats
```