### PR TITLE
🏷️ `_lib`: stub `_ccallback_c` and `_array_api[_compat_vendor]`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ lint = [
 type = [
   { include-group = "extras" },
   { include-group = "ci" },
+  "array-api-compat==1.12.0", # bundled as `scipy._lib.array_api_compat`
   "basedpyright>=1.29.5",
   "mypy>=1.16.1",
   "orjson>=3.10.18; python_version<'3.14'", # used by mypy

--- a/scipy-stubs/_lib/_array_api.pyi
+++ b/scipy-stubs/_lib/_array_api.pyi
@@ -1,0 +1,153 @@
+import dataclasses
+import re
+from _typeshed import Incomplete
+from collections.abc import Generator, Sequence
+from contextlib import contextmanager
+from types import ModuleType
+from typing import Any, Final, Literal, TypeAlias
+
+from array_api_compat import (
+    device as xp_device,  # pyright: ignore[reportUnknownVariableType]
+    is_array_api_strict_namespace as is_array_api_strict,
+    is_cupy_namespace as is_cupy,
+    is_jax_namespace as is_jax,
+    is_lazy_array as is_lazy_array,
+    is_numpy_namespace as is_numpy,
+    is_torch_namespace as is_torch,
+    size as xp_size,
+)
+
+__all__ = [
+    "SCIPY_ARRAY_API",
+    "SCIPY_DEVICE",
+    "_asarray",
+    "array_namespace",
+    "assert_almost_equal",
+    "assert_array_almost_equal",
+    "default_xp",
+    "eager_warns",
+    "is_array_api_strict",
+    "is_complex",
+    "is_cupy",
+    "is_jax",
+    "is_lazy_array",
+    "is_marray",
+    "is_numpy",
+    "is_torch",
+    "scipy_namespace_for",
+    "xp_assert_close",
+    "xp_assert_equal",
+    "xp_assert_less",
+    "xp_capabilities",
+    "xp_copy",
+    "xp_device",
+    "xp_promote",
+    "xp_ravel",
+    "xp_result_type",
+    "xp_size",
+    "xp_unsupported_param_msg",
+    "xp_vector_norm",
+]
+
+SCIPY_ARRAY_API: Final[str | Literal[False]] = ...
+SCIPY_DEVICE: Final[str] = ...
+
+Array: TypeAlias = Incomplete
+
+def array_namespace(*arrays: Array) -> ModuleType: ...
+def _asarray(
+    array: Any,
+    dtype: Any = None,
+    order: Literal["K", "A", "C", "F"] | None = None,
+    copy: bool | None = None,
+    *,
+    xp: ModuleType | None = None,
+    check_finite: bool = False,
+    subok: bool = False,
+) -> Array: ...
+def xp_copy(x: Array, *, xp: ModuleType | None = None) -> Array: ...
+@contextmanager
+def default_xp(xp: ModuleType) -> Generator[None]: ...
+def eager_warns(
+    x: Array, warning_type: type[Warning] | tuple[type[Warning], ...], match: str | re.Pattern[str] | None = None
+) -> Incomplete: ...  # _pytest.recwarn.WarningsChecker
+def xp_assert_equal(
+    actual: Incomplete,
+    desired: Incomplete,
+    *,
+    check_namespace: bool = True,
+    check_dtype: bool = True,
+    check_shape: bool = True,
+    check_0d: bool = True,
+    err_msg: str = "",
+    xp: ModuleType | None = None,
+) -> None: ...
+def xp_assert_close(
+    actual: Incomplete,
+    desired: Incomplete,
+    *,
+    rtol: Incomplete | None = None,
+    atol: int = 0,
+    check_namespace: bool = True,
+    check_dtype: bool = True,
+    check_shape: bool = True,
+    check_0d: bool = True,
+    err_msg: str = "",
+    xp: ModuleType | None = None,
+) -> None: ...
+def xp_assert_less(
+    actual: Incomplete,
+    desired: Incomplete,
+    *,
+    check_namespace: bool = True,
+    check_dtype: bool = True,
+    check_shape: bool = True,
+    check_0d: bool = True,
+    err_msg: str = "",
+    verbose: bool = True,
+    xp: ModuleType | None = None,
+) -> None: ...
+def assert_array_almost_equal(
+    actual: Incomplete, desired: Incomplete, decimal: int = 6, *args: Incomplete, **kwds: Incomplete
+) -> None: ...
+def assert_almost_equal(
+    actual: Incomplete, desired: Incomplete, decimal: int = 7, *args: Incomplete, **kwds: Incomplete
+) -> None: ...
+def xp_unsupported_param_msg(param: Incomplete) -> str: ...
+def is_complex(x: Array, xp: ModuleType) -> bool: ...
+def scipy_namespace_for(xp: ModuleType) -> ModuleType | None: ...
+def xp_vector_norm(
+    x: Array,
+    /,
+    *,
+    axis: int | tuple[int, ...] | None = None,
+    keepdims: bool = False,
+    ord: float = 2,
+    xp: ModuleType | None = None,
+) -> Array: ...
+def xp_ravel(x: Array, /, *, xp: ModuleType | None = None) -> Array: ...
+def xp_result_type(*args: Incomplete, force_floating: bool = False, xp: ModuleType) -> type: ...
+def xp_promote(*args: Incomplete, broadcast: bool = False, force_floating: bool = False, xp: ModuleType | None) -> Array: ...
+def is_marray(xp: ModuleType) -> bool: ...
+
+@dataclasses.dataclass(repr=False)
+class _XPSphinxCapability:
+    cpu: bool | None
+    gpu: bool | None
+    warnings: list[str] = ...
+
+    def _render(self, /, value: object) -> str: ...
+
+def xp_capabilities(
+    *,
+    capabilities_table: Incomplete | None = None,
+    skip_backends: Sequence[tuple[str, str]] = (),
+    xfail_backends: Sequence[tuple[str, str]] = (),
+    cpu_only: bool = False,
+    np_only: bool = False,
+    reason: str | None = None,
+    exceptions: Sequence[str] = (),
+    warnings: Sequence[tuple[str, str]] = (),
+    allow_dask_compute: bool = False,
+    jax_jit: bool = True,
+) -> dict[str, _XPSphinxCapability]: ...

--- a/scipy-stubs/_lib/_array_api_compat_vendor.pyi
+++ b/scipy-stubs/_lib/_array_api_compat_vendor.pyi
@@ -1,0 +1,29 @@
+from array_api_compat import (
+    common as common,
+    device as device,  # pyright: ignore[reportUnknownVariableType]
+    get_namespace as get_namespace,
+    is_array_api_obj as is_array_api_obj,  # pyright: ignore[reportUnknownVariableType]
+    is_array_api_strict_namespace as is_array_api_strict_namespace,
+    is_cupy_array as is_cupy_array,
+    is_cupy_namespace as is_cupy_namespace,
+    is_dask_array as is_dask_array,  # pyright: ignore[reportUnknownVariableType]
+    is_dask_namespace as is_dask_namespace,
+    is_jax_array as is_jax_array,  # pyright: ignore[reportUnknownVariableType]
+    is_jax_namespace as is_jax_namespace,
+    is_lazy_array as is_lazy_array,
+    is_ndonnx_array as is_ndonnx_array,  # pyright: ignore[reportUnknownVariableType]
+    is_ndonnx_namespace as is_ndonnx_namespace,
+    is_numpy_array as is_numpy_array,
+    is_numpy_namespace as is_numpy_namespace,
+    is_pydata_sparse_array as is_pydata_sparse_array,  # pyright: ignore[reportUnknownVariableType]
+    is_pydata_sparse_namespace as is_pydata_sparse_namespace,
+    is_torch_array as is_torch_array,  # pyright: ignore[reportUnknownVariableType]
+    is_torch_namespace as is_torch_namespace,
+    is_writeable_array as is_writeable_array,
+    size as size,
+    to_device as to_device,
+)
+
+from ._array_api import array_namespace as scipy_array_namespace
+
+array_namespace = scipy_array_namespace

--- a/scipy-stubs/_lib/_ccallback_c.pyi
+++ b/scipy-stubs/_lib/_ccallback_c.pyi
@@ -1,0 +1,28 @@
+from collections.abc import Callable
+from types import CapsuleType
+from typing import Any, Final, ReadOnly, SupportsFloat, TypeIs, TypedDict, type_check_only
+
+@type_check_only
+class _CApiDict(TypedDict):
+    plus1_cython: ReadOnly[CapsuleType]
+    plus1b_cython: ReadOnly[CapsuleType]
+    plus1bc_cython: ReadOnly[CapsuleType]
+    sine: ReadOnly[CapsuleType]
+
+###
+
+__pyx_capi__: Final[_CApiDict] = ...  # undocumented
+__test__: Final[dict[Any, Any]] = ...  # undocumented
+
+def check_capsule(item: object) -> TypeIs[CapsuleType]: ...  # undocumented
+def get_capsule_signature(capsule_obj: CapsuleType) -> str: ...  # undocumented
+def get_raw_capsule(
+    func_obj: CapsuleType | int, name_obj: str, context_obj: CapsuleType | int
+) -> CapsuleType: ...  # undocumented
+
+# namespace pollution
+idx: int = 1  # undocumented
+sig: tuple[bytes, int] = ...  # undocumented
+sigs: list[tuple[bytes, int]] = ...  # undocumented
+
+def test_call_cython(callback_obj: Callable[[float], SupportsFloat], value: float) -> float: ...  # undocumented

--- a/scipy-stubs/_lib/_ccallback_c.pyi
+++ b/scipy-stubs/_lib/_ccallback_c.pyi
@@ -1,6 +1,6 @@
 from collections.abc import Callable
-from types import CapsuleType
-from typing import Any, Final, ReadOnly, SupportsFloat, TypeIs, TypedDict, type_check_only
+from typing import Any, Final, SupportsFloat, TypedDict, type_check_only
+from typing_extensions import CapsuleType, ReadOnly, TypeIs
 
 @type_check_only
 class _CApiDict(TypedDict):

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,15 @@ revision = 2
 requires-python = ">=3.11"
 
 [[package]]
+name = "array-api-compat"
+version = "1.12.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/bd/9fa5c7c5621698d5632cc852a79fbbdc28024462c9396698e5fdcb395f37/array_api_compat-1.12.0.tar.gz", hash = "sha256:585bc615f650de53ac24b7c012baecfcdd810f50df3573be47e6dd9fa20df974", size = 99883, upload-time = "2025-05-16T08:49:59.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/b1/0542e0cab6f49f151a2d7a42400f84f706fc0b64e85dc1f56708b2e9fd37/array_api_compat-1.12.0-py3-none-any.whl", hash = "sha256:a0b4795b6944a9507fde54679f9350e2ad2b1e2acf4a2408a098cdc27f890a8b", size = 58156, upload-time = "2025-05-16T08:49:58.129Z" },
+]
+
+[[package]]
 name = "basedpyright"
 version = "1.29.5"
 source = { registry = "https://pypi.org/simple" }
@@ -447,6 +456,7 @@ ci = [
     { name = "packaging" },
 ]
 dev = [
+    { name = "array-api-compat" },
     { name = "basedpyright" },
     { name = "dprint-py" },
     { name = "mypy" },
@@ -466,6 +476,7 @@ lint = [
     { name = "sp-repo-review", extra = ["cli"] },
 ]
 type = [
+    { name = "array-api-compat" },
     { name = "basedpyright" },
     { name = "mypy" },
     { name = "orjson", marker = "python_full_version < '3.14'" },
@@ -483,6 +494,7 @@ provides-extras = ["scipy"]
 [package.metadata.requires-dev]
 ci = [{ name = "packaging", specifier = ">=25.0" }]
 dev = [
+    { name = "array-api-compat", specifier = "==1.12.0" },
     { name = "basedpyright", specifier = ">=1.29.5" },
     { name = "dprint-py", specifier = ">=0.50.0.0" },
     { name = "mypy", specifier = ">=1.16.1" },
@@ -500,6 +512,7 @@ lint = [
     { name = "sp-repo-review", extras = ["cli"], specifier = ">=2025.5.2" },
 ]
 type = [
+    { name = "array-api-compat", specifier = "==1.12.0" },
     { name = "basedpyright", specifier = ">=1.29.5" },
     { name = "mypy", specifier = ">=1.16.1" },
     { name = "orjson", marker = "python_full_version < '3.14'", specifier = ">=3.10.18" },


### PR DESCRIPTION
Stubtest missed these private C/Cython modules for some reason.