### PR TITLE
✨ `ndimage`: improved `fourier_*` annotations

### DIFF
--- a/scipy-stubs/ndimage/_fourier.pyi
+++ b/scipy-stubs/ndimage/_fourier.pyi
@@ -1,81 +1,202 @@
-from typing import TypeVar, overload
+from typing import Any, SupportsFloat as CanFloat, SupportsIndex as CanIndex, TypeAlias, TypeVar, overload
 
 import numpy as np
 import optype.numpy as onp
 
 __all__ = ["fourier_ellipsoid", "fourier_gaussian", "fourier_shift", "fourier_uniform"]
 
-_FloatArrayOutT = TypeVar("_FloatArrayOutT", bound=onp.ArrayND[np.float64 | np.float32])
-_ComplexArrayOutT = TypeVar("_ComplexArrayOutT", bound=onp.ArrayND[np.complex128 | np.float64 | np.complex64 | np.float32])
+###
 
-#
-@overload
+_ScalarComplex: TypeAlias = np.complex64 | np.complex128
+_OutputScalarComplexT = TypeVar("_OutputScalarComplexT", bound=_ScalarComplex)
+_OutputArrayComplexT = TypeVar("_OutputArrayComplexT", bound=onp.ArrayND[_ScalarComplex])
+
+_Scalar: TypeAlias = np.float32 | np.float64 | _ScalarComplex
+_OutputScalarT = TypeVar("_OutputScalarT", bound=_Scalar)
+_OutputArrayT = TypeVar("_OutputArrayT", bound=onp.ArrayND[_Scalar])
+
+_Sigma: TypeAlias = CanFloat | onp.ToFloat1D
+_AsF32: TypeAlias = np.float16 | np.float32
+_InputF64: TypeAlias = onp.ToJustFloat64_ND | onp.ToIntND
+_InputC128: TypeAlias = onp.ToJustComplex128_ND  # pro forma
+# these *should* be equivalent to `onp.ArrayND[Never, {}]`, but both mypy and pyright currently have bugs with `Never` unions
+_InputF32: TypeAlias = onp.CanArrayND[_AsF32] | onp.SequenceND[onp.CanArray[Any, np.dtype[_AsF32]]]
+_InputC64: TypeAlias = onp.CanArrayND[np.complex64] | onp.SequenceND[onp.CanArray[Any, np.dtype[np.complex64]]]
+
+###
+# NOTE: The gaussian, uniform, and ellipsoid function signatures are equivalent (except for the 2nd *name*): Keep them in sync!
+# NOTE: The [overload-overlap] mypy errors are false positives (probably a union/join thing).
+
+# undocumented
+@overload  # output: <T: ndarray>
+def _get_output_fourier(output: _OutputArrayT, input: onp.ToComplex128_ND) -> _OutputArrayT: ...
+@overload  # output: <T: scalar type>
+def _get_output_fourier(output: type[_OutputScalarT], input: onp.ToComplex128_ND) -> onp.ArrayND[_OutputScalarT]: ...
+@overload  # +float32
+def _get_output_fourier(output: None, input: _InputF32) -> onp.ArrayND[np.float32]: ...  # type: ignore[overload-overlap]
+@overload  # +float64
+def _get_output_fourier(output: None, input: _InputF64) -> onp.ArrayND[np.float64]: ...
+@overload  # ~complex64
+def _get_output_fourier(output: None, input: _InputC64) -> onp.ArrayND[np.complex64]: ...  # type: ignore[overload-overlap]
+@overload  # ~complex128
+def _get_output_fourier(output: None, input: _InputC128) -> onp.ArrayND[np.complex128]: ...
+@overload  # fallback
+def _get_output_fourier(output: None, input: onp.ToComplex128_ND) -> onp.ArrayND[_Scalar]: ...
+
+# undocumented
+@overload  # output: complex64 array or scalar-type
+def _get_output_fourier_complex(  # type: ignore[overload-overlap]
+    output: onp.ArrayND[np.complex64] | type[np.complex64], input: onp.ToComplex128_ND
+) -> onp.ArrayND[np.complex64]: ...
+@overload  # output: complex128 array or scalar-type
+def _get_output_fourier_complex(
+    output: onp.ArrayND[np.complex128] | type[np.complex128], input: onp.ToComplex128_ND
+) -> onp.ArrayND[np.complex128]: ...
+@overload  # ~complex64
+def _get_output_fourier_complex(output: None, input: _InputC64) -> onp.ArrayND[np.complex64]: ...  # type: ignore[overload-overlap]
+@overload  # ~complex128 | +floating
+def _get_output_fourier_complex(output: None, input: _InputC128 | onp.ToFloat64_ND) -> onp.ArrayND[np.complex128]: ...
+@overload  # fallback
+def _get_output_fourier_complex(output: None, input: onp.ToComplex128_ND) -> onp.ArrayND[_ScalarComplex]: ...
+
+# NOTE: Keep in sync with `fourier_uniform` and `fourier_ellipsoid` (but note the different 2nd parameter names)
+@overload  # output: <T: ndarray> (positional)
 def fourier_gaussian(
-    input: _FloatArrayOutT | onp.ToFloat | onp.ToFloatND,
-    sigma: onp.ToFloat | onp.ToFloatND,
-    n: onp.ToInt = -1,
-    axis: onp.ToInt = -1,
-    output: _FloatArrayOutT | None = None,
-) -> _FloatArrayOutT: ...
-@overload
+    input: onp.ToComplex128_ND, sigma: _Sigma, n: CanIndex, axis: int, output: _OutputArrayT
+) -> _OutputArrayT: ...
+@overload  # output: <T: ndarray> (keyword)
 def fourier_gaussian(
-    input: _ComplexArrayOutT | onp.ToComplex | onp.ToComplexND,
-    sigma: onp.ToFloat | onp.ToFloatND,
-    n: onp.ToInt = -1,
-    axis: onp.ToInt = -1,
-    output: _ComplexArrayOutT | None = None,
-) -> _ComplexArrayOutT: ...
+    input: onp.ToComplex128_ND, sigma: _Sigma, n: CanIndex = -1, axis: int = -1, *, output: _OutputArrayT
+) -> _OutputArrayT: ...
+@overload  # output: <T: scalar type> (positional)
+def fourier_gaussian(
+    input: onp.ToComplex128_ND, sigma: _Sigma, n: CanIndex, axis: int, output: type[_OutputScalarT]
+) -> onp.ArrayND[_OutputScalarT]: ...
+@overload  # output: <T: scalar type> (keyword)
+def fourier_gaussian(
+    input: onp.ToComplex128_ND, sigma: _Sigma, n: CanIndex = -1, axis: int = -1, *, output: type[_OutputScalarT]
+) -> onp.ArrayND[_OutputScalarT]: ...
+@overload  # +float32
+def fourier_gaussian(  # type: ignore[overload-overlap]
+    input: _InputF32, sigma: _Sigma, n: CanIndex = -1, axis: int = -1, output: None = None
+) -> onp.ArrayND[np.float32]: ...
+@overload  # +float64
+def fourier_gaussian(
+    input: _InputF64, sigma: _Sigma, n: CanIndex = -1, axis: int = -1, output: None = None
+) -> onp.ArrayND[np.float64]: ...
+@overload  # ~complex64
+def fourier_gaussian(  # type: ignore[overload-overlap]
+    input: _InputC64, sigma: _Sigma, n: CanIndex = -1, axis: int = -1, output: None = None
+) -> onp.ArrayND[np.complex64]: ...
+@overload  # ~complex128
+def fourier_gaussian(
+    input: _InputC128, sigma: _Sigma, n: CanIndex = -1, axis: int = -1, output: None = None
+) -> onp.ArrayND[np.complex128]: ...
+@overload  # fallback
+def fourier_gaussian(
+    input: onp.ToComplex128_ND, sigma: _Sigma, n: CanIndex = -1, axis: int = -1, output: None = None
+) -> onp.ArrayND[_Scalar]: ...
 
-#
-@overload
+# NOTE: Keep in sync with `fourier_ellipsoid` and `fourier_gaussian` (but note the different 2nd parameter name)
+@overload  # output: <T: ndarray> (positional)
+def fourier_uniform(input: onp.ToComplex128_ND, size: _Sigma, n: CanIndex, axis: int, output: _OutputArrayT) -> _OutputArrayT: ...
+@overload  # output: <T: ndarray> (keyword)
 def fourier_uniform(
-    input: _FloatArrayOutT | onp.ToFloat | onp.ToFloatND,
-    size: onp.ToFloat | onp.ToFloatND,
-    n: onp.ToInt = -1,
-    axis: onp.ToInt = -1,
-    output: _FloatArrayOutT | None = None,
-) -> _FloatArrayOutT: ...
-@overload
+    input: onp.ToComplex128_ND, size: _Sigma, n: CanIndex = -1, axis: int = -1, *, output: _OutputArrayT
+) -> _OutputArrayT: ...
+@overload  # output: <T: scalar type> (positional)
 def fourier_uniform(
-    input: _ComplexArrayOutT | onp.ToComplex | onp.ToComplexND,
-    size: onp.ToFloat | onp.ToFloatND,
-    n: onp.ToInt = -1,
-    axis: onp.ToInt = -1,
-    output: _ComplexArrayOutT | None = None,
-) -> _ComplexArrayOutT: ...
+    input: onp.ToComplex128_ND, size: _Sigma, n: CanIndex, axis: int, output: type[_OutputScalarT]
+) -> onp.ArrayND[_OutputScalarT]: ...
+@overload  # output: <T: scalar type> (keyword)
+def fourier_uniform(
+    input: onp.ToComplex128_ND, size: _Sigma, n: CanIndex = -1, axis: int = -1, *, output: type[_OutputScalarT]
+) -> onp.ArrayND[_OutputScalarT]: ...
+@overload  # +float32
+def fourier_uniform(  # type: ignore[overload-overlap]
+    input: _InputF32, size: _Sigma, n: CanIndex = -1, axis: int = -1, output: None = None
+) -> onp.ArrayND[np.float32]: ...
+@overload  # +float64
+def fourier_uniform(
+    input: _InputF64, size: _Sigma, n: CanIndex = -1, axis: int = -1, output: None = None
+) -> onp.ArrayND[np.float64]: ...
+@overload  # ~complex64
+def fourier_uniform(  # type: ignore[overload-overlap]
+    input: _InputC64, size: _Sigma, n: CanIndex = -1, axis: int = -1, output: None = None
+) -> onp.ArrayND[np.complex64]: ...
+@overload  # ~complex128
+def fourier_uniform(
+    input: _InputC128, size: _Sigma, n: CanIndex = -1, axis: int = -1, output: None = None
+) -> onp.ArrayND[np.complex128]: ...
+@overload  # fallback
+def fourier_uniform(
+    input: onp.ToComplex128_ND, size: _Sigma, n: CanIndex = -1, axis: int = -1, output: None = None
+) -> onp.ArrayND[_Scalar]: ...
 
-#
-@overload
+# NOTE: Keep in sync with `fourier_uniform` and `fourier_gaussian` (but note the different 2nd parameter name)
+@overload  # output: <T: ndarray> (positional)
 def fourier_ellipsoid(
-    input: _FloatArrayOutT | onp.ToFloat | onp.ToFloatND,
-    size: onp.ToFloat | onp.ToFloatND,
-    n: onp.ToInt = -1,
-    axis: onp.ToInt = -1,
-    output: _FloatArrayOutT | None = None,
-) -> _FloatArrayOutT: ...
-@overload
+    input: onp.ToComplex128_ND, size: _Sigma, n: CanIndex, axis: int, output: _OutputArrayT
+) -> _OutputArrayT: ...
+@overload  # output: <T: ndarray> (keyword)
 def fourier_ellipsoid(
-    input: _ComplexArrayOutT | onp.ToComplex | onp.ToComplexND,
-    size: onp.ToFloat | onp.ToFloatND,
-    n: onp.ToInt = -1,
-    axis: onp.ToInt = -1,
-    output: _ComplexArrayOutT | None = None,
-) -> _ComplexArrayOutT: ...
+    input: onp.ToComplex128_ND, size: _Sigma, n: CanIndex = -1, axis: int = -1, *, output: _OutputArrayT
+) -> _OutputArrayT: ...
+@overload  # output: <T: scalar type> (positional)
+def fourier_ellipsoid(
+    input: onp.ToComplex128_ND, size: _Sigma, n: CanIndex, axis: int, output: type[_OutputScalarT]
+) -> onp.ArrayND[_OutputScalarT]: ...
+@overload  # output: <T: scalar type> (keyword)
+def fourier_ellipsoid(
+    input: onp.ToComplex128_ND, size: _Sigma, n: CanIndex = -1, axis: int = -1, *, output: type[_OutputScalarT]
+) -> onp.ArrayND[_OutputScalarT]: ...
+@overload  # +float32
+def fourier_ellipsoid(  # type: ignore[overload-overlap]
+    input: _InputF32, size: _Sigma, n: CanIndex = -1, axis: int = -1, output: None = None
+) -> onp.ArrayND[np.float32]: ...
+@overload  # +float64
+def fourier_ellipsoid(
+    input: _InputF64, size: _Sigma, n: CanIndex = -1, axis: int = -1, output: None = None
+) -> onp.ArrayND[np.float64]: ...
+@overload  # ~complex64
+def fourier_ellipsoid(  # type: ignore[overload-overlap]
+    input: _InputC64, size: _Sigma, n: CanIndex = -1, axis: int = -1, output: None = None
+) -> onp.ArrayND[np.complex64]: ...
+@overload  # ~complex128
+def fourier_ellipsoid(
+    input: _InputC128, size: _Sigma, n: CanIndex = -1, axis: int = -1, output: None = None
+) -> onp.ArrayND[np.complex128]: ...
+@overload  # fallback
+def fourier_ellipsoid(
+    input: onp.ToComplex128_ND, size: _Sigma, n: CanIndex = -1, axis: int = -1, output: None = None
+) -> onp.ArrayND[_Scalar]: ...
 
-#
-@overload
+# NOTE: Unlike the other three functions, this always returns complex output
+@overload  # output: <T: ndarray> (positional)
 def fourier_shift(
-    input: _FloatArrayOutT | onp.ToFloat | onp.ToFloatND,
-    shift: onp.ToFloat | onp.ToFloatND,
-    n: onp.ToInt = -1,
-    axis: onp.ToInt = -1,
-    output: _FloatArrayOutT | None = None,
-) -> _FloatArrayOutT: ...
-@overload
+    input: onp.ToComplex128_ND, shift: _Sigma, n: CanIndex, axis: int, output: _OutputArrayComplexT
+) -> _OutputArrayComplexT: ...
+@overload  # output: <T: ndarray> (keyword)
 def fourier_shift(
-    input: _ComplexArrayOutT | onp.ToComplex | onp.ToComplexND,
-    shift: onp.ToFloat | onp.ToFloatND,
-    n: onp.ToInt = -1,
-    axis: onp.ToInt = -1,
-    output: _ComplexArrayOutT | None = None,
-) -> _ComplexArrayOutT: ...
+    input: onp.ToComplex128_ND, shift: _Sigma, n: CanIndex = -1, axis: int = -1, *, output: _OutputArrayComplexT
+) -> _OutputArrayComplexT: ...
+@overload  # output: <T: scalar type> (positional)
+def fourier_shift(
+    input: onp.ToComplex128_ND, shift: _Sigma, n: CanIndex, axis: int, output: type[_OutputScalarComplexT]
+) -> onp.ArrayND[_OutputScalarComplexT]: ...
+@overload  # output: <T: scalar type> (keyword)
+def fourier_shift(
+    input: onp.ToComplex128_ND, shift: _Sigma, n: CanIndex = -1, axis: int = -1, *, output: type[_OutputScalarComplexT]
+) -> onp.ArrayND[_OutputScalarComplexT]: ...
+@overload  # ~complex64
+def fourier_shift(  # type: ignore[overload-overlap]
+    input: _InputC64, shift: _Sigma, n: CanIndex = -1, axis: int = -1, output: None = None
+) -> onp.ArrayND[np.complex64]: ...
+@overload  # ~complex128 | +floating
+def fourier_shift(
+    input: _InputC128 | onp.ToFloat64_ND, shift: _Sigma, n: CanIndex = -1, axis: int = -1, output: None = None
+) -> onp.ArrayND[np.complex128]: ...
+@overload  # fallback
+def fourier_shift(
+    input: onp.ToComplex128_ND, shift: _Sigma, n: CanIndex = -1, axis: int = -1, output: None = None
+) -> onp.ArrayND[_ScalarComplex]: ...

--- a/tests/ndimage/test__fourier.pyi
+++ b/tests/ndimage/test__fourier.pyi
@@ -1,0 +1,93 @@
+# type-tests for `ndimage/_fourier.pyi`
+
+from typing import TypeAlias, assert_type
+
+import numpy as np
+import numpy.typing as npt
+import optype.numpy as onp
+
+from scipy.ndimage import fourier_gaussian, fourier_shift
+
+i8_nd: npt.NDArray[np.int8]
+f16_nd: npt.NDArray[np.float16]
+f32_nd: npt.NDArray[np.float32]
+f64_nd: npt.NDArray[np.float64]
+c64_nd: npt.NDArray[np.complex64]
+c128_nd: npt.NDArray[np.complex128]
+
+int_2d: list[list[int]]
+float_2d: list[list[float]]
+complex_2d: list[list[complex]]
+
+_OutputArray: TypeAlias = onp.Array2D[np.complex64]
+_OutputArrayND: TypeAlias = onp.ArrayND[np.complex64]
+output_array: _OutputArray
+output_sctype: type[np.complex64]
+
+###
+# `fourier_gaussian` (also `fourier_ellipsoid` and `fourier_uniform`)
+# NOTE: `fourier_uniform` and `fourier_ellipsoid` have the same signature, so no need to also test those.
+
+assert_type(fourier_gaussian(i8_nd, 4), onp.ArrayND[np.float64])
+assert_type(fourier_gaussian(f16_nd, 4), onp.ArrayND[np.float32])
+assert_type(fourier_gaussian(f32_nd, 4), onp.ArrayND[np.float32])
+assert_type(fourier_gaussian(f64_nd, 4), onp.ArrayND[np.float64])
+assert_type(fourier_gaussian(c64_nd, 4), onp.ArrayND[np.complex64])
+assert_type(fourier_gaussian(c128_nd, 4), onp.ArrayND[np.complex128])
+assert_type(fourier_gaussian(int_2d, 4), onp.ArrayND[np.float64])
+assert_type(fourier_gaussian(float_2d, 4), onp.ArrayND[np.float64])
+assert_type(fourier_gaussian(complex_2d, 4), onp.ArrayND[np.complex128])
+
+assert_type(fourier_gaussian(i8_nd, 4, output=output_array), _OutputArray)
+assert_type(fourier_gaussian(f16_nd, 4, output=output_array), _OutputArray)
+assert_type(fourier_gaussian(f32_nd, 4, output=output_array), _OutputArray)
+assert_type(fourier_gaussian(f64_nd, 4, output=output_array), _OutputArray)
+assert_type(fourier_gaussian(c64_nd, 4, output=output_array), _OutputArray)
+assert_type(fourier_gaussian(c128_nd, 4, output=output_array), _OutputArray)
+assert_type(fourier_gaussian(int_2d, 4, output=output_array), _OutputArray)
+assert_type(fourier_gaussian(float_2d, 4, output=output_array), _OutputArray)
+assert_type(fourier_gaussian(complex_2d, 4, output=output_array), _OutputArray)
+
+assert_type(fourier_gaussian(i8_nd, 4, output=output_sctype), _OutputArrayND)
+assert_type(fourier_gaussian(f16_nd, 4, output=output_sctype), _OutputArrayND)
+assert_type(fourier_gaussian(f32_nd, 4, output=output_sctype), _OutputArrayND)
+assert_type(fourier_gaussian(f64_nd, 4, output=output_sctype), _OutputArrayND)
+assert_type(fourier_gaussian(c64_nd, 4, output=output_sctype), _OutputArrayND)
+assert_type(fourier_gaussian(c128_nd, 4, output=output_sctype), _OutputArrayND)
+assert_type(fourier_gaussian(int_2d, 4, output=output_sctype), _OutputArrayND)
+assert_type(fourier_gaussian(float_2d, 4, output=output_sctype), _OutputArrayND)
+assert_type(fourier_gaussian(complex_2d, 4, output=output_sctype), _OutputArrayND)
+
+###
+# `fourier_shift`
+# NOTE: Unlike the other three functions, this always returns complex output.
+
+assert_type(fourier_shift(i8_nd, 4), onp.ArrayND[np.complex128])
+assert_type(fourier_shift(f16_nd, 4), onp.ArrayND[np.complex128])
+assert_type(fourier_shift(f32_nd, 4), onp.ArrayND[np.complex128])
+assert_type(fourier_shift(f64_nd, 4), onp.ArrayND[np.complex128])
+assert_type(fourier_shift(c64_nd, 4), onp.ArrayND[np.complex64])
+assert_type(fourier_shift(c128_nd, 4), onp.ArrayND[np.complex128])
+assert_type(fourier_shift(int_2d, 4), onp.ArrayND[np.complex128])
+assert_type(fourier_shift(float_2d, 4), onp.ArrayND[np.complex128])
+assert_type(fourier_shift(complex_2d, 4), onp.ArrayND[np.complex128])
+
+assert_type(fourier_shift(i8_nd, 4, output=output_array), _OutputArray)
+assert_type(fourier_shift(f16_nd, 4, output=output_array), _OutputArray)
+assert_type(fourier_shift(f32_nd, 4, output=output_array), _OutputArray)
+assert_type(fourier_shift(f64_nd, 4, output=output_array), _OutputArray)
+assert_type(fourier_shift(c64_nd, 4, output=output_array), _OutputArray)
+assert_type(fourier_shift(c128_nd, 4, output=output_array), _OutputArray)
+assert_type(fourier_shift(int_2d, 4, output=output_array), _OutputArray)
+assert_type(fourier_shift(float_2d, 4, output=output_array), _OutputArray)
+assert_type(fourier_shift(complex_2d, 4, output=output_array), _OutputArray)
+
+assert_type(fourier_shift(i8_nd, 4, output=output_sctype), _OutputArrayND)
+assert_type(fourier_shift(f16_nd, 4, output=output_sctype), _OutputArrayND)
+assert_type(fourier_shift(f32_nd, 4, output=output_sctype), _OutputArrayND)
+assert_type(fourier_shift(f64_nd, 4, output=output_sctype), _OutputArrayND)
+assert_type(fourier_shift(c64_nd, 4, output=output_sctype), _OutputArrayND)
+assert_type(fourier_shift(c128_nd, 4, output=output_sctype), _OutputArrayND)
+assert_type(fourier_shift(int_2d, 4, output=output_sctype), _OutputArrayND)
+assert_type(fourier_shift(float_2d, 4, output=output_sctype), _OutputArrayND)
+assert_type(fourier_shift(complex_2d, 4, output=output_sctype), _OutputArrayND)


### PR DESCRIPTION
This improves the return types of the following public `scipy.ndimage` functions:

- `fourier_gaussian`
- `fourier_uniform`
- `fourier_ellipsoid`
- `fourier_shift`