### PR TITLE
🏷️ `stats`: stub the remaining private modules

### DIFF
--- a/scipy-stubs/stats/_ansari_swilk_statistics.pyi
+++ b/scipy-stubs/stats/_ansari_swilk_statistics.pyi
@@ -1,0 +1,9 @@
+# defined in scipy/stats/_ansari_swilk_statistics.pyx
+
+import numpy as np
+import optype.numpy as onp
+
+def gscale(test: int, other: int) -> tuple[int, onp.Array1D[np.float32], int]: ...  # undocumented
+def swilk(
+    x: onp.Array1D[np.float64], a: onp.Array1D[np.float64], init: bool = False, n1: int = -1
+) -> tuple[float, float, int]: ...  # undocumented

--- a/scipy-stubs/stats/_constants.pyi
+++ b/scipy-stubs/stats/_constants.pyi
@@ -1,0 +1,16 @@
+from typing import Final
+
+import numpy as np
+
+_EPS: Final[np.float64] = ...  # undocumented
+_XMAX: Final[np.float64] = ...  # undocumented
+_LOGXMAX: Final[np.float64] = ...  # undocumented
+_XMIN: Final[np.float64] = ...  # undocumented
+_LOGXMIN: Final[np.float64] = ...  # undocumented
+
+_EULER: Final[float] = 0.577215664901532860606512090082402431042  # undocumented
+_ZETA3: Final[float] = 1.202056903159594285399738161511449990765  # undocumented
+_SQRT_PI: Final[float] = 1.772453850905516027298167483341145182798  # undocumented
+_SQRT_2_OVER_PI: Final[float] = 0.7978845608028654  # undocumented
+_LOG_PI: Final[float] = 1.1447298858494002  # undocumented
+_LOG_SQRT_2_OVER_PI: Final[float] = -0.22579135264472744  # undocumented

--- a/scipy-stubs/stats/_finite_differences.pyi
+++ b/scipy-stubs/stats/_finite_differences.pyi
@@ -1,0 +1,22 @@
+from collections.abc import Callable
+from typing import overload
+from typing_extensions import TypeVarTuple
+
+import numpy as np
+import optype.numpy as onp
+
+_Ts = TypeVarTuple("_Ts")
+
+###
+
+def _central_diff_weights(Np: int, ndiv: int = 1) -> onp.Array1D[np.float64]: ...  # undocumented
+
+#
+@overload
+def _derivative(
+    func: Callable[[float], onp.ToFloat], x0: float, dx: float = 1.0, n: int = 1, args: tuple[()] = ..., order: int = 3
+) -> np.float64: ...
+@overload
+def _derivative(
+    func: Callable[[float, *_Ts], onp.ToFloat], x0: float, dx: float = 1.0, n: int = 1, *, args: tuple[*_Ts], order: int = 3
+) -> np.float64: ...  # undocumented

--- a/scipy-stubs/stats/_qmvnt_cy.pyi
+++ b/scipy-stubs/stats/_qmvnt_cy.pyi
@@ -1,0 +1,30 @@
+# defined in scipy/stats/_qmvnt_cy.pyx
+
+from typing import Final
+
+import numpy as np
+import optype.numpy as onp
+
+###
+
+gammaincinv: Final[np.ufunc] = ...  # implicit re-export from `scipy.special`, required by stubtest
+
+def _qmvn_inner(
+    q: onp.Array1D[np.float64],
+    rndm: onp.Array2D[np.float64],
+    n_qmc_samples: int,
+    n_batches: int,
+    cho: onp.Array2D[np.float64],
+    lo: onp.Array1D[np.float64],
+    hi: onp.Array1D[np.float64],
+) -> tuple[float, np.float64, int]: ...  # undocumented
+def _qmvt_inner(
+    q: onp.Array1D[np.float64],
+    rndm: onp.Array2D[np.float64],
+    n_qmc_samples: int,
+    n_batches: int,
+    cho: onp.Array2D[np.float64],
+    lo: onp.Array1D[np.float64],
+    hi: onp.Array1D[np.float64],
+    nu: float,
+) -> tuple[float, np.float64, int]: ...  # undocumented

--- a/scipy-stubs/stats/_stats.pyi
+++ b/scipy-stubs/stats/_stats.pyi
@@ -1,0 +1,154 @@
+# defined in scipy/stats/_stats.pyx
+
+from collections.abc import Callable
+from typing import Final, Literal, TypeAlias, TypedDict, overload, type_check_only
+from typing_extensions import CapsuleType, ReadOnly
+
+import numpy as np
+import optype.numpy as onp
+import optype.numpy.compat as npc
+
+###
+
+# matches the `ctypedef fused ordered`
+_Ordered: TypeAlias = np.int32 | np.int64 | np.float32 | np.float64
+
+# matches the `ctypedef fused real`
+_Real: TypeAlias = np.float32 | np.float64 | np.longdouble
+
+# castable to `_Real`
+_AsReal: TypeAlias = npc.floating | npc.integer | np.bool_
+
+# castable to a real distance matrix
+_Dist2D: TypeAlias = onp.Array2D[_AsReal]
+
+# the (presumed) type of the `global_corr` parameters
+_GlobalCorr: TypeAlias = Literal["mgc", "mantel", "biased", "rank"]
+
+###
+
+@type_check_only
+class _CApiDict(TypedDict):
+    _geninvgauss_pdf: ReadOnly[CapsuleType]
+    _studentized_range_cdf: ReadOnly[CapsuleType]
+    _studentized_range_cdf_asymptotic: ReadOnly[CapsuleType]
+    _studentized_range_pdf: ReadOnly[CapsuleType]
+    _studentized_range_pdf_asymptotic: ReadOnly[CapsuleType]
+    _studentized_range_moment: ReadOnly[CapsuleType]
+    _genhyperbolic_pdf: ReadOnly[CapsuleType]
+    _genhyperbolic_logpdf: ReadOnly[CapsuleType]
+
+###
+
+__pyx_capi__: Final[_CApiDict] = ...  # undocumented
+
+def von_mises_cdf(k_obj: onp.ToFloatND, x_obj: onp.ToFloatND) -> onp.ArrayND[np.float64]: ...  # undocumented
+def _kendall_dis(x: onp.Array1D[np.intp], y: onp.Array1D[np.intp]) -> int: ...  # undocumented
+def _toint64(x: onp.ToIntND) -> onp.Array1D[np.int64]: ...  # undocumented
+def _weightedrankedtau(
+    x: onp.Array1D[_Ordered],
+    y: onp.Array1D[_Ordered],
+    rank: onp.Array1D[np.intp],
+    weigher: Callable[[float], onp.ToFloat],
+    additive: bool,
+) -> np.float64: ...  # undocumented
+def _rank_distance_matrix(distx: onp.Array2D[npc.floating | npc.integer]) -> onp.Array2D[np.intp]: ...  # undocumented
+
+#
+@overload
+def _center_distance_matrix(
+    distx: _Dist2D, global_corr: _GlobalCorr = "mgc", is_ranked: onp.ToTrue = True
+) -> tuple[onp.Array2D[np.float64], onp.Array2D[np.intp]]: ...
+@overload
+def _center_distance_matrix(
+    distx: _Dist2D, global_corr: _GlobalCorr, is_ranked: onp.ToFalse
+) -> tuple[onp.Array2D[np.float64], onp.Array1D[np.float64]]: ...
+@overload
+def _center_distance_matrix(
+    distx: _Dist2D, global_corr: _GlobalCorr = "mgc", *, is_ranked: onp.ToFalse
+) -> tuple[onp.Array2D[np.float64], onp.Array1D[np.float64]]: ...  # undocumented
+
+#
+@overload
+def _transform_distance_matrix(
+    distx: _Dist2D, disty: _Dist2D, global_corr: _GlobalCorr = "mgc", is_ranked: onp.ToTrue = True
+) -> dict[str, onp.Array2D[np.float64] | onp.Array2D[np.intp]]: ...
+@overload
+def _transform_distance_matrix(
+    distx: _Dist2D, disty: _Dist2D, global_corr: _GlobalCorr, is_ranked: onp.ToFalse
+) -> dict[str, onp.Array2D[np.float64] | onp.Array1D[np.float64]]: ...
+@overload
+def _transform_distance_matrix(
+    distx: _Dist2D, disty: _Dist2D, global_corr: _GlobalCorr = "mgc", *, is_ranked: onp.ToFalse
+) -> dict[str, onp.Array2D[np.float64] | onp.Array1D[np.float64]]: ...  # undocumented
+
+#
+def _local_covariance(
+    distx: _Dist2D, disty: _Dist2D, rank_distx: onp.ArrayND[_AsReal], rank_disty: onp.ArrayND[_AsReal]
+) -> onp.Array2D[np.float64]: ...  # undocumented
+def _local_correlations(
+    distx: _Dist2D, disty: _Dist2D, global_corr: _GlobalCorr = "mgc"
+) -> onp.Array2D[np.float64]: ...  # undocumented
+def geninvgauss_logpdf(x: float, p: float, b: float) -> float: ...  # undocumented
+def _studentized_range_cdf_logconst(k: float, df: float) -> float: ...  # undocumented
+def _studentized_range_pdf_logconst(k: float, df: float) -> float: ...  # undocumented
+def genhyperbolic_pdf(x: float, p: float, a: float, b: float) -> float: ...  # undocumented
+def genhyperbolic_logpdf(x: float, p: float, a: float, b: float) -> float: ...  # undocumented
+
+# keep in sync with `gaussian_kernel_estimate_log`
+@overload
+def gaussian_kernel_estimate(  # type: ignore[overload-overlap]
+    points: onp.Array2D[_AsReal],
+    values: onp.Array2D[_Real],
+    xi: onp.Array2D[_AsReal],
+    cho_cov: onp.Array2D[_AsReal],
+    dtype: onp.AnyFloat32DType,
+    _: _Real | float = 0.0,
+) -> onp.Array2D[np.float32]: ...
+@overload
+def gaussian_kernel_estimate(
+    points: onp.Array2D[_AsReal],
+    values: onp.Array2D[_Real],
+    xi: onp.Array2D[_AsReal],
+    cho_cov: onp.Array2D[_AsReal],
+    dtype: onp.AnyFloat64DType,
+    _: _Real | float = 0.0,
+) -> onp.Array2D[np.float64]: ...
+@overload
+def gaussian_kernel_estimate(
+    points: onp.Array2D[_AsReal],
+    values: onp.Array2D[_Real],
+    xi: onp.Array2D[_AsReal],
+    cho_cov: onp.Array2D[_AsReal],
+    dtype: onp.AnyLongDoubleDType,
+    _: _Real | float = 0.0,
+) -> onp.Array2D[np.longdouble]: ...  # undocumented
+
+# keep in sync with `gaussian_kernel_estimate`
+@overload
+def gaussian_kernel_estimate_log(  # type: ignore[overload-overlap]
+    points: onp.Array2D[_AsReal],
+    values: onp.Array2D[_Real],
+    xi: onp.Array2D[_AsReal],
+    cho_cov: onp.Array2D[_AsReal],
+    dtype: onp.AnyFloat32DType,
+    _: _Real | float = 0.0,
+) -> onp.Array2D[np.float32]: ...
+@overload
+def gaussian_kernel_estimate_log(
+    points: onp.Array2D[_AsReal],
+    values: onp.Array2D[_Real],
+    xi: onp.Array2D[_AsReal],
+    cho_cov: onp.Array2D[_AsReal],
+    dtype: onp.AnyFloat64DType,
+    _: _Real | float = 0.0,
+) -> onp.Array2D[np.float64]: ...
+@overload
+def gaussian_kernel_estimate_log(
+    points: onp.Array2D[_AsReal],
+    values: onp.Array2D[_Real],
+    xi: onp.Array2D[_AsReal],
+    cho_cov: onp.Array2D[_AsReal],
+    dtype: onp.AnyLongDoubleDType,
+    _: _Real | float = 0.0,
+) -> onp.Array2D[np.longdouble]: ...  # undocumented


### PR DESCRIPTION
And with this, all private scipy submodules are stubbed (according to `scripts/unstubbed_modules.py`).