### PR TITLE
♻️ explicit `onp.AnyFloat64DType | None`

### DIFF
--- a/scipy-stubs/ndimage/_measurements.pyi
+++ b/scipy-stubs/ndimage/_measurements.pyi
@@ -88,7 +88,7 @@ def labeled_comprehension(
     labels: onp.ToComplex | onp.ToComplexND | None,
     index: onp.ToInt | onp.ToIntND | None,
     func: _ComprehensionFunc,
-    out_dtype: onp.AnyFloat64DType,
+    out_dtype: onp.AnyFloat64DType | None,
     default: onp.ToFloat,
     pass_positions: bool = False,
 ) -> onp.ArrayND[np.float64]: ...

--- a/scipy-stubs/stats/_stats.pyi
+++ b/scipy-stubs/stats/_stats.pyi
@@ -111,7 +111,7 @@ def gaussian_kernel_estimate(
     values: onp.Array2D[_Real],
     xi: onp.Array2D[_AsReal],
     cho_cov: onp.Array2D[_AsReal],
-    dtype: onp.AnyFloat64DType,
+    dtype: onp.AnyFloat64DType | None,
     _: _Real | float = 0.0,
 ) -> onp.Array2D[np.float64]: ...
 @overload
@@ -140,7 +140,7 @@ def gaussian_kernel_estimate_log(
     values: onp.Array2D[_Real],
     xi: onp.Array2D[_AsReal],
     cho_cov: onp.Array2D[_AsReal],
-    dtype: onp.AnyFloat64DType,
+    dtype: onp.AnyFloat64DType | None,
     _: _Real | float = 0.0,
 ) -> onp.Array2D[np.float64]: ...
 @overload


### PR DESCRIPTION
In preparation for optype 0.11 (hype).

The vast majority of `onp.AnyFloat64DType` uses already included an explcit `| None` where appropriate. In some cases (such as `sparse.linalg.LinearOperator`), there is no `| None`, because we're basically pretending it doesn't exist. When optype 0.11 will be released, we'll no longer have to pretend :).

ref: https://github.com/scipy/scipy-stubs/pull/733#issuecomment-3052821614

cc @JulVandenBroeck