### PR TITLE
✨ `linalg`: improved basic `solve*` annotations

### DIFF
--- a/scipy-stubs/linalg/_basic.pyi
+++ b/scipy-stubs/linalg/_basic.pyi
@@ -1,7 +1,6 @@
 # mypy: disable-error-code=overload-overlap
 
-from collections.abc import Sequence
-from typing import Any, Final, Literal, TypeAlias, TypeVar, overload
+from typing import Final, Literal, TypeAlias, TypeVar, overload
 
 import numpy as np
 import optype as op
@@ -34,11 +33,11 @@ _Float1D: TypeAlias = onp.Array1D[_Float]
 _Float2D: TypeAlias = onp.Array2D[_Float]
 _FloatND: TypeAlias = onp.ArrayND[_Float]
 
-_Complex: TypeAlias = npc.inexact  # float and complex input types are near impossible to distinguish
-_Complex0D: TypeAlias = onp.Array0D[_Complex]
-_Complex1D: TypeAlias = onp.Array1D[_Complex]
-_Complex2D: TypeAlias = onp.Array2D[_Complex]
-_ComplexND: TypeAlias = onp.ArrayND[_Complex]
+_Inexact: TypeAlias = npc.inexact
+_Inexact0D: TypeAlias = onp.Array0D[_Inexact]
+_Inexact1D: TypeAlias = onp.Array1D[_Inexact]
+_Inexact2D: TypeAlias = onp.Array2D[_Inexact]
+_InexactND: TypeAlias = onp.ArrayND[_Inexact]
 
 _InputFloat: TypeAlias = onp.ToArrayND[float, np.float64 | np.longdouble | npc.integer | np.bool_]
 _InputFloatStrict1D: TypeAlias = onp.ToArrayStrict1D[float, np.float64 | np.longdouble | npc.integer | np.bool_]
@@ -48,23 +47,9 @@ _InputF64: TypeAlias = onp.ToArrayND[float, np.float64 | npc.integer | np.bool_]
 _InputF64Strict1D: TypeAlias = onp.ToArrayStrict1D[float, np.float64 | npc.integer | np.bool_]
 _InputF64Strict2D: TypeAlias = onp.ToArrayStrict2D[float, np.float64 | npc.integer | np.bool_]
 
-_AsF32: TypeAlias = np.float16 | np.float32
-_InputF32: TypeAlias = onp.CanArrayND[_AsF32] | onp.SequenceND[onp.CanArray[Any, np.dtype[_AsF32]]]
-_InputF32Strict1D: TypeAlias = onp.CanArray1D[_AsF32] | Sequence[onp.CanArray0D[_AsF32]]
-_InputF32Strict2D: TypeAlias = onp.CanArray2D[_AsF32] | Sequence[_InputF32Strict1D]
-
-_InputC64: TypeAlias = onp.CanArrayND[np.complex64] | onp.SequenceND[onp.CanArray[Any, np.dtype[np.complex64]]]
-_InputC64Strict1D: TypeAlias = onp.CanArray1D[np.complex64] | Sequence[onp.CanArray0D[np.complex64]]
-_InputC64Strict2D: TypeAlias = onp.CanArray2D[np.complex64] | Sequence[_InputC64Strict1D]
-
 _InputComplex: TypeAlias = onp.ToArrayND[op.JustComplex, np.complex128 | np.clongdouble]
 _InputComplexStrict1D: TypeAlias = onp.ToArrayStrict1D[op.JustComplex, np.complex128 | np.clongdouble]
 _InputComplexStrict2D: TypeAlias = onp.ToArrayStrict2D[op.JustComplex, np.complex128 | np.clongdouble]
-
-_CoC64: TypeAlias = np.complex64 | _AsF32 | npc.integer16 | npc.integer8 | np.bool_
-_CoInputC64: TypeAlias = onp.CanArrayND[_CoC64] | onp.SequenceND[onp.CanArray[Any, np.dtype[_CoC64]]]
-_CoInputC64Strict1D: TypeAlias = onp.CanArray1D[_CoC64] | Sequence[onp.CanArray0D[_CoC64]]
-_CoInputC64Strict2D: TypeAlias = onp.CanArray2D[_CoC64] | Sequence[_CoInputC64Strict1D]
 
 _AssumeA: TypeAlias = Literal[
     "diagonal",
@@ -85,28 +70,6 @@ _LapackDriver: TypeAlias = Literal["gelsd", "gelsy", "gelss"]
 
 lapack_cast_dict: Final[dict[str, str]] = ...
 
-@overload  # 2d ~float32, ~float32
-def solve(
-    a: _InputF32Strict2D,
-    b: _InputF32Strict1D | _InputF32Strict2D,
-    lower: bool = False,
-    overwrite_a: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-    assume_a: _AssumeA | None = None,
-    transposed: bool = False,
-) -> onp.Array2D[np.float32]: ...
-@overload  # Nd ~float32, ~float32
-def solve(
-    a: _InputF32,
-    b: _InputF32,
-    lower: bool = False,
-    overwrite_a: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-    assume_a: _AssumeA | None = None,
-    transposed: bool = False,
-) -> onp.ArrayND[np.float32]: ...
 @overload  # 2D ~float64, +float64
 def solve(
     a: _InputFloatStrict2D,
@@ -151,50 +114,6 @@ def solve(
     assume_a: _AssumeA | None = None,
     transposed: bool = False,
 ) -> onp.ArrayND[np.float64]: ...
-@overload  # 2d ~complex64, +complex64
-def solve(
-    a: _InputC64Strict2D,
-    b: _CoInputC64Strict1D | _CoInputC64Strict2D,
-    lower: bool = False,
-    overwrite_a: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-    assume_a: _AssumeA | None = None,
-    transposed: bool = False,
-) -> onp.Array2D[np.complex64]: ...
-@overload  # Nd ~complex64, +complex64
-def solve(
-    a: _InputC64,
-    b: _CoInputC64,
-    lower: bool = False,
-    overwrite_a: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-    assume_a: _AssumeA | None = None,
-    transposed: bool = False,
-) -> onp.ArrayND[np.complex64]: ...
-@overload  # 2d +complex64, ~complex64
-def solve(
-    a: _CoInputC64Strict2D,
-    b: _InputC64Strict1D | _InputC64Strict2D,
-    lower: bool = False,
-    overwrite_a: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-    assume_a: _AssumeA | None = None,
-    transposed: bool = False,
-) -> onp.Array2D[np.complex64]: ...
-@overload  # Nd +complex64, ~complex64
-def solve(
-    a: _CoInputC64,
-    b: _InputC64,
-    lower: bool = False,
-    overwrite_a: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-    assume_a: _AssumeA | None = None,
-    transposed: bool = False,
-) -> onp.ArrayND[np.complex64]: ...
 @overload  # 2d ~complex128, +complex128
 def solve(
     a: _InputComplexStrict2D,
@@ -261,28 +180,6 @@ def solve(
     assume_a: _AssumeA | None = None,
     transposed: bool = False,
 ) -> onp.ArrayND[np.float32 | np.float64]: ...
-@overload  # 2d ~complexfloating, +complexfloating
-def solve(
-    a: onp.ToJustComplexStrict2D,
-    b: onp.ToComplexStrict1D | onp.ToComplexStrict2D,
-    lower: bool = False,
-    overwrite_a: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-    assume_a: _AssumeA | None = None,
-    transposed: bool = False,
-) -> onp.Array2D[np.complex64 | np.complex128]: ...
-@overload  # Nd ~complexfloating, +complexfloating
-def solve(
-    a: onp.ToJustComplexND,
-    b: onp.ToComplexND,
-    lower: bool = False,
-    overwrite_a: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-    assume_a: _AssumeA | None = None,
-    transposed: bool = False,
-) -> onp.ArrayND[np.complex64 | np.complex128]: ...
 @overload  # 2d +complexfloating, ~complexfloating
 def solve(
     a: onp.ToComplexStrict2D,
@@ -305,17 +202,6 @@ def solve(
     assume_a: _AssumeA | None = None,
     transposed: bool = False,
 ) -> onp.ArrayND[np.complex64 | np.complex128]: ...
-@overload  # 2d +complexfloating, +complexfloating
-def solve(
-    a: onp.ToComplexStrict2D,
-    b: onp.ToComplexStrict1D | onp.ToComplexStrict2D,
-    lower: bool = False,
-    overwrite_a: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-    assume_a: _AssumeA | None = None,
-    transposed: bool = False,
-) -> onp.Array2D[np.float32 | np.float64 | np.complex64 | np.complex128]: ...
 @overload  # Nd +complexfloating, +complexfloating
 def solve(
     a: onp.ToComplexND,
@@ -329,36 +215,6 @@ def solve(
 ) -> onp.ArrayND[np.float32 | np.float64 | np.complex64 | np.complex128]: ...
 
 #
-@overload  # 1d ~float32, ~float32
-def solve_triangular(
-    a: _InputF32Strict2D,
-    b: _InputF32Strict1D,
-    trans: _TransSystem = 0,
-    lower: bool = False,
-    unit_diagonal: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-) -> onp.Array1D[np.float32]: ...
-@overload  # 2d ~float32, ~float32
-def solve_triangular(
-    a: _InputF32Strict2D,
-    b: _InputF32Strict2D,
-    trans: _TransSystem = 0,
-    lower: bool = False,
-    unit_diagonal: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-) -> onp.Array2D[np.float32]: ...
-@overload  # Nd ~float32, ~float32
-def solve_triangular(
-    a: _InputF32,
-    b: _InputF32,
-    trans: _TransSystem = 0,
-    lower: bool = False,
-    unit_diagonal: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-) -> onp.ArrayND[np.float32]: ...
 @overload  # 1D ~float64, +float64
 def solve_triangular(
     a: _InputFloatStrict2D,
@@ -419,66 +275,6 @@ def solve_triangular(
     overwrite_b: bool = False,
     check_finite: bool = True,
 ) -> onp.ArrayND[np.float64]: ...
-@overload  # 1d ~complex64, +complex64
-def solve_triangular(
-    a: _InputC64Strict2D,
-    b: _CoInputC64Strict1D,
-    trans: _TransSystem = 0,
-    lower: bool = False,
-    unit_diagonal: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-) -> onp.Array1D[np.complex64]: ...
-@overload  # 2d ~complex64, +complex64
-def solve_triangular(
-    a: _InputC64Strict2D,
-    b: _CoInputC64Strict2D,
-    trans: _TransSystem = 0,
-    lower: bool = False,
-    unit_diagonal: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-) -> onp.Array2D[np.complex64]: ...
-@overload  # Nd ~complex64, +complex64
-def solve_triangular(
-    a: _InputC64,
-    b: _CoInputC64,
-    trans: _TransSystem = 0,
-    lower: bool = False,
-    unit_diagonal: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-) -> onp.ArrayND[np.complex64]: ...
-@overload  # 1d +complex64, ~complex64
-def solve_triangular(
-    a: _CoInputC64Strict2D,
-    b: _InputC64Strict1D,
-    trans: _TransSystem = 0,
-    lower: bool = False,
-    unit_diagonal: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-) -> onp.Array1D[np.complex64]: ...
-@overload  # 2d +complex64, ~complex64
-def solve_triangular(
-    a: _CoInputC64Strict2D,
-    b: _InputC64Strict2D,
-    trans: _TransSystem = 0,
-    lower: bool = False,
-    unit_diagonal: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-) -> onp.Array2D[np.complex64]: ...
-@overload  # Nd +complex64, ~complex64
-def solve_triangular(
-    a: _CoInputC64,
-    b: _InputC64,
-    trans: _TransSystem = 0,
-    lower: bool = False,
-    unit_diagonal: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-) -> onp.ArrayND[np.complex64]: ...
 @overload  # 1d ~complex128, +complex128
 def solve_triangular(
     a: _InputComplexStrict2D,
@@ -569,36 +365,6 @@ def solve_triangular(
     overwrite_b: bool = False,
     check_finite: bool = True,
 ) -> onp.ArrayND[np.float32 | np.float64]: ...
-@overload  # 1d ~complexfloating, +complexfloating
-def solve_triangular(
-    a: onp.ToJustComplexStrict2D,
-    b: onp.ToComplexStrict1D,
-    trans: _TransSystem = 0,
-    lower: bool = False,
-    unit_diagonal: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-) -> onp.Array1D[np.complex64 | np.complex128]: ...
-@overload  # 2d ~complexfloating, +complexfloating
-def solve_triangular(
-    a: onp.ToJustComplexStrict2D,
-    b: onp.ToComplexStrict2D,
-    trans: _TransSystem = 0,
-    lower: bool = False,
-    unit_diagonal: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-) -> onp.Array2D[np.complex64 | np.complex128]: ...
-@overload  # Nd ~complexfloating, +complexfloating
-def solve_triangular(
-    a: onp.ToJustComplexND,
-    b: onp.ToComplexND,
-    trans: _TransSystem = 0,
-    lower: bool = False,
-    unit_diagonal: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-) -> onp.ArrayND[np.complex64 | np.complex128]: ...
 @overload  # 1d +complexfloating, ~complexfloating
 def solve_triangular(
     a: onp.ToComplexStrict2D,
@@ -629,26 +395,6 @@ def solve_triangular(
     overwrite_b: bool = False,
     check_finite: bool = True,
 ) -> onp.ArrayND[np.complex64 | np.complex128]: ...
-@overload  # 1d +complexfloating, +complexfloating
-def solve_triangular(
-    a: onp.ToComplexStrict2D,
-    b: onp.ToComplexStrict1D,
-    trans: _TransSystem = 0,
-    lower: bool = False,
-    unit_diagonal: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-) -> onp.Array1D[np.float32 | np.float64 | np.complex64 | np.complex128]: ...
-@overload  # 2d +complexfloating, +complexfloating
-def solve_triangular(
-    a: onp.ToComplexStrict2D,
-    b: onp.ToComplexStrict2D,
-    trans: _TransSystem = 0,
-    lower: bool = False,
-    unit_diagonal: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-) -> onp.Array2D[np.float32 | np.float64 | np.complex64 | np.complex128]: ...
 @overload  # Nd +complexfloating, +complexfloating
 def solve_triangular(
     a: onp.ToComplexND,
@@ -660,34 +406,7 @@ def solve_triangular(
     check_finite: bool = True,
 ) -> onp.ArrayND[np.float32 | np.float64 | np.complex64 | np.complex128]: ...
 
-#
-@overload  # 1d ~float32, ~float32
-def solve_banded(
-    l_and_u: tuple[int, int],
-    ab: _InputF32Strict2D,
-    b: _InputF32Strict1D,
-    overwrite_ab: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-) -> onp.Array1D[np.float32]: ...
-@overload  # 2d ~float32, ~float32
-def solve_banded(
-    l_and_u: tuple[int, int],
-    ab: _InputF32Strict2D,
-    b: _InputF32Strict2D,
-    overwrite_ab: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-) -> onp.Array2D[np.float32]: ...
-@overload  # Nd ~float32, ~float32
-def solve_banded(
-    l_and_u: tuple[int, int],
-    ab: _InputF32,
-    b: _InputF32,
-    overwrite_ab: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-) -> onp.ArrayND[np.float32]: ...
+# NOTE: keep overload structure consistent with `solveh_banded` below
 @overload  # 1D ~float64, +float64
 def solve_banded(
     l_and_u: tuple[int, int],
@@ -742,60 +461,6 @@ def solve_banded(
     overwrite_b: bool = False,
     check_finite: bool = True,
 ) -> onp.ArrayND[np.float64]: ...
-@overload  # 1d ~complex64, +complex64
-def solve_banded(
-    l_and_u: tuple[int, int],
-    ab: _InputC64Strict2D,
-    b: _InputC64Strict1D | _InputF32Strict1D,
-    overwrite_ab: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-) -> onp.Array1D[np.complex64]: ...
-@overload  # 2d ~complex64, +complex64
-def solve_banded(
-    l_and_u: tuple[int, int],
-    ab: _InputC64Strict2D,
-    b: _InputC64Strict2D | _InputF32Strict2D,
-    overwrite_ab: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-) -> onp.Array2D[np.complex64]: ...
-@overload  # Nd ~complex64, +complex64
-def solve_banded(
-    l_and_u: tuple[int, int],
-    ab: _InputC64,
-    b: _InputC64 | _InputF32,
-    overwrite_ab: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-) -> onp.ArrayND[np.complex64]: ...
-@overload  # 1d +complex64, ~complex64
-def solve_banded(
-    l_and_u: tuple[int, int],
-    ab: _InputC64Strict2D | _InputF32Strict2D,
-    b: _InputC64Strict1D,
-    overwrite_ab: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-) -> onp.Array1D[np.complex64]: ...
-@overload  # 2d +complex64, ~complex64
-def solve_banded(
-    l_and_u: tuple[int, int],
-    ab: _InputC64Strict2D | _InputF32Strict2D,
-    b: _InputC64Strict2D,
-    overwrite_ab: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-) -> onp.Array2D[np.complex64]: ...
-@overload  # Nd +complex64, ~complex64
-def solve_banded(
-    l_and_u: tuple[int, int],
-    ab: _InputC64 | _InputF32,
-    b: _InputC64,
-    overwrite_ab: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-) -> onp.ArrayND[np.complex64]: ...
 @overload  # 1d ~complex128, +complex128
 def solve_banded(
     l_and_u: tuple[int, int],
@@ -877,33 +542,6 @@ def solve_banded(
     overwrite_b: bool = False,
     check_finite: bool = True,
 ) -> onp.ArrayND[np.float32 | np.float64]: ...
-@overload  # 1d ~complexfloating, +complexfloating
-def solve_banded(
-    l_and_u: tuple[int, int],
-    ab: onp.ToJustComplexStrict2D,
-    b: onp.ToComplexStrict1D,
-    overwrite_ab: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-) -> onp.Array1D[np.complex64 | np.complex128]: ...
-@overload  # 2d ~complexfloating, +complexfloating
-def solve_banded(
-    l_and_u: tuple[int, int],
-    ab: onp.ToJustComplexStrict2D,
-    b: onp.ToComplexStrict2D,
-    overwrite_ab: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-) -> onp.Array2D[np.complex64 | np.complex128]: ...
-@overload  # Nd ~complexfloating, +complexfloating
-def solve_banded(
-    l_and_u: tuple[int, int],
-    ab: onp.ToJustComplexND,
-    b: onp.ToComplexND,
-    overwrite_ab: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-) -> onp.ArrayND[np.complex64 | np.complex128]: ...
 @overload  # 1d +complexfloating, ~complexfloating
 def solve_banded(
     l_and_u: tuple[int, int],
@@ -931,24 +569,6 @@ def solve_banded(
     overwrite_b: bool = False,
     check_finite: bool = True,
 ) -> onp.ArrayND[np.complex64 | np.complex128]: ...
-@overload  # 1d +complexfloating, +complexfloating
-def solve_banded(
-    l_and_u: tuple[int, int],
-    ab: onp.ToComplexStrict2D,
-    b: onp.ToComplexStrict1D,
-    overwrite_ab: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-) -> onp.Array1D[np.float32 | np.float64 | np.complex64 | np.complex128]: ...
-@overload  # 2d +complexfloating, +complexfloating
-def solve_banded(
-    l_and_u: tuple[int, int],
-    ab: onp.ToComplexStrict2D,
-    b: onp.ToComplexStrict2D,
-    overwrite_ab: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-) -> onp.Array2D[np.float32 | np.float64 | np.complex64 | np.complex128]: ...
 @overload  # Nd +complexfloating, +complexfloating
 def solve_banded(
     l_and_u: tuple[int, int],
@@ -959,34 +579,7 @@ def solve_banded(
     check_finite: bool = True,
 ) -> onp.ArrayND[np.float32 | np.float64 | np.complex64 | np.complex128]: ...
 
-#
-@overload  # 1d ~float32, ~float32
-def solveh_banded(
-    ab: _InputF32Strict2D,
-    b: _InputF32Strict1D,
-    overwrite_ab: bool = False,
-    overwrite_b: bool = False,
-    lower: bool = False,
-    check_finite: bool = True,
-) -> onp.Array1D[np.float32]: ...
-@overload  # 2d ~float32, ~float32
-def solveh_banded(
-    ab: _InputF32Strict2D,
-    b: _InputF32Strict2D,
-    overwrite_ab: bool = False,
-    overwrite_b: bool = False,
-    lower: bool = False,
-    check_finite: bool = True,
-) -> onp.Array2D[np.float32]: ...
-@overload  # Nd ~float32, ~float32
-def solveh_banded(
-    ab: _InputF32,
-    b: _InputF32,
-    overwrite_ab: bool = False,
-    overwrite_b: bool = False,
-    lower: bool = False,
-    check_finite: bool = True,
-) -> onp.ArrayND[np.float32]: ...
+# NOTE: keep overload structure consistent with `solve_banded` above
 @overload  # 1D ~float64, +float64
 def solveh_banded(
     ab: _InputFloatStrict2D,
@@ -1041,60 +634,6 @@ def solveh_banded(
     lower: bool = False,
     check_finite: bool = True,
 ) -> onp.ArrayND[np.float64]: ...
-@overload  # 1d ~complex64, +complex64
-def solveh_banded(
-    ab: _InputC64Strict2D,
-    b: _InputC64Strict1D | _InputF32Strict1D,
-    overwrite_ab: bool = False,
-    overwrite_b: bool = False,
-    lower: bool = False,
-    check_finite: bool = True,
-) -> onp.Array1D[np.complex64]: ...
-@overload  # 2d ~complex64, +complex64
-def solveh_banded(
-    ab: _InputC64Strict2D,
-    b: _InputC64Strict2D | _InputF32Strict2D,
-    overwrite_ab: bool = False,
-    overwrite_b: bool = False,
-    lower: bool = False,
-    check_finite: bool = True,
-) -> onp.Array2D[np.complex64]: ...
-@overload  # Nd ~complex64, +complex64
-def solveh_banded(
-    ab: _InputC64,
-    b: _InputC64 | _InputF32,
-    overwrite_ab: bool = False,
-    overwrite_b: bool = False,
-    lower: bool = False,
-    check_finite: bool = True,
-) -> onp.ArrayND[np.complex64]: ...
-@overload  # 1d +complex64, ~complex64
-def solveh_banded(
-    ab: _InputC64Strict2D | _InputF32Strict2D,
-    b: _InputC64Strict1D,
-    overwrite_ab: bool = False,
-    overwrite_b: bool = False,
-    lower: bool = False,
-    check_finite: bool = True,
-) -> onp.Array1D[np.complex64]: ...
-@overload  # 2d +complex64, ~complex64
-def solveh_banded(
-    ab: _InputC64Strict2D | _InputF32Strict2D,
-    b: _InputC64Strict2D,
-    overwrite_ab: bool = False,
-    overwrite_b: bool = False,
-    lower: bool = False,
-    check_finite: bool = True,
-) -> onp.Array2D[np.complex64]: ...
-@overload  # Nd +complex64, ~complex64
-def solveh_banded(
-    ab: _InputC64 | _InputF32,
-    b: _InputC64,
-    overwrite_ab: bool = False,
-    overwrite_b: bool = False,
-    lower: bool = False,
-    check_finite: bool = True,
-) -> onp.ArrayND[np.complex64]: ...
 @overload  # 1d ~complex128, +complex128
 def solveh_banded(
     ab: _InputComplexStrict2D,
@@ -1176,33 +715,6 @@ def solveh_banded(
     lower: bool = False,
     check_finite: bool = True,
 ) -> onp.ArrayND[np.float32 | np.float64]: ...
-@overload  # 1d ~complexfloating, +complexfloating
-def solveh_banded(
-    ab: onp.ToJustComplexStrict2D,
-    b: onp.ToComplexStrict1D,
-    overwrite_ab: bool = False,
-    overwrite_b: bool = False,
-    lower: bool = False,
-    check_finite: bool = True,
-) -> onp.Array1D[np.complex64 | np.complex128]: ...
-@overload  # 2d ~complexfloating, +complexfloating
-def solveh_banded(
-    ab: onp.ToJustComplexStrict2D,
-    b: onp.ToComplexStrict2D,
-    overwrite_ab: bool = False,
-    overwrite_b: bool = False,
-    lower: bool = False,
-    check_finite: bool = True,
-) -> onp.Array2D[np.complex64 | np.complex128]: ...
-@overload  # Nd ~complexfloating, +complexfloating
-def solveh_banded(
-    ab: onp.ToJustComplexND,
-    b: onp.ToComplexND,
-    overwrite_ab: bool = False,
-    overwrite_b: bool = False,
-    lower: bool = False,
-    check_finite: bool = True,
-) -> onp.ArrayND[np.complex64 | np.complex128]: ...
 @overload  # 1d +complexfloating, ~complexfloating
 def solveh_banded(
     ab: onp.ToComplexStrict2D,
@@ -1230,24 +742,6 @@ def solveh_banded(
     lower: bool = False,
     check_finite: bool = True,
 ) -> onp.ArrayND[np.complex64 | np.complex128]: ...
-@overload  # 1d +complexfloating, +complexfloating
-def solveh_banded(
-    ab: onp.ToComplexStrict2D,
-    b: onp.ToComplexStrict1D,
-    overwrite_ab: bool = False,
-    overwrite_b: bool = False,
-    lower: bool = False,
-    check_finite: bool = True,
-) -> onp.Array1D[np.float32 | np.float64 | np.complex64 | np.complex128]: ...
-@overload  # 2d +complexfloating, +complexfloating
-def solveh_banded(
-    ab: onp.ToComplexStrict2D,
-    b: onp.ToComplexStrict2D,
-    overwrite_ab: bool = False,
-    overwrite_b: bool = False,
-    lower: bool = False,
-    check_finite: bool = True,
-) -> onp.Array2D[np.float32 | np.float64 | np.complex64 | np.complex128]: ...
 @overload  # Nd +complexfloating, +complexfloating
 def solveh_banded(
     ab: onp.ToComplexND,
@@ -1307,215 +801,125 @@ def solve_toeplitz(
 ) -> onp.ArrayND[np.float64 | np.complex128]: ...
 
 #
-@overload  # 1d ~float32, ~float32
-def solve_circulant(
-    c: _InputF32Strict1D,
-    b: _InputF32Strict1D,
-    singular: _Singular = "raise",
-    tol: onp.ToFloat | None = None,
-    caxis: op.CanIndex = -1,
-    baxis: op.CanIndex = 0,
-    outaxis: op.CanIndex = 0,
-) -> onp.Array1D[np.float32]: ...
-@overload  # 2d ~float32, ~float32
-def solve_circulant(
-    c: _InputF32Strict1D,
-    b: _InputF32Strict2D,
-    singular: _Singular = "raise",
-    tol: onp.ToFloat | None = None,
-    caxis: op.CanIndex = -1,
-    baxis: op.CanIndex = 0,
-    outaxis: op.CanIndex = 0,
-) -> onp.Array2D[np.float32]: ...
-@overload  # Nd ~float32, ~float32
-def solve_circulant(
-    c: _InputF32,
-    b: _InputF32,
-    singular: _Singular = "raise",
-    tol: onp.ToFloat | None = None,
-    caxis: op.CanIndex = -1,
-    baxis: op.CanIndex = 0,
-    outaxis: op.CanIndex = 0,
-) -> onp.ArrayND[np.float32]: ...
 @overload  # 1D ~float64, +float64
 def solve_circulant(
     c: _InputF64Strict1D,
     b: onp.ToFloat64Strict1D,
     singular: _Singular = "raise",
-    tol: onp.ToFloat | None = None,
-    caxis: op.CanIndex = -1,
-    baxis: op.CanIndex = 0,
-    outaxis: op.CanIndex = 0,
+    tol: float | None = None,
+    caxis: int = -1,
+    baxis: int = 0,
+    outaxis: int = 0,
 ) -> onp.Array1D[np.float64]: ...
 @overload  # 2D ~float64, +float64
 def solve_circulant(
     c: _InputF64Strict1D,
     b: onp.ToFloat64Strict2D,
     singular: _Singular = "raise",
-    tol: onp.ToFloat | None = None,
-    caxis: op.CanIndex = -1,
-    baxis: op.CanIndex = 0,
-    outaxis: op.CanIndex = 0,
+    tol: float | None = None,
+    caxis: int = -1,
+    baxis: int = 0,
+    outaxis: int = 0,
 ) -> onp.Array2D[np.float64]: ...
 @overload  # Nd ~float64, +float64
 def solve_circulant(
     c: _InputF64,
     b: onp.ToFloat64_ND,
     singular: _Singular = "raise",
-    tol: onp.ToFloat | None = None,
-    caxis: op.CanIndex = -1,
-    baxis: op.CanIndex = 0,
-    outaxis: op.CanIndex = 0,
+    tol: float | None = None,
+    caxis: int = -1,
+    baxis: int = 0,
+    outaxis: int = 0,
 ) -> onp.ArrayND[np.float64]: ...
 @overload  # 1d +float64, ~float64
 def solve_circulant(
     c: onp.ToFloat64Strict1D,
     b: _InputF64Strict1D,
     singular: _Singular = "raise",
-    tol: onp.ToFloat | None = None,
-    caxis: op.CanIndex = -1,
-    baxis: op.CanIndex = 0,
-    outaxis: op.CanIndex = 0,
+    tol: float | None = None,
+    caxis: int = -1,
+    baxis: int = 0,
+    outaxis: int = 0,
 ) -> onp.Array1D[np.float64]: ...
 @overload  # 2d +float64, ~float64
 def solve_circulant(
     c: onp.ToFloat64Strict1D,
     b: _InputF64Strict2D,
     singular: _Singular = "raise",
-    tol: onp.ToFloat | None = None,
-    caxis: op.CanIndex = -1,
-    baxis: op.CanIndex = 0,
-    outaxis: op.CanIndex = 0,
+    tol: float | None = None,
+    caxis: int = -1,
+    baxis: int = 0,
+    outaxis: int = 0,
 ) -> onp.Array2D[np.float64]: ...
 @overload  # Nd +float64, ~float64
 def solve_circulant(
     c: onp.ToFloatND,
     b: _InputF64,
     singular: _Singular = "raise",
-    tol: onp.ToFloat | None = None,
-    caxis: op.CanIndex = -1,
-    baxis: op.CanIndex = 0,
-    outaxis: op.CanIndex = 0,
+    tol: float | None = None,
+    caxis: int = -1,
+    baxis: int = 0,
+    outaxis: int = 0,
 ) -> onp.ArrayND[np.float64]: ...
-@overload  # 1d ~complex64, +complex64
-def solve_circulant(
-    c: _InputC64Strict1D,
-    b: _InputC64Strict1D | _InputF32Strict1D,
-    singular: _Singular = "raise",
-    tol: onp.ToFloat | None = None,
-    caxis: op.CanIndex = -1,
-    baxis: op.CanIndex = 0,
-    outaxis: op.CanIndex = 0,
-) -> onp.Array1D[np.complex64]: ...
-@overload  # 2d ~complex64, +complex64
-def solve_circulant(
-    c: _InputC64Strict1D,
-    b: _CoInputC64Strict2D,
-    singular: _Singular = "raise",
-    tol: onp.ToFloat | None = None,
-    caxis: op.CanIndex = -1,
-    baxis: op.CanIndex = 0,
-    outaxis: op.CanIndex = 0,
-) -> onp.Array2D[np.complex64]: ...
-@overload  # Nd ~complex64, +complex64
-def solve_circulant(
-    c: _InputC64,
-    b: _CoInputC64,
-    singular: _Singular = "raise",
-    tol: onp.ToFloat | None = None,
-    caxis: op.CanIndex = -1,
-    baxis: op.CanIndex = 0,
-    outaxis: op.CanIndex = 0,
-) -> onp.ArrayND[np.complex64]: ...
-@overload  # 1d +complex64, ~complex64
-def solve_circulant(
-    c: _CoInputC64Strict1D,
-    b: _InputC64Strict1D,
-    singular: _Singular = "raise",
-    tol: onp.ToFloat | None = None,
-    caxis: op.CanIndex = -1,
-    baxis: op.CanIndex = 0,
-    outaxis: op.CanIndex = 0,
-) -> onp.Array1D[np.complex64]: ...
-@overload  # 2d +complex64, ~complex64
-def solve_circulant(
-    c: _CoInputC64Strict1D,
-    b: _InputC64Strict2D,
-    singular: _Singular = "raise",
-    tol: onp.ToFloat | None = None,
-    caxis: op.CanIndex = -1,
-    baxis: op.CanIndex = 0,
-    outaxis: op.CanIndex = 0,
-) -> onp.Array2D[np.complex64]: ...
-@overload  # Nd +complex64, ~complex64
-def solve_circulant(
-    c: _CoInputC64,
-    b: _InputC64,
-    singular: _Singular = "raise",
-    tol: onp.ToFloat | None = None,
-    caxis: op.CanIndex = -1,
-    baxis: op.CanIndex = 0,
-    outaxis: op.CanIndex = 0,
-) -> onp.ArrayND[np.complex64]: ...
 @overload  # 1d ~complex128, +complex128
 def solve_circulant(
     c: onp.ToJustComplex128Strict1D,
     b: onp.ToComplex128Strict1D,
     singular: _Singular = "raise",
-    tol: onp.ToFloat | None = None,
-    caxis: op.CanIndex = -1,
-    baxis: op.CanIndex = 0,
-    outaxis: op.CanIndex = 0,
+    tol: float | None = None,
+    caxis: int = -1,
+    baxis: int = 0,
+    outaxis: int = 0,
 ) -> onp.Array1D[np.complex128]: ...
 @overload  # 2d ~complex128, +complex128
 def solve_circulant(
     c: onp.ToJustComplex128Strict1D,
     b: onp.ToComplex128Strict2D,
     singular: _Singular = "raise",
-    tol: onp.ToFloat | None = None,
-    caxis: op.CanIndex = -1,
-    baxis: op.CanIndex = 0,
-    outaxis: op.CanIndex = 0,
+    tol: float | None = None,
+    caxis: int = -1,
+    baxis: int = 0,
+    outaxis: int = 0,
 ) -> onp.Array2D[np.complex128]: ...
 @overload  # Nd ~complex128, +complex128
 def solve_circulant(
     c: onp.ToJustComplex128_ND,
     b: onp.ToComplex128_ND,
     singular: _Singular = "raise",
-    tol: onp.ToFloat | None = None,
-    caxis: op.CanIndex = -1,
-    baxis: op.CanIndex = 0,
-    outaxis: op.CanIndex = 0,
+    tol: float | None = None,
+    caxis: int = -1,
+    baxis: int = 0,
+    outaxis: int = 0,
 ) -> onp.ArrayND[np.complex128]: ...
 @overload  # 1d +complex128, ~complex128
 def solve_circulant(
     c: onp.ToComplex128Strict1D,
     b: onp.ToJustComplex128Strict1D,
     singular: _Singular = "raise",
-    tol: onp.ToFloat | None = None,
-    caxis: op.CanIndex = -1,
-    baxis: op.CanIndex = 0,
-    outaxis: op.CanIndex = 0,
+    tol: float | None = None,
+    caxis: int = -1,
+    baxis: int = 0,
+    outaxis: int = 0,
 ) -> onp.Array1D[np.complex128]: ...
 @overload  # 2d +complex128, ~complex128
 def solve_circulant(
     c: onp.ToComplex128Strict1D,
     b: onp.ToJustComplex128Strict2D,
     singular: _Singular = "raise",
-    tol: onp.ToFloat | None = None,
-    caxis: op.CanIndex = -1,
-    baxis: op.CanIndex = 0,
-    outaxis: op.CanIndex = 0,
+    tol: float | None = None,
+    caxis: int = -1,
+    baxis: int = 0,
+    outaxis: int = 0,
 ) -> onp.Array2D[np.complex128]: ...
 @overload  # Nd +complex128, ~complex128
 def solve_circulant(
     c: onp.ToComplex128_ND,
     b: onp.ToJustComplex128_ND,
     singular: _Singular = "raise",
-    tol: onp.ToFloat | None = None,
-    caxis: op.CanIndex = -1,
-    baxis: op.CanIndex = 0,
-    outaxis: op.CanIndex = 0,
+    tol: float | None = None,
+    caxis: int = -1,
+    baxis: int = 0,
+    outaxis: int = 0,
 ) -> onp.ArrayND[np.complex128]: ...
 @overload  # 1d +floating, +floating
 def solve_circulant(
@@ -1542,41 +946,11 @@ def solve_circulant(
     c: onp.ToFloatND,
     b: onp.ToFloatND,
     singular: _Singular = "raise",
-    tol: onp.ToFloat | None = None,
-    caxis: op.CanIndex = -1,
-    baxis: op.CanIndex = 0,
-    outaxis: op.CanIndex = 0,
+    tol: float | None = None,
+    caxis: int = -1,
+    baxis: int = 0,
+    outaxis: int = 0,
 ) -> onp.ArrayND[npc.floating]: ...
-@overload  # 1d ~complexfloating, +complexfloating
-def solve_circulant(
-    c: onp.ToJustComplexStrict1D,
-    b: onp.ToComplexStrict1D,
-    singular: _Singular = "raise",
-    tol: onp.ToFloat | None = None,
-    caxis: op.CanIndex = -1,
-    baxis: op.CanIndex = 0,
-    outaxis: op.CanIndex = 0,
-) -> onp.Array1D[npc.complexfloating]: ...
-@overload  # 2d ~complexfloating, +complexfloating
-def solve_circulant(
-    c: onp.ToJustComplexStrict1D,
-    b: onp.ToComplexStrict2D,
-    singular: _Singular = "raise",
-    tol: onp.ToFloat | None = None,
-    caxis: op.CanIndex = -1,
-    baxis: op.CanIndex = 0,
-    outaxis: op.CanIndex = 0,
-) -> onp.Array2D[npc.complexfloating]: ...
-@overload  # Nd ~complexfloating, +complexfloating
-def solve_circulant(
-    c: onp.ToJustComplexND,
-    b: onp.ToComplexND,
-    singular: _Singular = "raise",
-    tol: onp.ToFloat | None = None,
-    caxis: op.CanIndex = -1,
-    baxis: op.CanIndex = 0,
-    outaxis: op.CanIndex = 0,
-) -> onp.ArrayND[npc.complexfloating]: ...
 @overload  # 1d +complexfloating, ~complexfloating
 def solve_circulant(
     c: onp.ToComplexStrict1D,
@@ -1602,40 +976,20 @@ def solve_circulant(
     c: onp.ToComplexND,
     b: onp.ToJustComplexND,
     singular: _Singular = "raise",
-    tol: onp.ToFloat | None = None,
-    caxis: op.CanIndex = -1,
-    baxis: op.CanIndex = 0,
-    outaxis: op.CanIndex = 0,
+    tol: float | None = None,
+    caxis: int = -1,
+    baxis: int = 0,
+    outaxis: int = 0,
 ) -> onp.ArrayND[npc.complexfloating]: ...
-@overload  # 1d +complexfloating, +complexfloating
-def solve_circulant(
-    c: onp.ToComplexStrict1D,
-    b: onp.ToComplexStrict1D,
-    singular: _Singular = "raise",
-    tol: onp.ToFloat | None = None,
-    caxis: op.CanIndex = -1,
-    baxis: op.CanIndex = 0,
-    outaxis: op.CanIndex = 0,
-) -> onp.Array1D[npc.inexact]: ...
-@overload  # 2d +complexfloating, +complexfloating
-def solve_circulant(
-    c: onp.ToComplexStrict1D,
-    b: onp.ToComplexStrict2D,
-    singular: _Singular = "raise",
-    tol: onp.ToFloat | None = None,
-    caxis: op.CanIndex = -1,
-    baxis: op.CanIndex = 0,
-    outaxis: op.CanIndex = 0,
-) -> onp.Array2D[npc.inexact]: ...
 @overload  # Nd +complexfloating, +complexfloating
 def solve_circulant(
     c: onp.ToComplexND,
     b: onp.ToComplexND,
     singular: _Singular = "raise",
-    tol: onp.ToFloat | None = None,
-    caxis: op.CanIndex = -1,
-    baxis: op.CanIndex = 0,
-    outaxis: op.CanIndex = 0,
+    tol: float | None = None,
+    caxis: int = -1,
+    baxis: int = 0,
+    outaxis: int = 0,
 ) -> onp.ArrayND[npc.inexact]: ...
 
 # TODO(jorenham): improve this
@@ -1644,9 +998,9 @@ def inv(a: onp.ToFloatStrict2D, overwrite_a: bool = False, check_finite: bool = 
 @overload  # floating
 def inv(a: onp.ToFloatND, overwrite_a: bool = False, check_finite: bool = True) -> _FloatND: ...
 @overload  # complexfloating 2d
-def inv(a: onp.ToComplexStrict2D, overwrite_a: bool = False, check_finite: bool = True) -> _Complex2D: ...
+def inv(a: onp.ToComplexStrict2D, overwrite_a: bool = False, check_finite: bool = True) -> _Inexact2D: ...
 @overload  # complexfloating
-def inv(a: onp.ToComplexND, overwrite_a: bool = False, check_finite: bool = True) -> _ComplexND: ...
+def inv(a: onp.ToComplexND, overwrite_a: bool = False, check_finite: bool = True) -> _InexactND: ...
 
 # TODO(jorenham): improve this
 @overload  # floating 2d
@@ -1656,11 +1010,11 @@ def det(a: onp.ToFloatStrict3D, overwrite_a: bool = False, check_finite: bool = 
 @overload  # floating
 def det(a: onp.ToFloatND, overwrite_a: bool = False, check_finite: bool = True) -> _Float | _FloatND: ...
 @overload  # complexfloating 2d
-def det(a: onp.ToJustComplexStrict2D, overwrite_a: bool = False, check_finite: bool = True) -> _Complex1D: ...
+def det(a: onp.ToJustComplexStrict2D, overwrite_a: bool = False, check_finite: bool = True) -> _Inexact1D: ...
 @overload  # complexfloating 3d
-def det(a: onp.ToJustComplexStrict3D, overwrite_a: bool = False, check_finite: bool = True) -> _ComplexND: ...
+def det(a: onp.ToJustComplexStrict3D, overwrite_a: bool = False, check_finite: bool = True) -> _InexactND: ...
 @overload  # complexfloating
-def det(a: onp.ToComplexND, overwrite_a: bool = False, check_finite: bool = True) -> _Complex | _ComplexND: ...
+def det(a: onp.ToComplexND, overwrite_a: bool = False, check_finite: bool = True) -> _Inexact | _InexactND: ...
 
 # TODO(jorenham): improve this
 @overload  # (float[:, :], float[:]) -> (float[:], float[], ...)
@@ -1702,7 +1056,7 @@ def lstsq(
     overwrite_b: bool = False,
     check_finite: bool = True,
     lapack_driver: _LapackDriver | None = None,
-) -> tuple[_ComplexND, _Complex0D | _ComplexND, int, _ComplexND | None]: ...
+) -> tuple[_InexactND, _Inexact0D | _InexactND, int, _InexactND | None]: ...
 
 # TODO(jorenham): improve this
 @overload
@@ -1731,7 +1085,7 @@ def pinv(
     rtol: onp.ToFloat | None = None,
     return_rank: onp.ToFalse = False,
     check_finite: bool = True,
-) -> _ComplexND: ...
+) -> _InexactND: ...
 @overload  # (complex[:, :], return_rank=True) -> (complex[:, :], int)
 def pinv(
     a: onp.ToComplexND,
@@ -1740,7 +1094,7 @@ def pinv(
     rtol: onp.ToFloat | None = None,
     return_rank: onp.ToTrue,
     check_finite: bool = True,
-) -> tuple[_ComplexND, int]: ...
+) -> tuple[_InexactND, int]: ...
 
 # TODO(jorenham): improve this
 @overload  # (float[:, :], return_rank=False) -> float[:, :]
@@ -1779,7 +1133,7 @@ def pinvh(
     lower: bool = True,
     return_rank: onp.ToFalse = False,
     check_finite: bool = True,
-) -> _ComplexND: ...
+) -> _InexactND: ...
 @overload  # (complex[:, :], return_rank=True, /) -> (complex[:, :], int)
 def pinvh(
     a: onp.ToComplexND,
@@ -1788,7 +1142,7 @@ def pinvh(
     lower: bool,
     return_rank: onp.ToTrue,
     check_finite: bool = True,
-) -> tuple[_ComplexND, int]: ...
+) -> tuple[_InexactND, int]: ...
 @overload  # (complex[:, :], *, return_rank=True) -> (complex[:, :], int)
 def pinvh(
     a: onp.ToComplexND,
@@ -1798,7 +1152,7 @@ def pinvh(
     *,
     return_rank: onp.ToTrue,
     check_finite: bool = True,
-) -> tuple[_ComplexND, int]: ...
+) -> tuple[_InexactND, int]: ...
 
 # TODO(jorenham): improve this
 @overload  # (float[:, :], separate=True) -> (float[:, :], float[:, :])
@@ -1824,15 +1178,15 @@ def matrix_balance(
     scale: onp.ToBool = True,
     separate: onp.ToFalse = False,
     overwrite_a: bool = False,
-) -> _Tuple2[_ComplexND]: ...
+) -> _Tuple2[_InexactND]: ...
 @overload  # (complex[:, :], separate=False, /) -> (complex[:, :], (complex[:], complex[:]))
 def matrix_balance(
     A: onp.ToComplexND, permute: onp.ToBool, scale: onp.ToBool, separate: onp.ToTrue, overwrite_a: bool = False
-) -> tuple[_ComplexND, _Tuple2[_ComplexND]]: ...
+) -> tuple[_InexactND, _Tuple2[_InexactND]]: ...
 @overload  # (complex[:, :], *, separate=False) -> (complex[:, :], (complex[:], complex[:]))
 def matrix_balance(
     A: onp.ToComplexND, permute: onp.ToBool = True, scale: onp.ToBool = True, *, separate: onp.ToTrue, overwrite_a: bool = False
-) -> tuple[_ComplexND, _Tuple2[_ComplexND]]: ...
+) -> tuple[_InexactND, _Tuple2[_InexactND]]: ...
 
 # TODO(jorenham): improve this
 @overload  # floating 1d, 1d
@@ -1855,11 +1209,11 @@ def matmul_toeplitz(
     x: onp.ToComplexStrict1D,
     check_finite: bool = False,
     workers: onp.ToJustInt | None = None,
-) -> _Complex1D: ...
+) -> _Inexact1D: ...
 @overload  # complexfloating
 def matmul_toeplitz(
     c_or_cr: onp.ToComplexND | _Tuple2[onp.ToComplexND],
     x: onp.ToComplexND,
     check_finite: bool = False,
     workers: onp.ToJustInt | None = None,
-) -> _ComplexND: ...
+) -> _InexactND: ...

--- a/scipy-stubs/linalg/_basic.pyi
+++ b/scipy-stubs/linalg/_basic.pyi
@@ -1,5 +1,9 @@
-from typing import Final, Literal, TypeAlias, TypeVar, overload
+# mypy: disable-error-code=overload-overlap
 
+from collections.abc import Sequence
+from typing import Any, Final, Literal, TypeAlias, TypeVar, overload
+
+import numpy as np
 import optype as op
 import optype.numpy as onp
 import optype.numpy.compat as npc
@@ -22,6 +26,7 @@ __all__ = [
 
 _T = TypeVar("_T")
 _Tuple2: TypeAlias = tuple[_T, _T]
+_COrCR: TypeAlias = _T | _Tuple2[_T]
 
 _Float: TypeAlias = npc.floating
 _Float0D: TypeAlias = onp.Array0D[_Float]
@@ -34,6 +39,32 @@ _Complex0D: TypeAlias = onp.Array0D[_Complex]
 _Complex1D: TypeAlias = onp.Array1D[_Complex]
 _Complex2D: TypeAlias = onp.Array2D[_Complex]
 _ComplexND: TypeAlias = onp.ArrayND[_Complex]
+
+_InputFloat: TypeAlias = onp.ToArrayND[float, np.float64 | np.longdouble | npc.integer | np.bool_]
+_InputFloatStrict1D: TypeAlias = onp.ToArrayStrict1D[float, np.float64 | np.longdouble | npc.integer | np.bool_]
+_InputFloatStrict2D: TypeAlias = onp.ToArrayStrict2D[float, np.float64 | np.longdouble | npc.integer | np.bool_]
+
+_InputF64: TypeAlias = onp.ToArrayND[float, np.float64 | npc.integer | np.bool_]
+_InputF64Strict1D: TypeAlias = onp.ToArrayStrict1D[float, np.float64 | npc.integer | np.bool_]
+_InputF64Strict2D: TypeAlias = onp.ToArrayStrict2D[float, np.float64 | npc.integer | np.bool_]
+
+_AsF32: TypeAlias = np.float16 | np.float32
+_InputF32: TypeAlias = onp.CanArrayND[_AsF32] | onp.SequenceND[onp.CanArray[Any, np.dtype[_AsF32]]]
+_InputF32Strict1D: TypeAlias = onp.CanArray1D[_AsF32] | Sequence[onp.CanArray0D[_AsF32]]
+_InputF32Strict2D: TypeAlias = onp.CanArray2D[_AsF32] | Sequence[_InputF32Strict1D]
+
+_InputC64: TypeAlias = onp.CanArrayND[np.complex64] | onp.SequenceND[onp.CanArray[Any, np.dtype[np.complex64]]]
+_InputC64Strict1D: TypeAlias = onp.CanArray1D[np.complex64] | Sequence[onp.CanArray0D[np.complex64]]
+_InputC64Strict2D: TypeAlias = onp.CanArray2D[np.complex64] | Sequence[_InputC64Strict1D]
+
+_InputComplex: TypeAlias = onp.ToArrayND[op.JustComplex, np.complex128 | np.clongdouble]
+_InputComplexStrict1D: TypeAlias = onp.ToArrayStrict1D[op.JustComplex, np.complex128 | np.clongdouble]
+_InputComplexStrict2D: TypeAlias = onp.ToArrayStrict2D[op.JustComplex, np.complex128 | np.clongdouble]
+
+_CoC64: TypeAlias = np.complex64 | _AsF32 | npc.integer16 | npc.integer8 | np.bool_
+_CoInputC64: TypeAlias = onp.CanArrayND[_CoC64] | onp.SequenceND[onp.CanArray[Any, np.dtype[_CoC64]]]
+_CoInputC64Strict1D: TypeAlias = onp.CanArray1D[_CoC64] | Sequence[onp.CanArray0D[_CoC64]]
+_CoInputC64Strict2D: TypeAlias = onp.CanArray2D[_CoC64] | Sequence[_CoInputC64Strict1D]
 
 _AssumeA: TypeAlias = Literal[
     "diagonal",
@@ -54,199 +85,1459 @@ _LapackDriver: TypeAlias = Literal["gelsd", "gelsy", "gelss"]
 
 lapack_cast_dict: Final[dict[str, str]] = ...
 
-@overload  # floating, 2d, 2d
+@overload  # 2d ~float32, ~float32
 def solve(
+    a: _InputF32Strict2D,
+    b: _InputF32Strict1D | _InputF32Strict2D,
+    lower: bool = False,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    assume_a: _AssumeA | None = None,
+    transposed: bool = False,
+) -> onp.Array2D[np.float32]: ...
+@overload  # Nd ~float32, ~float32
+def solve(
+    a: _InputF32,
+    b: _InputF32,
+    lower: bool = False,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    assume_a: _AssumeA | None = None,
+    transposed: bool = False,
+) -> onp.ArrayND[np.float32]: ...
+@overload  # 2D ~float64, +float64
+def solve(
+    a: _InputFloatStrict2D,
+    b: onp.ToFloatStrict1D | onp.ToFloatStrict2D,
+    lower: bool = False,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    assume_a: _AssumeA | None = None,
+    transposed: bool = False,
+) -> onp.Array2D[np.float64]: ...
+@overload  # Nd ~float64, +float64
+def solve(
+    a: _InputFloat,
+    b: onp.ToFloatND,
+    lower: bool = False,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    assume_a: _AssumeA | None = None,
+    transposed: bool = False,
+) -> onp.ArrayND[np.float64]: ...
+@overload  # 2d +float64, ~float64
+def solve(
+    a: onp.ToFloatStrict2D,
+    b: _InputFloatStrict1D | _InputFloatStrict2D,
+    lower: bool = False,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    assume_a: _AssumeA | None = None,
+    transposed: bool = False,
+) -> onp.Array2D[np.float64]: ...
+@overload  # Nd +float64, ~float64
+def solve(
+    a: onp.ToFloatND,
+    b: _InputFloat,
+    lower: bool = False,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    assume_a: _AssumeA | None = None,
+    transposed: bool = False,
+) -> onp.ArrayND[np.float64]: ...
+@overload  # 2d ~complex64, +complex64
+def solve(
+    a: _InputC64Strict2D,
+    b: _CoInputC64Strict1D | _CoInputC64Strict2D,
+    lower: bool = False,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    assume_a: _AssumeA | None = None,
+    transposed: bool = False,
+) -> onp.Array2D[np.complex64]: ...
+@overload  # Nd ~complex64, +complex64
+def solve(
+    a: _InputC64,
+    b: _CoInputC64,
+    lower: bool = False,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    assume_a: _AssumeA | None = None,
+    transposed: bool = False,
+) -> onp.ArrayND[np.complex64]: ...
+@overload  # 2d +complex64, ~complex64
+def solve(
+    a: _CoInputC64Strict2D,
+    b: _InputC64Strict1D | _InputC64Strict2D,
+    lower: bool = False,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    assume_a: _AssumeA | None = None,
+    transposed: bool = False,
+) -> onp.Array2D[np.complex64]: ...
+@overload  # Nd +complex64, ~complex64
+def solve(
+    a: _CoInputC64,
+    b: _InputC64,
+    lower: bool = False,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    assume_a: _AssumeA | None = None,
+    transposed: bool = False,
+) -> onp.ArrayND[np.complex64]: ...
+@overload  # 2d ~complex128, +complex128
+def solve(
+    a: _InputComplexStrict2D,
+    b: onp.ToComplexStrict1D | onp.ToComplexStrict2D,
+    lower: bool = False,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    assume_a: _AssumeA | None = None,
+    transposed: bool = False,
+) -> onp.Array2D[np.complex128]: ...
+@overload  # Nd ~complex128, +complex128
+def solve(
+    a: _InputComplex,
+    b: onp.ToComplexND,
+    lower: bool = False,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    assume_a: _AssumeA | None = None,
+    transposed: bool = False,
+) -> onp.ArrayND[np.complex128]: ...
+@overload  # 2d +complex128, ~complex128
+def solve(
+    a: onp.ToComplexStrict2D,
+    b: _InputComplexStrict1D | _InputComplexStrict2D,
+    lower: bool = False,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    assume_a: _AssumeA | None = None,
+    transposed: bool = False,
+) -> onp.Array2D[np.complex128]: ...
+@overload  # Nd +complex128, ~complex128
+def solve(
+    a: onp.ToComplexND,
+    b: _InputComplex,
+    lower: bool = False,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    assume_a: _AssumeA | None = None,
+    transposed: bool = False,
+) -> onp.ArrayND[np.complex128]: ...
+@overload  # 2d +floating, +floating
+def solve(
+    a: onp.ToFloatStrict2D,
+    b: onp.ToFloatStrict1D | onp.ToFloatStrict2D,
+    lower: bool = False,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    assume_a: _AssumeA | None = None,
+    transposed: bool = False,
+) -> onp.Array2D[np.float32 | np.float64]: ...
+@overload  # Nd +floating, +floating
+def solve(
+    a: onp.ToFloatND,
+    b: onp.ToFloatND,
+    lower: bool = False,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    assume_a: _AssumeA | None = None,
+    transposed: bool = False,
+) -> onp.ArrayND[np.float32 | np.float64]: ...
+@overload  # 2d ~complexfloating, +complexfloating
+def solve(
+    a: onp.ToJustComplexStrict2D,
+    b: onp.ToComplexStrict1D | onp.ToComplexStrict2D,
+    lower: bool = False,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    assume_a: _AssumeA | None = None,
+    transposed: bool = False,
+) -> onp.Array2D[np.complex64 | np.complex128]: ...
+@overload  # Nd ~complexfloating, +complexfloating
+def solve(
+    a: onp.ToJustComplexND,
+    b: onp.ToComplexND,
+    lower: bool = False,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    assume_a: _AssumeA | None = None,
+    transposed: bool = False,
+) -> onp.ArrayND[np.complex64 | np.complex128]: ...
+@overload  # 2d +complexfloating, ~complexfloating
+def solve(
+    a: onp.ToComplexStrict2D,
+    b: onp.ToJustComplexStrict1D | onp.ToJustComplexStrict2D,
+    lower: bool = False,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    assume_a: _AssumeA | None = None,
+    transposed: bool = False,
+) -> onp.Array2D[np.complex64 | np.complex128]: ...
+@overload  # Nd +complexfloating, ~complexfloating
+def solve(
+    a: onp.ToComplexND,
+    b: onp.ToJustComplexND,
+    lower: bool = False,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    assume_a: _AssumeA | None = None,
+    transposed: bool = False,
+) -> onp.ArrayND[np.complex64 | np.complex128]: ...
+@overload  # 2d +complexfloating, +complexfloating
+def solve(
+    a: onp.ToComplexStrict2D,
+    b: onp.ToComplexStrict1D | onp.ToComplexStrict2D,
+    lower: bool = False,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    assume_a: _AssumeA | None = None,
+    transposed: bool = False,
+) -> onp.Array2D[np.float32 | np.float64 | np.complex64 | np.complex128]: ...
+@overload  # Nd +complexfloating, +complexfloating
+def solve(
+    a: onp.ToComplexND,
+    b: onp.ToComplexND,
+    lower: bool = False,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    assume_a: _AssumeA | None = None,
+    transposed: bool = False,
+) -> onp.ArrayND[np.float32 | np.float64 | np.complex64 | np.complex128]: ...
+
+#
+@overload  # 1d ~float32, ~float32
+def solve_triangular(
+    a: _InputF32Strict2D,
+    b: _InputF32Strict1D,
+    trans: _TransSystem = 0,
+    lower: bool = False,
+    unit_diagonal: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.Array1D[np.float32]: ...
+@overload  # 2d ~float32, ~float32
+def solve_triangular(
+    a: _InputF32Strict2D,
+    b: _InputF32Strict2D,
+    trans: _TransSystem = 0,
+    lower: bool = False,
+    unit_diagonal: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.Array2D[np.float32]: ...
+@overload  # Nd ~float32, ~float32
+def solve_triangular(
+    a: _InputF32,
+    b: _InputF32,
+    trans: _TransSystem = 0,
+    lower: bool = False,
+    unit_diagonal: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.ArrayND[np.float32]: ...
+@overload  # 1D ~float64, +float64
+def solve_triangular(
+    a: _InputFloatStrict2D,
+    b: onp.ToFloatStrict1D,
+    trans: _TransSystem = 0,
+    lower: bool = False,
+    unit_diagonal: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.Array1D[np.float64]: ...
+@overload  # 2D ~float64, +float64
+def solve_triangular(
+    a: _InputFloatStrict2D,
+    b: onp.ToFloatStrict2D,
+    trans: _TransSystem = 0,
+    lower: bool = False,
+    unit_diagonal: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.Array2D[np.float64]: ...
+@overload  # Nd ~float64, +float64
+def solve_triangular(
+    a: _InputFloat,
+    b: onp.ToFloatND,
+    trans: _TransSystem = 0,
+    lower: bool = False,
+    unit_diagonal: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.ArrayND[np.float64]: ...
+@overload  # 1d +float64, ~float64
+def solve_triangular(
+    a: onp.ToFloatStrict2D,
+    b: _InputFloatStrict1D,
+    trans: _TransSystem = 0,
+    lower: bool = False,
+    unit_diagonal: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.Array1D[np.float64]: ...
+@overload  # 2d +float64, ~float64
+def solve_triangular(
+    a: onp.ToFloatStrict2D,
+    b: _InputFloatStrict2D,
+    trans: _TransSystem = 0,
+    lower: bool = False,
+    unit_diagonal: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.Array2D[np.float64]: ...
+@overload  # Nd +float64, ~float64
+def solve_triangular(
+    a: onp.ToFloatND,
+    b: _InputFloat,
+    trans: _TransSystem = 0,
+    lower: bool = False,
+    unit_diagonal: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.ArrayND[np.float64]: ...
+@overload  # 1d ~complex64, +complex64
+def solve_triangular(
+    a: _InputC64Strict2D,
+    b: _CoInputC64Strict1D,
+    trans: _TransSystem = 0,
+    lower: bool = False,
+    unit_diagonal: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.Array1D[np.complex64]: ...
+@overload  # 2d ~complex64, +complex64
+def solve_triangular(
+    a: _InputC64Strict2D,
+    b: _CoInputC64Strict2D,
+    trans: _TransSystem = 0,
+    lower: bool = False,
+    unit_diagonal: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.Array2D[np.complex64]: ...
+@overload  # Nd ~complex64, +complex64
+def solve_triangular(
+    a: _InputC64,
+    b: _CoInputC64,
+    trans: _TransSystem = 0,
+    lower: bool = False,
+    unit_diagonal: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.ArrayND[np.complex64]: ...
+@overload  # 1d +complex64, ~complex64
+def solve_triangular(
+    a: _CoInputC64Strict2D,
+    b: _InputC64Strict1D,
+    trans: _TransSystem = 0,
+    lower: bool = False,
+    unit_diagonal: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.Array1D[np.complex64]: ...
+@overload  # 2d +complex64, ~complex64
+def solve_triangular(
+    a: _CoInputC64Strict2D,
+    b: _InputC64Strict2D,
+    trans: _TransSystem = 0,
+    lower: bool = False,
+    unit_diagonal: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.Array2D[np.complex64]: ...
+@overload  # Nd +complex64, ~complex64
+def solve_triangular(
+    a: _CoInputC64,
+    b: _InputC64,
+    trans: _TransSystem = 0,
+    lower: bool = False,
+    unit_diagonal: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.ArrayND[np.complex64]: ...
+@overload  # 1d ~complex128, +complex128
+def solve_triangular(
+    a: _InputComplexStrict2D,
+    b: onp.ToComplexStrict1D,
+    trans: _TransSystem = 0,
+    lower: bool = False,
+    unit_diagonal: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.Array1D[np.complex128]: ...
+@overload  # 2d ~complex128, +complex128
+def solve_triangular(
+    a: _InputComplexStrict2D,
+    b: onp.ToComplexStrict2D,
+    trans: _TransSystem = 0,
+    lower: bool = False,
+    unit_diagonal: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.Array2D[np.complex128]: ...
+@overload  # Nd ~complex128, +complex128
+def solve_triangular(
+    a: _InputComplex,
+    b: onp.ToComplexND,
+    trans: _TransSystem = 0,
+    lower: bool = False,
+    unit_diagonal: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.ArrayND[np.complex128]: ...
+@overload  # 1d +complex128, ~complex128
+def solve_triangular(
+    a: onp.ToComplexStrict2D,
+    b: _InputComplexStrict1D,
+    trans: _TransSystem = 0,
+    lower: bool = False,
+    unit_diagonal: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.Array1D[np.complex128]: ...
+@overload  # 2d +complex128, ~complex128
+def solve_triangular(
+    a: onp.ToComplexStrict2D,
+    b: _InputComplexStrict2D,
+    trans: _TransSystem = 0,
+    lower: bool = False,
+    unit_diagonal: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.Array2D[np.complex128]: ...
+@overload  # Nd +complex128, ~complex128
+def solve_triangular(
+    a: onp.ToComplexND,
+    b: _InputComplex,
+    trans: _TransSystem = 0,
+    lower: bool = False,
+    unit_diagonal: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.ArrayND[np.complex128]: ...
+@overload  # 1d +floating, +floating
+def solve_triangular(
+    a: onp.ToFloatStrict2D,
+    b: onp.ToFloatStrict1D,
+    trans: _TransSystem = 0,
+    lower: bool = False,
+    unit_diagonal: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.Array1D[np.float32 | np.float64]: ...
+@overload  # 2d +floating, +floating
+def solve_triangular(
     a: onp.ToFloatStrict2D,
     b: onp.ToFloatStrict2D,
-    lower: onp.ToBool = False,
-    overwrite_a: onp.ToBool = False,
-    overwrite_b: onp.ToBool = False,
-    check_finite: onp.ToBool = True,
-    assume_a: _AssumeA | None = None,
-    transposed: onp.ToBool = False,
-) -> _Float2D: ...
-@overload  # floating
-def solve(
+    trans: _TransSystem = 0,
+    lower: bool = False,
+    unit_diagonal: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.Array2D[np.float32 | np.float64]: ...
+@overload  # Nd +floating, +floating
+def solve_triangular(
     a: onp.ToFloatND,
     b: onp.ToFloatND,
-    lower: onp.ToBool = False,
-    overwrite_a: onp.ToBool = False,
-    overwrite_b: onp.ToBool = False,
-    check_finite: onp.ToBool = True,
-    assume_a: _AssumeA | None = None,
-    transposed: onp.ToBool = False,
-) -> _FloatND: ...
-@overload  # complexfloating 2d, 2d
-def solve(
+    trans: _TransSystem = 0,
+    lower: bool = False,
+    unit_diagonal: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.ArrayND[np.float32 | np.float64]: ...
+@overload  # 1d ~complexfloating, +complexfloating
+def solve_triangular(
+    a: onp.ToJustComplexStrict2D,
+    b: onp.ToComplexStrict1D,
+    trans: _TransSystem = 0,
+    lower: bool = False,
+    unit_diagonal: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.Array1D[np.complex64 | np.complex128]: ...
+@overload  # 2d ~complexfloating, +complexfloating
+def solve_triangular(
+    a: onp.ToJustComplexStrict2D,
+    b: onp.ToComplexStrict2D,
+    trans: _TransSystem = 0,
+    lower: bool = False,
+    unit_diagonal: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.Array2D[np.complex64 | np.complex128]: ...
+@overload  # Nd ~complexfloating, +complexfloating
+def solve_triangular(
+    a: onp.ToJustComplexND,
+    b: onp.ToComplexND,
+    trans: _TransSystem = 0,
+    lower: bool = False,
+    unit_diagonal: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.ArrayND[np.complex64 | np.complex128]: ...
+@overload  # 1d +complexfloating, ~complexfloating
+def solve_triangular(
+    a: onp.ToComplexStrict2D,
+    b: onp.ToJustComplexStrict1D,
+    trans: _TransSystem = 0,
+    lower: bool = False,
+    unit_diagonal: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.Array1D[np.complex64 | np.complex128]: ...
+@overload  # 2d +complexfloating, ~complexfloating
+def solve_triangular(
+    a: onp.ToComplexStrict2D,
+    b: onp.ToJustComplexStrict2D,
+    trans: _TransSystem = 0,
+    lower: bool = False,
+    unit_diagonal: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.Array2D[np.complex64 | np.complex128]: ...
+@overload  # Nd +complexfloating, ~complexfloating
+def solve_triangular(
+    a: onp.ToComplexND,
+    b: onp.ToJustComplexND,
+    trans: _TransSystem = 0,
+    lower: bool = False,
+    unit_diagonal: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.ArrayND[np.complex64 | np.complex128]: ...
+@overload  # 1d +complexfloating, +complexfloating
+def solve_triangular(
+    a: onp.ToComplexStrict2D,
+    b: onp.ToComplexStrict1D,
+    trans: _TransSystem = 0,
+    lower: bool = False,
+    unit_diagonal: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.Array1D[np.float32 | np.float64 | np.complex64 | np.complex128]: ...
+@overload  # 2d +complexfloating, +complexfloating
+def solve_triangular(
     a: onp.ToComplexStrict2D,
     b: onp.ToComplexStrict2D,
-    lower: onp.ToBool = False,
-    overwrite_a: onp.ToBool = False,
-    overwrite_b: onp.ToBool = False,
-    check_finite: onp.ToBool = True,
-    assume_a: _AssumeA | None = None,
-    transposed: onp.ToBool = False,
-) -> _Complex2D: ...
-@overload  # complexfloating
-def solve(
-    a: onp.ToComplexND,
-    b: onp.ToComplexND,
-    lower: onp.ToBool = False,
-    overwrite_a: onp.ToBool = False,
-    overwrite_b: onp.ToBool = False,
-    check_finite: onp.ToBool = True,
-    assume_a: _AssumeA | None = None,
-    transposed: onp.ToBool = False,
-) -> _ComplexND: ...
-
-#
-@overload  # floating 2d, 1d
-def solve_triangular(
-    a: onp.ToFloatStrict2D,
-    b: onp.ToFloatStrict1D,
     trans: _TransSystem = 0,
-    lower: onp.ToBool = False,
-    unit_diagonal: onp.ToBool = False,
-    overwrite_b: onp.ToBool = False,
-    check_finite: onp.ToBool = True,
-) -> _Float1D: ...
-@overload  # floating
-def solve_triangular(
-    a: onp.ToFloatND,
-    b: onp.ToFloatND,
-    trans: _TransSystem = 0,
-    lower: onp.ToBool = False,
-    unit_diagonal: onp.ToBool = False,
-    overwrite_b: onp.ToBool = False,
-    check_finite: onp.ToBool = True,
-) -> _FloatND: ...
-@overload  # complexfloating 2d, 1d
-def solve_triangular(
-    a: onp.ToComplexStrict2D,
-    b: onp.ToComplexStrict1D,
-    trans: _TransSystem = 0,
-    lower: onp.ToBool = False,
-    unit_diagonal: onp.ToBool = False,
-    overwrite_b: onp.ToBool = False,
-    check_finite: onp.ToBool = True,
-) -> _Complex1D: ...
-@overload  # complexfloating
+    lower: bool = False,
+    unit_diagonal: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.Array2D[np.float32 | np.float64 | np.complex64 | np.complex128]: ...
+@overload  # Nd +complexfloating, +complexfloating
 def solve_triangular(
     a: onp.ToComplexND,
     b: onp.ToComplexND,
     trans: _TransSystem = 0,
-    lower: onp.ToBool = False,
-    unit_diagonal: onp.ToBool = False,
-    overwrite_b: onp.ToBool = False,
-    check_finite: onp.ToBool = True,
-) -> _ComplexND: ...
+    lower: bool = False,
+    unit_diagonal: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.ArrayND[np.float32 | np.float64 | np.complex64 | np.complex128]: ...
 
 #
-@overload  # floating 2d, 1d
+@overload  # 1d ~float32, ~float32
 def solve_banded(
-    l_and_u: _Tuple2[onp.ToJustInt],
+    l_and_u: tuple[int, int],
+    ab: _InputF32Strict2D,
+    b: _InputF32Strict1D,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.Array1D[np.float32]: ...
+@overload  # 2d ~float32, ~float32
+def solve_banded(
+    l_and_u: tuple[int, int],
+    ab: _InputF32Strict2D,
+    b: _InputF32Strict2D,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.Array2D[np.float32]: ...
+@overload  # Nd ~float32, ~float32
+def solve_banded(
+    l_and_u: tuple[int, int],
+    ab: _InputF32,
+    b: _InputF32,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.ArrayND[np.float32]: ...
+@overload  # 1D ~float64, +float64
+def solve_banded(
+    l_and_u: tuple[int, int],
+    ab: _InputFloatStrict2D,
+    b: onp.ToFloatStrict1D,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.Array1D[np.float64]: ...
+@overload  # 2D ~float64, +float64
+def solve_banded(
+    l_and_u: tuple[int, int],
+    ab: _InputFloatStrict2D,
+    b: onp.ToFloatStrict2D,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.Array2D[np.float64]: ...
+@overload  # Nd ~float64, +float64
+def solve_banded(
+    l_and_u: tuple[int, int],
+    ab: _InputFloat,
+    b: onp.ToFloatND,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.ArrayND[np.float64]: ...
+@overload  # 1d +float64, ~float64
+def solve_banded(
+    l_and_u: tuple[int, int],
+    ab: onp.ToFloatStrict2D,
+    b: _InputFloatStrict1D,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.Array1D[np.float64]: ...
+@overload  # 2d +float64, ~float64
+def solve_banded(
+    l_and_u: tuple[int, int],
+    ab: onp.ToFloatStrict2D,
+    b: _InputFloatStrict2D,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.Array2D[np.float64]: ...
+@overload  # Nd +float64, ~float64
+def solve_banded(
+    l_and_u: tuple[int, int],
+    ab: onp.ToFloatND,
+    b: _InputFloat,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.ArrayND[np.float64]: ...
+@overload  # 1d ~complex64, +complex64
+def solve_banded(
+    l_and_u: tuple[int, int],
+    ab: _InputC64Strict2D,
+    b: _InputC64Strict1D | _InputF32Strict1D,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.Array1D[np.complex64]: ...
+@overload  # 2d ~complex64, +complex64
+def solve_banded(
+    l_and_u: tuple[int, int],
+    ab: _InputC64Strict2D,
+    b: _InputC64Strict2D | _InputF32Strict2D,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.Array2D[np.complex64]: ...
+@overload  # Nd ~complex64, +complex64
+def solve_banded(
+    l_and_u: tuple[int, int],
+    ab: _InputC64,
+    b: _InputC64 | _InputF32,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.ArrayND[np.complex64]: ...
+@overload  # 1d +complex64, ~complex64
+def solve_banded(
+    l_and_u: tuple[int, int],
+    ab: _InputC64Strict2D | _InputF32Strict2D,
+    b: _InputC64Strict1D,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.Array1D[np.complex64]: ...
+@overload  # 2d +complex64, ~complex64
+def solve_banded(
+    l_and_u: tuple[int, int],
+    ab: _InputC64Strict2D | _InputF32Strict2D,
+    b: _InputC64Strict2D,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.Array2D[np.complex64]: ...
+@overload  # Nd +complex64, ~complex64
+def solve_banded(
+    l_and_u: tuple[int, int],
+    ab: _InputC64 | _InputF32,
+    b: _InputC64,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.ArrayND[np.complex64]: ...
+@overload  # 1d ~complex128, +complex128
+def solve_banded(
+    l_and_u: tuple[int, int],
+    ab: _InputComplexStrict2D,
+    b: onp.ToComplexStrict1D,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.Array1D[np.complex128]: ...
+@overload  # 2d ~complex128, +complex128
+def solve_banded(
+    l_and_u: tuple[int, int],
+    ab: _InputComplexStrict2D,
+    b: onp.ToComplexStrict2D,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.Array2D[np.complex128]: ...
+@overload  # Nd ~complex128, +complex128
+def solve_banded(
+    l_and_u: tuple[int, int],
+    ab: _InputComplex,
+    b: onp.ToComplexND,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.ArrayND[np.complex128]: ...
+@overload  # 1d +complex128, ~complex128
+def solve_banded(
+    l_and_u: tuple[int, int],
+    ab: onp.ToComplexStrict2D,
+    b: _InputComplexStrict1D,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.Array1D[np.complex128]: ...
+@overload  # 2d +complex128, ~complex128
+def solve_banded(
+    l_and_u: tuple[int, int],
+    ab: onp.ToComplexStrict2D,
+    b: _InputComplexStrict2D,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.Array2D[np.complex128]: ...
+@overload  # Nd +complex128, ~complex128
+def solve_banded(
+    l_and_u: tuple[int, int],
+    ab: onp.ToComplexND,
+    b: _InputComplex,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.ArrayND[np.complex128]: ...
+@overload  # 1d +floating, +floating
+def solve_banded(
+    l_and_u: tuple[int, int],
     ab: onp.ToFloatStrict2D,
     b: onp.ToFloatStrict1D,
-    overwrite_ab: onp.ToBool = False,
-    overwrite_b: onp.ToBool = False,
-    check_finite: onp.ToBool = True,
-) -> _Float1D: ...
-@overload  # floating
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.Array1D[np.float32 | np.float64]: ...
+@overload  # 2d +floating, +floating
 def solve_banded(
-    l_and_u: _Tuple2[onp.ToJustInt],
+    l_and_u: tuple[int, int],
+    ab: onp.ToFloatStrict2D,
+    b: onp.ToFloatStrict2D,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.Array2D[np.float32 | np.float64]: ...
+@overload  # Nd +floating, +floating
+def solve_banded(
+    l_and_u: tuple[int, int],
     ab: onp.ToFloatND,
     b: onp.ToFloatND,
-    overwrite_ab: onp.ToBool = False,
-    overwrite_b: onp.ToBool = False,
-    check_finite: onp.ToBool = True,
-) -> _FloatND: ...
-@overload  # complexfloating 2d, 1d
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.ArrayND[np.float32 | np.float64]: ...
+@overload  # 1d ~complexfloating, +complexfloating
 def solve_banded(
-    l_and_u: _Tuple2[onp.ToJustInt],
+    l_and_u: tuple[int, int],
+    ab: onp.ToJustComplexStrict2D,
+    b: onp.ToComplexStrict1D,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.Array1D[np.complex64 | np.complex128]: ...
+@overload  # 2d ~complexfloating, +complexfloating
+def solve_banded(
+    l_and_u: tuple[int, int],
+    ab: onp.ToJustComplexStrict2D,
+    b: onp.ToComplexStrict2D,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.Array2D[np.complex64 | np.complex128]: ...
+@overload  # Nd ~complexfloating, +complexfloating
+def solve_banded(
+    l_and_u: tuple[int, int],
+    ab: onp.ToJustComplexND,
+    b: onp.ToComplexND,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.ArrayND[np.complex64 | np.complex128]: ...
+@overload  # 1d +complexfloating, ~complexfloating
+def solve_banded(
+    l_and_u: tuple[int, int],
+    ab: onp.ToComplexStrict2D,
+    b: onp.ToJustComplexStrict1D,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.Array1D[np.complex64 | np.complex128]: ...
+@overload  # 2d +complexfloating, ~complexfloating
+def solve_banded(
+    l_and_u: tuple[int, int],
+    ab: onp.ToComplexStrict2D,
+    b: onp.ToJustComplexStrict2D,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.Array2D[np.complex64 | np.complex128]: ...
+@overload  # Nd +complexfloating, ~complexfloating
+def solve_banded(
+    l_and_u: tuple[int, int],
+    ab: onp.ToComplexND,
+    b: onp.ToJustComplexND,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.ArrayND[np.complex64 | np.complex128]: ...
+@overload  # 1d +complexfloating, +complexfloating
+def solve_banded(
+    l_and_u: tuple[int, int],
     ab: onp.ToComplexStrict2D,
     b: onp.ToComplexStrict1D,
-    overwrite_ab: onp.ToBool = False,
-    overwrite_b: onp.ToBool = False,
-    check_finite: onp.ToBool = True,
-) -> _Complex1D: ...
-@overload  # complexfloating
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.Array1D[np.float32 | np.float64 | np.complex64 | np.complex128]: ...
+@overload  # 2d +complexfloating, +complexfloating
 def solve_banded(
-    l_and_u: _Tuple2[onp.ToJustInt],
+    l_and_u: tuple[int, int],
+    ab: onp.ToComplexStrict2D,
+    b: onp.ToComplexStrict2D,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.Array2D[np.float32 | np.float64 | np.complex64 | np.complex128]: ...
+@overload  # Nd +complexfloating, +complexfloating
+def solve_banded(
+    l_and_u: tuple[int, int],
     ab: onp.ToComplexND,
     b: onp.ToComplexND,
-    overwrite_ab: onp.ToBool = False,
-    overwrite_b: onp.ToBool = False,
-    check_finite: onp.ToBool = True,
-) -> _ComplexND: ...
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+) -> onp.ArrayND[np.float32 | np.float64 | np.complex64 | np.complex128]: ...
 
 #
-@overload  # floating 2d, 1d
+@overload  # 1d ~float32, ~float32
+def solveh_banded(
+    ab: _InputF32Strict2D,
+    b: _InputF32Strict1D,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    lower: bool = False,
+    check_finite: bool = True,
+) -> onp.Array1D[np.float32]: ...
+@overload  # 2d ~float32, ~float32
+def solveh_banded(
+    ab: _InputF32Strict2D,
+    b: _InputF32Strict2D,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    lower: bool = False,
+    check_finite: bool = True,
+) -> onp.Array2D[np.float32]: ...
+@overload  # Nd ~float32, ~float32
+def solveh_banded(
+    ab: _InputF32,
+    b: _InputF32,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    lower: bool = False,
+    check_finite: bool = True,
+) -> onp.ArrayND[np.float32]: ...
+@overload  # 1D ~float64, +float64
+def solveh_banded(
+    ab: _InputFloatStrict2D,
+    b: onp.ToFloatStrict1D,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    lower: bool = False,
+    check_finite: bool = True,
+) -> onp.Array1D[np.float64]: ...
+@overload  # 2D ~float64, +float64
+def solveh_banded(
+    ab: _InputFloatStrict2D,
+    b: onp.ToFloatStrict2D,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    lower: bool = False,
+    check_finite: bool = True,
+) -> onp.Array2D[np.float64]: ...
+@overload  # Nd ~float64, +float64
+def solveh_banded(
+    ab: _InputFloat,
+    b: onp.ToFloatND,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    lower: bool = False,
+    check_finite: bool = True,
+) -> onp.ArrayND[np.float64]: ...
+@overload  # 1d +float64, ~float64
+def solveh_banded(
+    ab: onp.ToFloatStrict2D,
+    b: _InputFloatStrict1D,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    lower: bool = False,
+    check_finite: bool = True,
+) -> onp.Array1D[np.float64]: ...
+@overload  # 2d +float64, ~float64
+def solveh_banded(
+    ab: onp.ToFloatStrict2D,
+    b: _InputFloatStrict2D,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    lower: bool = False,
+    check_finite: bool = True,
+) -> onp.Array2D[np.float64]: ...
+@overload  # Nd +float64, ~float64
+def solveh_banded(
+    ab: onp.ToFloatND,
+    b: _InputFloat,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    lower: bool = False,
+    check_finite: bool = True,
+) -> onp.ArrayND[np.float64]: ...
+@overload  # 1d ~complex64, +complex64
+def solveh_banded(
+    ab: _InputC64Strict2D,
+    b: _InputC64Strict1D | _InputF32Strict1D,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    lower: bool = False,
+    check_finite: bool = True,
+) -> onp.Array1D[np.complex64]: ...
+@overload  # 2d ~complex64, +complex64
+def solveh_banded(
+    ab: _InputC64Strict2D,
+    b: _InputC64Strict2D | _InputF32Strict2D,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    lower: bool = False,
+    check_finite: bool = True,
+) -> onp.Array2D[np.complex64]: ...
+@overload  # Nd ~complex64, +complex64
+def solveh_banded(
+    ab: _InputC64,
+    b: _InputC64 | _InputF32,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    lower: bool = False,
+    check_finite: bool = True,
+) -> onp.ArrayND[np.complex64]: ...
+@overload  # 1d +complex64, ~complex64
+def solveh_banded(
+    ab: _InputC64Strict2D | _InputF32Strict2D,
+    b: _InputC64Strict1D,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    lower: bool = False,
+    check_finite: bool = True,
+) -> onp.Array1D[np.complex64]: ...
+@overload  # 2d +complex64, ~complex64
+def solveh_banded(
+    ab: _InputC64Strict2D | _InputF32Strict2D,
+    b: _InputC64Strict2D,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    lower: bool = False,
+    check_finite: bool = True,
+) -> onp.Array2D[np.complex64]: ...
+@overload  # Nd +complex64, ~complex64
+def solveh_banded(
+    ab: _InputC64 | _InputF32,
+    b: _InputC64,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    lower: bool = False,
+    check_finite: bool = True,
+) -> onp.ArrayND[np.complex64]: ...
+@overload  # 1d ~complex128, +complex128
+def solveh_banded(
+    ab: _InputComplexStrict2D,
+    b: onp.ToComplexStrict1D,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    lower: bool = False,
+    check_finite: bool = True,
+) -> onp.Array1D[np.complex128]: ...
+@overload  # 2d ~complex128, +complex128
+def solveh_banded(
+    ab: _InputComplexStrict2D,
+    b: onp.ToComplexStrict2D,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    lower: bool = False,
+    check_finite: bool = True,
+) -> onp.Array2D[np.complex128]: ...
+@overload  # Nd ~complex128, +complex128
+def solveh_banded(
+    ab: _InputComplex,
+    b: onp.ToComplexND,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    lower: bool = False,
+    check_finite: bool = True,
+) -> onp.ArrayND[np.complex128]: ...
+@overload  # 1d +complex128, ~complex128
+def solveh_banded(
+    ab: onp.ToComplexStrict2D,
+    b: _InputComplexStrict1D,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    lower: bool = False,
+    check_finite: bool = True,
+) -> onp.Array1D[np.complex128]: ...
+@overload  # 2d +complex128, ~complex128
+def solveh_banded(
+    ab: onp.ToComplexStrict2D,
+    b: _InputComplexStrict2D,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    lower: bool = False,
+    check_finite: bool = True,
+) -> onp.Array2D[np.complex128]: ...
+@overload  # Nd +complex128, ~complex128
+def solveh_banded(
+    ab: onp.ToComplexND,
+    b: _InputComplex,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    lower: bool = False,
+    check_finite: bool = True,
+) -> onp.ArrayND[np.complex128]: ...
+@overload  # 1d +floating, +floating
 def solveh_banded(
     ab: onp.ToFloatStrict2D,
     b: onp.ToFloatStrict1D,
-    overwrite_ab: onp.ToBool = False,
-    overwrite_b: onp.ToBool = False,
-    lower: onp.ToBool = False,
-    check_finite: onp.ToBool = True,
-) -> _Float1D: ...
-@overload  # floating
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    lower: bool = False,
+    check_finite: bool = True,
+) -> onp.Array1D[np.float32 | np.float64]: ...
+@overload  # 2d +floating, +floating
+def solveh_banded(
+    ab: onp.ToFloatStrict2D,
+    b: onp.ToFloatStrict2D,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    lower: bool = False,
+    check_finite: bool = True,
+) -> onp.Array2D[np.float32 | np.float64]: ...
+@overload  # Nd +floating, +floating
 def solveh_banded(
     ab: onp.ToFloatND,
     b: onp.ToFloatND,
-    overwrite_ab: onp.ToBool = False,
-    overwrite_b: onp.ToBool = False,
-    lower: onp.ToBool = False,
-    check_finite: onp.ToBool = True,
-) -> _FloatND: ...
-@overload  # complexfloating 2d, 1d
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    lower: bool = False,
+    check_finite: bool = True,
+) -> onp.ArrayND[np.float32 | np.float64]: ...
+@overload  # 1d ~complexfloating, +complexfloating
+def solveh_banded(
+    ab: onp.ToJustComplexStrict2D,
+    b: onp.ToComplexStrict1D,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    lower: bool = False,
+    check_finite: bool = True,
+) -> onp.Array1D[np.complex64 | np.complex128]: ...
+@overload  # 2d ~complexfloating, +complexfloating
+def solveh_banded(
+    ab: onp.ToJustComplexStrict2D,
+    b: onp.ToComplexStrict2D,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    lower: bool = False,
+    check_finite: bool = True,
+) -> onp.Array2D[np.complex64 | np.complex128]: ...
+@overload  # Nd ~complexfloating, +complexfloating
+def solveh_banded(
+    ab: onp.ToJustComplexND,
+    b: onp.ToComplexND,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    lower: bool = False,
+    check_finite: bool = True,
+) -> onp.ArrayND[np.complex64 | np.complex128]: ...
+@overload  # 1d +complexfloating, ~complexfloating
+def solveh_banded(
+    ab: onp.ToComplexStrict2D,
+    b: onp.ToJustComplexStrict1D,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    lower: bool = False,
+    check_finite: bool = True,
+) -> onp.Array1D[np.complex64 | np.complex128]: ...
+@overload  # 2d +complexfloating, ~complexfloating
+def solveh_banded(
+    ab: onp.ToComplexStrict2D,
+    b: onp.ToJustComplexStrict2D,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    lower: bool = False,
+    check_finite: bool = True,
+) -> onp.Array2D[np.complex64 | np.complex128]: ...
+@overload  # Nd +complexfloating, ~complexfloating
+def solveh_banded(
+    ab: onp.ToComplexND,
+    b: onp.ToJustComplexND,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    lower: bool = False,
+    check_finite: bool = True,
+) -> onp.ArrayND[np.complex64 | np.complex128]: ...
+@overload  # 1d +complexfloating, +complexfloating
 def solveh_banded(
     ab: onp.ToComplexStrict2D,
     b: onp.ToComplexStrict1D,
-    overwrite_ab: onp.ToBool = False,
-    overwrite_b: onp.ToBool = False,
-    lower: onp.ToBool = False,
-    check_finite: onp.ToBool = True,
-) -> _Complex1D: ...
-@overload  # complexfloating
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    lower: bool = False,
+    check_finite: bool = True,
+) -> onp.Array1D[np.float32 | np.float64 | np.complex64 | np.complex128]: ...
+@overload  # 2d +complexfloating, +complexfloating
+def solveh_banded(
+    ab: onp.ToComplexStrict2D,
+    b: onp.ToComplexStrict2D,
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    lower: bool = False,
+    check_finite: bool = True,
+) -> onp.Array2D[np.float32 | np.float64 | np.complex64 | np.complex128]: ...
+@overload  # Nd +complexfloating, +complexfloating
 def solveh_banded(
     ab: onp.ToComplexND,
     b: onp.ToComplexND,
-    overwrite_ab: onp.ToBool = False,
-    overwrite_b: onp.ToBool = False,
-    lower: onp.ToBool = False,
-    check_finite: onp.ToBool = True,
-) -> _ComplexND: ...
+    overwrite_ab: bool = False,
+    overwrite_b: bool = False,
+    lower: bool = False,
+    check_finite: bool = True,
+) -> onp.ArrayND[np.float32 | np.float64 | np.complex64 | np.complex128]: ...
 
 #
-@overload  # floating 1d
+@overload  # 1d +float, +float
 def solve_toeplitz(
-    c_or_cr: onp.ToFloatStrict1D | _Tuple2[onp.ToFloatStrict1D], b: onp.ToFloat1D, check_finite: onp.ToBool = True
-) -> _Float1D: ...
-@overload  # floating
+    c_or_cr: _COrCR[onp.ToFloatStrict1D], b: onp.ToFloatStrict1D, check_finite: bool = True
+) -> onp.Array1D[np.float64]: ...
+@overload  # 2d +float, +float
 def solve_toeplitz(
-    c_or_cr: onp.ToFloatND | _Tuple2[onp.ToFloatND], b: onp.ToFloatND, check_finite: onp.ToBool = True
-) -> _FloatND: ...
-@overload  # complexfloating 1d
+    c_or_cr: _COrCR[onp.ToFloatStrict1D], b: onp.ToFloatStrict2D, check_finite: bool = True
+) -> onp.Array2D[np.float64]: ...
+@overload  # Nd +float, +float
+def solve_toeplitz(c_or_cr: _COrCR[onp.ToFloatND], b: onp.ToFloatND, check_finite: bool = True) -> onp.ArrayND[np.float64]: ...
+@overload  # 1d ~complex, +complex
 def solve_toeplitz(
-    c_or_cr: onp.ToComplexStrict1D | _Tuple2[onp.ToComplexStrict1D], b: onp.ToComplex1D, check_finite: onp.ToBool = True
-) -> _Complex1D: ...
-@overload  # complexfloating
+    c_or_cr: _COrCR[onp.ToJustComplexStrict1D], b: onp.ToComplexStrict1D, check_finite: bool = True
+) -> onp.Array1D[np.complex128]: ...
+@overload  # 2d ~complex, +complex
 def solve_toeplitz(
-    c_or_cr: onp.ToComplexND | _Tuple2[onp.ToComplexND], b: onp.ToComplexND, check_finite: onp.ToBool = True
-) -> _ComplexND: ...
+    c_or_cr: _COrCR[onp.ToJustComplexStrict1D], b: onp.ToComplexStrict2D, check_finite: bool = True
+) -> onp.Array2D[np.complex128]: ...
+@overload  # Nd ~complex, +complex
+def solve_toeplitz(
+    c_or_cr: _COrCR[onp.ToJustComplexND], b: onp.ToComplexND, check_finite: bool = True
+) -> onp.ArrayND[np.complex128]: ...
+@overload  # 1d +complex, ~complex
+def solve_toeplitz(
+    c_or_cr: _COrCR[onp.ToComplexStrict1D], b: onp.ToJustComplexStrict1D, check_finite: bool = True
+) -> onp.Array1D[np.complex128]: ...
+@overload  # 2d +complex, ~complex
+def solve_toeplitz(
+    c_or_cr: _COrCR[onp.ToComplexStrict1D], b: onp.ToJustComplexStrict2D, check_finite: bool = True
+) -> onp.Array2D[np.complex128]: ...
+@overload  # Nd +complex, ~complex
+def solve_toeplitz(
+    c_or_cr: _COrCR[onp.ToComplexND], b: onp.ToJustComplexND, check_finite: bool = True
+) -> onp.ArrayND[np.complex128]: ...
+@overload  # 1d +complex, +complex
+def solve_toeplitz(
+    c_or_cr: _COrCR[onp.ToComplexStrict1D], b: onp.ToComplexStrict1D, check_finite: bool = True
+) -> onp.Array1D[np.float64 | np.complex128]: ...
+@overload  # 2d +complex, +complex
+def solve_toeplitz(
+    c_or_cr: _COrCR[onp.ToComplexStrict1D], b: onp.ToComplexStrict2D, check_finite: bool = True
+) -> onp.Array2D[np.float64 | np.complex128]: ...
+@overload  # Nd +complex, +complex
+def solve_toeplitz(
+    c_or_cr: _COrCR[onp.ToComplexND], b: onp.ToComplexND, check_finite: bool = True
+) -> onp.ArrayND[np.float64 | np.complex128]: ...
 
 #
-@overload  # floating 2d, 2d
+@overload  # 1d ~float32, ~float32
 def solve_circulant(
-    c: onp.ToFloatStrict2D,
+    c: _InputF32Strict1D,
+    b: _InputF32Strict1D,
+    singular: _Singular = "raise",
+    tol: onp.ToFloat | None = None,
+    caxis: op.CanIndex = -1,
+    baxis: op.CanIndex = 0,
+    outaxis: op.CanIndex = 0,
+) -> onp.Array1D[np.float32]: ...
+@overload  # 2d ~float32, ~float32
+def solve_circulant(
+    c: _InputF32Strict1D,
+    b: _InputF32Strict2D,
+    singular: _Singular = "raise",
+    tol: onp.ToFloat | None = None,
+    caxis: op.CanIndex = -1,
+    baxis: op.CanIndex = 0,
+    outaxis: op.CanIndex = 0,
+) -> onp.Array2D[np.float32]: ...
+@overload  # Nd ~float32, ~float32
+def solve_circulant(
+    c: _InputF32,
+    b: _InputF32,
+    singular: _Singular = "raise",
+    tol: onp.ToFloat | None = None,
+    caxis: op.CanIndex = -1,
+    baxis: op.CanIndex = 0,
+    outaxis: op.CanIndex = 0,
+) -> onp.ArrayND[np.float32]: ...
+@overload  # 1D ~float64, +float64
+def solve_circulant(
+    c: _InputF64Strict1D,
+    b: onp.ToFloat64Strict1D,
+    singular: _Singular = "raise",
+    tol: onp.ToFloat | None = None,
+    caxis: op.CanIndex = -1,
+    baxis: op.CanIndex = 0,
+    outaxis: op.CanIndex = 0,
+) -> onp.Array1D[np.float64]: ...
+@overload  # 2D ~float64, +float64
+def solve_circulant(
+    c: _InputF64Strict1D,
+    b: onp.ToFloat64Strict2D,
+    singular: _Singular = "raise",
+    tol: onp.ToFloat | None = None,
+    caxis: op.CanIndex = -1,
+    baxis: op.CanIndex = 0,
+    outaxis: op.CanIndex = 0,
+) -> onp.Array2D[np.float64]: ...
+@overload  # Nd ~float64, +float64
+def solve_circulant(
+    c: _InputF64,
+    b: onp.ToFloat64_ND,
+    singular: _Singular = "raise",
+    tol: onp.ToFloat | None = None,
+    caxis: op.CanIndex = -1,
+    baxis: op.CanIndex = 0,
+    outaxis: op.CanIndex = 0,
+) -> onp.ArrayND[np.float64]: ...
+@overload  # 1d +float64, ~float64
+def solve_circulant(
+    c: onp.ToFloat64Strict1D,
+    b: _InputF64Strict1D,
+    singular: _Singular = "raise",
+    tol: onp.ToFloat | None = None,
+    caxis: op.CanIndex = -1,
+    baxis: op.CanIndex = 0,
+    outaxis: op.CanIndex = 0,
+) -> onp.Array1D[np.float64]: ...
+@overload  # 2d +float64, ~float64
+def solve_circulant(
+    c: onp.ToFloat64Strict1D,
+    b: _InputF64Strict2D,
+    singular: _Singular = "raise",
+    tol: onp.ToFloat | None = None,
+    caxis: op.CanIndex = -1,
+    baxis: op.CanIndex = 0,
+    outaxis: op.CanIndex = 0,
+) -> onp.Array2D[np.float64]: ...
+@overload  # Nd +float64, ~float64
+def solve_circulant(
+    c: onp.ToFloatND,
+    b: _InputF64,
+    singular: _Singular = "raise",
+    tol: onp.ToFloat | None = None,
+    caxis: op.CanIndex = -1,
+    baxis: op.CanIndex = 0,
+    outaxis: op.CanIndex = 0,
+) -> onp.ArrayND[np.float64]: ...
+@overload  # 1d ~complex64, +complex64
+def solve_circulant(
+    c: _InputC64Strict1D,
+    b: _InputC64Strict1D | _InputF32Strict1D,
+    singular: _Singular = "raise",
+    tol: onp.ToFloat | None = None,
+    caxis: op.CanIndex = -1,
+    baxis: op.CanIndex = 0,
+    outaxis: op.CanIndex = 0,
+) -> onp.Array1D[np.complex64]: ...
+@overload  # 2d ~complex64, +complex64
+def solve_circulant(
+    c: _InputC64Strict1D,
+    b: _CoInputC64Strict2D,
+    singular: _Singular = "raise",
+    tol: onp.ToFloat | None = None,
+    caxis: op.CanIndex = -1,
+    baxis: op.CanIndex = 0,
+    outaxis: op.CanIndex = 0,
+) -> onp.Array2D[np.complex64]: ...
+@overload  # Nd ~complex64, +complex64
+def solve_circulant(
+    c: _InputC64,
+    b: _CoInputC64,
+    singular: _Singular = "raise",
+    tol: onp.ToFloat | None = None,
+    caxis: op.CanIndex = -1,
+    baxis: op.CanIndex = 0,
+    outaxis: op.CanIndex = 0,
+) -> onp.ArrayND[np.complex64]: ...
+@overload  # 1d +complex64, ~complex64
+def solve_circulant(
+    c: _CoInputC64Strict1D,
+    b: _InputC64Strict1D,
+    singular: _Singular = "raise",
+    tol: onp.ToFloat | None = None,
+    caxis: op.CanIndex = -1,
+    baxis: op.CanIndex = 0,
+    outaxis: op.CanIndex = 0,
+) -> onp.Array1D[np.complex64]: ...
+@overload  # 2d +complex64, ~complex64
+def solve_circulant(
+    c: _CoInputC64Strict1D,
+    b: _InputC64Strict2D,
+    singular: _Singular = "raise",
+    tol: onp.ToFloat | None = None,
+    caxis: op.CanIndex = -1,
+    baxis: op.CanIndex = 0,
+    outaxis: op.CanIndex = 0,
+) -> onp.Array2D[np.complex64]: ...
+@overload  # Nd +complex64, ~complex64
+def solve_circulant(
+    c: _CoInputC64,
+    b: _InputC64,
+    singular: _Singular = "raise",
+    tol: onp.ToFloat | None = None,
+    caxis: op.CanIndex = -1,
+    baxis: op.CanIndex = 0,
+    outaxis: op.CanIndex = 0,
+) -> onp.ArrayND[np.complex64]: ...
+@overload  # 1d ~complex128, +complex128
+def solve_circulant(
+    c: onp.ToJustComplex128Strict1D,
+    b: onp.ToComplex128Strict1D,
+    singular: _Singular = "raise",
+    tol: onp.ToFloat | None = None,
+    caxis: op.CanIndex = -1,
+    baxis: op.CanIndex = 0,
+    outaxis: op.CanIndex = 0,
+) -> onp.Array1D[np.complex128]: ...
+@overload  # 2d ~complex128, +complex128
+def solve_circulant(
+    c: onp.ToJustComplex128Strict1D,
+    b: onp.ToComplex128Strict2D,
+    singular: _Singular = "raise",
+    tol: onp.ToFloat | None = None,
+    caxis: op.CanIndex = -1,
+    baxis: op.CanIndex = 0,
+    outaxis: op.CanIndex = 0,
+) -> onp.Array2D[np.complex128]: ...
+@overload  # Nd ~complex128, +complex128
+def solve_circulant(
+    c: onp.ToJustComplex128_ND,
+    b: onp.ToComplex128_ND,
+    singular: _Singular = "raise",
+    tol: onp.ToFloat | None = None,
+    caxis: op.CanIndex = -1,
+    baxis: op.CanIndex = 0,
+    outaxis: op.CanIndex = 0,
+) -> onp.ArrayND[np.complex128]: ...
+@overload  # 1d +complex128, ~complex128
+def solve_circulant(
+    c: onp.ToComplex128Strict1D,
+    b: onp.ToJustComplex128Strict1D,
+    singular: _Singular = "raise",
+    tol: onp.ToFloat | None = None,
+    caxis: op.CanIndex = -1,
+    baxis: op.CanIndex = 0,
+    outaxis: op.CanIndex = 0,
+) -> onp.Array1D[np.complex128]: ...
+@overload  # 2d +complex128, ~complex128
+def solve_circulant(
+    c: onp.ToComplex128Strict1D,
+    b: onp.ToJustComplex128Strict2D,
+    singular: _Singular = "raise",
+    tol: onp.ToFloat | None = None,
+    caxis: op.CanIndex = -1,
+    baxis: op.CanIndex = 0,
+    outaxis: op.CanIndex = 0,
+) -> onp.Array2D[np.complex128]: ...
+@overload  # Nd +complex128, ~complex128
+def solve_circulant(
+    c: onp.ToComplex128_ND,
+    b: onp.ToJustComplex128_ND,
+    singular: _Singular = "raise",
+    tol: onp.ToFloat | None = None,
+    caxis: op.CanIndex = -1,
+    baxis: op.CanIndex = 0,
+    outaxis: op.CanIndex = 0,
+) -> onp.ArrayND[np.complex128]: ...
+@overload  # 1d +floating, +floating
+def solve_circulant(
+    c: onp.ToFloatStrict1D,
+    b: onp.ToFloatStrict1D,
+    singular: _Singular = "raise",
+    tol: onp.ToFloat | None = None,
+    caxis: op.CanIndex = -1,
+    baxis: op.CanIndex = 0,
+    outaxis: op.CanIndex = 0,
+) -> onp.Array1D[npc.floating]: ...
+@overload  # 2d +floating, +floating
+def solve_circulant(
+    c: onp.ToFloatStrict1D,
     b: onp.ToFloatStrict2D,
     singular: _Singular = "raise",
     tol: onp.ToFloat | None = None,
     caxis: op.CanIndex = -1,
     baxis: op.CanIndex = 0,
     outaxis: op.CanIndex = 0,
-) -> _Float1D: ...
-@overload  # floating
+) -> onp.Array2D[npc.floating]: ...
+@overload  # Nd +floating, +floating
 def solve_circulant(
     c: onp.ToFloatND,
     b: onp.ToFloatND,
@@ -255,18 +1546,88 @@ def solve_circulant(
     caxis: op.CanIndex = -1,
     baxis: op.CanIndex = 0,
     outaxis: op.CanIndex = 0,
-) -> _FloatND: ...
-@overload  # complexfloating 2d, 2d
+) -> onp.ArrayND[npc.floating]: ...
+@overload  # 1d ~complexfloating, +complexfloating
 def solve_circulant(
-    c: onp.ToComplexStrict2D,
+    c: onp.ToJustComplexStrict1D,
+    b: onp.ToComplexStrict1D,
+    singular: _Singular = "raise",
+    tol: onp.ToFloat | None = None,
+    caxis: op.CanIndex = -1,
+    baxis: op.CanIndex = 0,
+    outaxis: op.CanIndex = 0,
+) -> onp.Array1D[npc.complexfloating]: ...
+@overload  # 2d ~complexfloating, +complexfloating
+def solve_circulant(
+    c: onp.ToJustComplexStrict1D,
     b: onp.ToComplexStrict2D,
     singular: _Singular = "raise",
     tol: onp.ToFloat | None = None,
     caxis: op.CanIndex = -1,
     baxis: op.CanIndex = 0,
     outaxis: op.CanIndex = 0,
-) -> _Complex1D: ...
-@overload  # complexfloating
+) -> onp.Array2D[npc.complexfloating]: ...
+@overload  # Nd ~complexfloating, +complexfloating
+def solve_circulant(
+    c: onp.ToJustComplexND,
+    b: onp.ToComplexND,
+    singular: _Singular = "raise",
+    tol: onp.ToFloat | None = None,
+    caxis: op.CanIndex = -1,
+    baxis: op.CanIndex = 0,
+    outaxis: op.CanIndex = 0,
+) -> onp.ArrayND[npc.complexfloating]: ...
+@overload  # 1d +complexfloating, ~complexfloating
+def solve_circulant(
+    c: onp.ToComplexStrict1D,
+    b: onp.ToJustComplexStrict1D,
+    singular: _Singular = "raise",
+    tol: onp.ToFloat | None = None,
+    caxis: op.CanIndex = -1,
+    baxis: op.CanIndex = 0,
+    outaxis: op.CanIndex = 0,
+) -> onp.Array1D[npc.complexfloating]: ...
+@overload  # 2d +complexfloating, ~complexfloating
+def solve_circulant(
+    c: onp.ToComplexStrict1D,
+    b: onp.ToJustComplexStrict2D,
+    singular: _Singular = "raise",
+    tol: onp.ToFloat | None = None,
+    caxis: op.CanIndex = -1,
+    baxis: op.CanIndex = 0,
+    outaxis: op.CanIndex = 0,
+) -> onp.Array2D[npc.complexfloating]: ...
+@overload  # Nd +complexfloating, ~complexfloating
+def solve_circulant(
+    c: onp.ToComplexND,
+    b: onp.ToJustComplexND,
+    singular: _Singular = "raise",
+    tol: onp.ToFloat | None = None,
+    caxis: op.CanIndex = -1,
+    baxis: op.CanIndex = 0,
+    outaxis: op.CanIndex = 0,
+) -> onp.ArrayND[npc.complexfloating]: ...
+@overload  # 1d +complexfloating, +complexfloating
+def solve_circulant(
+    c: onp.ToComplexStrict1D,
+    b: onp.ToComplexStrict1D,
+    singular: _Singular = "raise",
+    tol: onp.ToFloat | None = None,
+    caxis: op.CanIndex = -1,
+    baxis: op.CanIndex = 0,
+    outaxis: op.CanIndex = 0,
+) -> onp.Array1D[npc.inexact]: ...
+@overload  # 2d +complexfloating, +complexfloating
+def solve_circulant(
+    c: onp.ToComplexStrict1D,
+    b: onp.ToComplexStrict2D,
+    singular: _Singular = "raise",
+    tol: onp.ToFloat | None = None,
+    caxis: op.CanIndex = -1,
+    baxis: op.CanIndex = 0,
+    outaxis: op.CanIndex = 0,
+) -> onp.Array2D[npc.inexact]: ...
+@overload  # Nd +complexfloating, +complexfloating
 def solve_circulant(
     c: onp.ToComplexND,
     b: onp.ToComplexND,
@@ -275,41 +1636,41 @@ def solve_circulant(
     caxis: op.CanIndex = -1,
     baxis: op.CanIndex = 0,
     outaxis: op.CanIndex = 0,
-) -> _ComplexND: ...
+) -> onp.ArrayND[npc.inexact]: ...
 
-#
+# TODO(jorenham): improve this
 @overload  # floating 2d
-def inv(a: onp.ToFloatStrict2D, overwrite_a: onp.ToBool = False, check_finite: onp.ToBool = True) -> _Float2D: ...
+def inv(a: onp.ToFloatStrict2D, overwrite_a: bool = False, check_finite: bool = True) -> _Float2D: ...
 @overload  # floating
-def inv(a: onp.ToFloatND, overwrite_a: onp.ToBool = False, check_finite: onp.ToBool = True) -> _FloatND: ...
+def inv(a: onp.ToFloatND, overwrite_a: bool = False, check_finite: bool = True) -> _FloatND: ...
 @overload  # complexfloating 2d
-def inv(a: onp.ToComplexStrict2D, overwrite_a: onp.ToBool = False, check_finite: onp.ToBool = True) -> _Complex2D: ...
+def inv(a: onp.ToComplexStrict2D, overwrite_a: bool = False, check_finite: bool = True) -> _Complex2D: ...
 @overload  # complexfloating
-def inv(a: onp.ToComplexND, overwrite_a: onp.ToBool = False, check_finite: onp.ToBool = True) -> _ComplexND: ...
+def inv(a: onp.ToComplexND, overwrite_a: bool = False, check_finite: bool = True) -> _ComplexND: ...
 
-#
+# TODO(jorenham): improve this
 @overload  # floating 2d
-def det(a: onp.ToFloatStrict2D, overwrite_a: onp.ToBool = False, check_finite: onp.ToBool = True) -> _Float: ...
+def det(a: onp.ToFloatStrict2D, overwrite_a: bool = False, check_finite: bool = True) -> _Float: ...
 @overload  # floating 3d
-def det(a: onp.ToFloatStrict3D, overwrite_a: onp.ToBool = False, check_finite: onp.ToBool = True) -> _Float1D: ...
+def det(a: onp.ToFloatStrict3D, overwrite_a: bool = False, check_finite: bool = True) -> _Float1D: ...
 @overload  # floating
-def det(a: onp.ToFloatND, overwrite_a: onp.ToBool = False, check_finite: onp.ToBool = True) -> _Float | _FloatND: ...
+def det(a: onp.ToFloatND, overwrite_a: bool = False, check_finite: bool = True) -> _Float | _FloatND: ...
 @overload  # complexfloating 2d
-def det(a: onp.ToJustComplexStrict2D, overwrite_a: onp.ToBool = False, check_finite: onp.ToBool = True) -> _Complex1D: ...
+def det(a: onp.ToJustComplexStrict2D, overwrite_a: bool = False, check_finite: bool = True) -> _Complex1D: ...
 @overload  # complexfloating 3d
-def det(a: onp.ToJustComplexStrict3D, overwrite_a: onp.ToBool = False, check_finite: onp.ToBool = True) -> _ComplexND: ...
+def det(a: onp.ToJustComplexStrict3D, overwrite_a: bool = False, check_finite: bool = True) -> _ComplexND: ...
 @overload  # complexfloating
-def det(a: onp.ToComplexND, overwrite_a: onp.ToBool = False, check_finite: onp.ToBool = True) -> _Complex | _ComplexND: ...
+def det(a: onp.ToComplexND, overwrite_a: bool = False, check_finite: bool = True) -> _Complex | _ComplexND: ...
 
-#
+# TODO(jorenham): improve this
 @overload  # (float[:, :], float[:]) -> (float[:], float[], ...)
 def lstsq(
     a: onp.ToFloatStrict2D,
     b: onp.ToFloatStrict1D,
     cond: onp.ToFloat | None = None,
-    overwrite_a: onp.ToBool = False,
-    overwrite_b: onp.ToBool = False,
-    check_finite: onp.ToBool = True,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
     lapack_driver: _LapackDriver | None = None,
 ) -> tuple[_Float1D, _Float0D, int, _Float1D | None]: ...
 @overload  # (float[:, :], float[:, :]) -> (float[:, :], float[:], ...)
@@ -317,9 +1678,9 @@ def lstsq(
     a: onp.ToFloatND,
     b: onp.ToFloatStrict2D,
     cond: onp.ToFloat | None = None,
-    overwrite_a: onp.ToBool = False,
-    overwrite_b: onp.ToBool = False,
-    check_finite: onp.ToBool = True,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
     lapack_driver: _LapackDriver | None = None,
 ) -> tuple[_FloatND, _FloatND, int, _FloatND | None]: ...
 @overload  # (float[:, :], float[:, :?]) -> (float[:, :?], float[:?], ...)
@@ -327,9 +1688,9 @@ def lstsq(
     a: onp.ToFloatND,
     b: onp.ToFloatND,
     cond: onp.ToFloat | None = None,
-    overwrite_a: onp.ToBool = False,
-    overwrite_b: onp.ToBool = False,
-    check_finite: onp.ToBool = True,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
     lapack_driver: _LapackDriver | None = None,
 ) -> tuple[_FloatND, _Float0D | _FloatND, int, _FloatND | None]: ...
 @overload  # (complex[:, :], complex[:, :?]) -> (complex[:, :?], complex[:?], ...)
@@ -337,13 +1698,13 @@ def lstsq(
     a: onp.ToComplexND,
     b: onp.ToComplexND,
     cond: onp.ToFloat | None = None,
-    overwrite_a: onp.ToBool = False,
-    overwrite_b: onp.ToBool = False,
-    check_finite: onp.ToBool = True,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
     lapack_driver: _LapackDriver | None = None,
 ) -> tuple[_ComplexND, _Complex0D | _ComplexND, int, _ComplexND | None]: ...
 
-#
+# TODO(jorenham): improve this
 @overload
 def pinv(  # (float[:, :], return_rank=False) -> float[:, :]
     a: onp.ToFloatND,
@@ -351,7 +1712,7 @@ def pinv(  # (float[:, :], return_rank=False) -> float[:, :]
     atol: onp.ToFloat | None = None,
     rtol: onp.ToFloat | None = None,
     return_rank: onp.ToFalse = False,
-    check_finite: onp.ToBool = True,
+    check_finite: bool = True,
 ) -> _FloatND: ...
 @overload  # (float[:, :], return_rank=True) -> (float[:, :], int)
 def pinv(
@@ -360,7 +1721,7 @@ def pinv(
     atol: onp.ToFloat | None = None,
     rtol: onp.ToFloat | None = None,
     return_rank: onp.ToTrue,
-    check_finite: onp.ToBool = True,
+    check_finite: bool = True,
 ) -> tuple[_FloatND, int]: ...
 @overload  # (complex[:, :], return_rank=False) -> complex[:, :]
 def pinv(
@@ -369,7 +1730,7 @@ def pinv(
     atol: onp.ToFloat | None = None,
     rtol: onp.ToFloat | None = None,
     return_rank: onp.ToFalse = False,
-    check_finite: onp.ToBool = True,
+    check_finite: bool = True,
 ) -> _ComplexND: ...
 @overload  # (complex[:, :], return_rank=True) -> (complex[:, :], int)
 def pinv(
@@ -378,88 +1739,83 @@ def pinv(
     atol: onp.ToFloat | None = None,
     rtol: onp.ToFloat | None = None,
     return_rank: onp.ToTrue,
-    check_finite: onp.ToBool = True,
+    check_finite: bool = True,
 ) -> tuple[_ComplexND, int]: ...
 
-#
+# TODO(jorenham): improve this
 @overload  # (float[:, :], return_rank=False) -> float[:, :]
 def pinvh(
     a: onp.ToFloatND,
     atol: onp.ToFloat | None = None,
     rtol: onp.ToFloat | None = None,
-    lower: onp.ToBool = True,
+    lower: bool = True,
     return_rank: onp.ToFalse = False,
-    check_finite: onp.ToBool = True,
+    check_finite: bool = True,
 ) -> _FloatND: ...
 @overload  # (float[:, :], return_rank=True, /) -> (float[:, :], int)
 def pinvh(
     a: onp.ToFloatND,
     atol: onp.ToFloat | None,
     rtol: onp.ToFloat | None,
-    lower: onp.ToBool,
+    lower: bool,
     return_rank: onp.ToTrue,
-    check_finite: onp.ToBool = True,
+    check_finite: bool = True,
 ) -> tuple[_FloatND, int]: ...
 @overload  # (float[:, :], *, return_rank=True) -> (float[:, :], int)
 def pinvh(
     a: onp.ToFloatND,
     atol: onp.ToFloat | None = None,
     rtol: onp.ToFloat | None = None,
-    lower: onp.ToBool = True,
+    lower: bool = True,
     *,
     return_rank: onp.ToTrue,
-    check_finite: onp.ToBool = True,
+    check_finite: bool = True,
 ) -> tuple[_FloatND, int]: ...
 @overload  # (complex[:, :], return_rank=False) -> complex[:, :]
 def pinvh(
     a: onp.ToComplexND,
     atol: onp.ToFloat | None = None,
     rtol: onp.ToFloat | None = None,
-    lower: onp.ToBool = True,
+    lower: bool = True,
     return_rank: onp.ToFalse = False,
-    check_finite: onp.ToBool = True,
+    check_finite: bool = True,
 ) -> _ComplexND: ...
 @overload  # (complex[:, :], return_rank=True, /) -> (complex[:, :], int)
 def pinvh(
     a: onp.ToComplexND,
     atol: onp.ToFloat | None,
     rtol: onp.ToFloat | None,
-    lower: onp.ToBool,
+    lower: bool,
     return_rank: onp.ToTrue,
-    check_finite: onp.ToBool = True,
+    check_finite: bool = True,
 ) -> tuple[_ComplexND, int]: ...
 @overload  # (complex[:, :], *, return_rank=True) -> (complex[:, :], int)
 def pinvh(
     a: onp.ToComplexND,
     atol: onp.ToFloat | None = None,
     rtol: onp.ToFloat | None = None,
-    lower: onp.ToBool = True,
+    lower: bool = True,
     *,
     return_rank: onp.ToTrue,
-    check_finite: onp.ToBool = True,
+    check_finite: bool = True,
 ) -> tuple[_ComplexND, int]: ...
 
-#
+# TODO(jorenham): improve this
 @overload  # (float[:, :], separate=True) -> (float[:, :], float[:, :])
 def matrix_balance(
     A: onp.ToFloatND,
     permute: onp.ToBool = True,
     scale: onp.ToBool = True,
     separate: onp.ToFalse = False,
-    overwrite_a: onp.ToBool = False,
+    overwrite_a: bool = False,
 ) -> _Tuple2[_FloatND]: ...
 @overload  # (float[:, :], separate=False, /) -> (float[:, :], (float[:], float[:]))
 def matrix_balance(
-    A: onp.ToFloatND, permute: onp.ToBool, scale: onp.ToBool, separate: onp.ToTrue, overwrite_a: onp.ToBool = False
+    A: onp.ToFloatND, permute: onp.ToBool, scale: onp.ToBool, separate: onp.ToTrue, overwrite_a: bool = False
 ) -> tuple[_FloatND, _Tuple2[_FloatND]]: ...
 @overload  # (float[:, :], *, separate=False) -> (float[:, :], (float[:], float[:]))
 def matrix_balance(
-    A: onp.ToFloatND,
-    permute: onp.ToBool = True,
-    scale: onp.ToBool = True,
-    *,
-    separate: onp.ToTrue,
-    overwrite_a: onp.ToBool = False,
+    A: onp.ToFloatND, permute: onp.ToBool = True, scale: onp.ToBool = True, *, separate: onp.ToTrue, overwrite_a: bool = False
 ) -> tuple[_FloatND, _Tuple2[_FloatND]]: ...
 @overload  # (complex[:, :], separate=True) -> (complex[:, :], complex[:, :])
 def matrix_balance(
@@ -467,48 +1823,43 @@ def matrix_balance(
     permute: onp.ToBool = True,
     scale: onp.ToBool = True,
     separate: onp.ToFalse = False,
-    overwrite_a: onp.ToBool = False,
+    overwrite_a: bool = False,
 ) -> _Tuple2[_ComplexND]: ...
 @overload  # (complex[:, :], separate=False, /) -> (complex[:, :], (complex[:], complex[:]))
 def matrix_balance(
-    A: onp.ToComplexND, permute: onp.ToBool, scale: onp.ToBool, separate: onp.ToTrue, overwrite_a: onp.ToBool = False
+    A: onp.ToComplexND, permute: onp.ToBool, scale: onp.ToBool, separate: onp.ToTrue, overwrite_a: bool = False
 ) -> tuple[_ComplexND, _Tuple2[_ComplexND]]: ...
 @overload  # (complex[:, :], *, separate=False) -> (complex[:, :], (complex[:], complex[:]))
 def matrix_balance(
-    A: onp.ToComplexND,
-    permute: onp.ToBool = True,
-    scale: onp.ToBool = True,
-    *,
-    separate: onp.ToTrue,
-    overwrite_a: onp.ToBool = False,
+    A: onp.ToComplexND, permute: onp.ToBool = True, scale: onp.ToBool = True, *, separate: onp.ToTrue, overwrite_a: bool = False
 ) -> tuple[_ComplexND, _Tuple2[_ComplexND]]: ...
 
-#
+# TODO(jorenham): improve this
 @overload  # floating 1d, 1d
 def matmul_toeplitz(
     c_or_cr: onp.ToFloatStrict1D | _Tuple2[onp.ToFloatStrict1D],
     x: onp.ToFloatStrict1D,
-    check_finite: onp.ToBool = False,
+    check_finite: bool = False,
     workers: onp.ToJustInt | None = None,
 ) -> _Float1D: ...
 @overload  # floating
 def matmul_toeplitz(
     c_or_cr: onp.ToFloatND | _Tuple2[onp.ToFloatND],
     x: onp.ToFloatND,
-    check_finite: onp.ToBool = False,
+    check_finite: bool = False,
     workers: onp.ToJustInt | None = None,
 ) -> _FloatND: ...
 @overload  # complexfloating 1d, 1d
 def matmul_toeplitz(
     c_or_cr: onp.ToComplexStrict1D | _Tuple2[onp.ToComplexStrict1D],
     x: onp.ToComplexStrict1D,
-    check_finite: onp.ToBool = False,
+    check_finite: bool = False,
     workers: onp.ToJustInt | None = None,
 ) -> _Complex1D: ...
 @overload  # complexfloating
 def matmul_toeplitz(
     c_or_cr: onp.ToComplexND | _Tuple2[onp.ToComplexND],
     x: onp.ToComplexND,
-    check_finite: onp.ToBool = False,
+    check_finite: bool = False,
     workers: onp.ToJustInt | None = None,
 ) -> _ComplexND: ...

--- a/tests/linalg/test__basic.pyi
+++ b/tests/linalg/test__basic.pyi
@@ -6,7 +6,7 @@ import numpy as np
 import optype.numpy as onp
 import optype.numpy.compat as npc
 
-from scipy.linalg import solve, solve_banded, solve_circulant, solve_toeplitz, solve_triangular, solveh_banded
+from scipy.linalg import solve, solve_banded, solve_circulant, solve_toeplitz, solve_triangular
 
 i8_1d: onp.Array1D[np.int8]
 i8_2d: onp.Array2D[np.int8]
@@ -56,15 +56,15 @@ assert_type(solve(i8_2d, i8_2d), onp.Array2D[np.float64])
 assert_type(solve(i8_2d, i8_3d), onp.ArrayND[np.float64])
 assert_type(solve(i8_3d, i8_1d), onp.ArrayND[np.float64])
 
-assert_type(solve(f16_2d, f16_1d), onp.Array2D[np.float32])
-assert_type(solve(f16_2d, f16_2d), onp.Array2D[np.float32])
-assert_type(solve(f16_2d, f16_3d), onp.ArrayND[np.float32])
-assert_type(solve(f16_3d, f16_1d), onp.ArrayND[np.float32])
+assert_type(solve(f16_2d, f16_1d), onp.Array2D[np.float32 | np.float64])
+assert_type(solve(f16_2d, f16_2d), onp.Array2D[np.float32 | np.float64])
+assert_type(solve(f16_2d, f16_3d), onp.ArrayND[np.float32 | np.float64])
+assert_type(solve(f16_3d, f16_1d), onp.ArrayND[np.float32 | np.float64])
 
-assert_type(solve(f32_2d, f32_1d), onp.Array2D[np.float32])
-assert_type(solve(f32_2d, f32_2d), onp.Array2D[np.float32])
-assert_type(solve(f32_2d, f32_3d), onp.ArrayND[np.float32])
-assert_type(solve(f32_3d, f32_1d), onp.ArrayND[np.float32])
+assert_type(solve(f32_2d, f32_1d), onp.Array2D[np.float32 | np.float64])
+assert_type(solve(f32_2d, f32_2d), onp.Array2D[np.float32 | np.float64])
+assert_type(solve(f32_2d, f32_3d), onp.ArrayND[np.float32 | np.float64])
+assert_type(solve(f32_3d, f32_1d), onp.ArrayND[np.float32 | np.float64])
 
 assert_type(solve(f64_2d, f64_1d), onp.Array2D[np.float64])
 assert_type(solve(f64_2d, f64_2d), onp.Array2D[np.float64])
@@ -76,10 +76,10 @@ assert_type(solve(f80_2d, f80_2d), onp.Array2D[np.float64])
 assert_type(solve(f80_2d, f80_3d), onp.ArrayND[np.float64])
 assert_type(solve(f80_3d, f80_1d), onp.ArrayND[np.float64])
 
-assert_type(solve(c64_2d, c64_1d), onp.Array2D[np.complex64])
-assert_type(solve(c64_2d, c64_2d), onp.Array2D[np.complex64])
-assert_type(solve(c64_2d, c64_3d), onp.ArrayND[np.complex64])
-assert_type(solve(c64_3d, c64_1d), onp.ArrayND[np.complex64])
+assert_type(solve(c64_2d, c64_1d), onp.Array2D[np.complex64 | np.complex128])
+assert_type(solve(c64_2d, c64_2d), onp.Array2D[np.complex64 | np.complex128])
+assert_type(solve(c64_2d, c64_3d), onp.ArrayND[np.complex64 | np.complex128])
+assert_type(solve(c64_3d, c64_1d), onp.ArrayND[np.complex64 | np.complex128])
 
 assert_type(solve(c128_2d, c128_1d), onp.Array2D[np.complex128])
 assert_type(solve(c128_2d, c128_2d), onp.Array2D[np.complex128])
@@ -109,15 +109,15 @@ assert_type(solve_triangular(i8_2d, i8_2d), onp.Array2D[np.float64])
 assert_type(solve_triangular(i8_2d, i8_3d), onp.ArrayND[np.float64])
 assert_type(solve_triangular(i8_3d, i8_1d), onp.ArrayND[np.float64])
 
-assert_type(solve_triangular(f16_2d, f16_1d), onp.Array1D[np.float32])
-assert_type(solve_triangular(f16_2d, f16_2d), onp.Array2D[np.float32])
-assert_type(solve_triangular(f16_2d, f16_3d), onp.ArrayND[np.float32])
-assert_type(solve_triangular(f16_3d, f16_1d), onp.ArrayND[np.float32])
+assert_type(solve_triangular(f16_2d, f16_1d), onp.Array1D[np.float32 | np.float64])
+assert_type(solve_triangular(f16_2d, f16_2d), onp.Array2D[np.float32 | np.float64])
+assert_type(solve_triangular(f16_2d, f16_3d), onp.ArrayND[np.float32 | np.float64])
+assert_type(solve_triangular(f16_3d, f16_1d), onp.ArrayND[np.float32 | np.float64])
 
-assert_type(solve_triangular(f32_2d, f32_1d), onp.Array1D[np.float32])
-assert_type(solve_triangular(f32_2d, f32_2d), onp.Array2D[np.float32])
-assert_type(solve_triangular(f32_2d, f32_3d), onp.ArrayND[np.float32])
-assert_type(solve_triangular(f32_3d, f32_1d), onp.ArrayND[np.float32])
+assert_type(solve_triangular(f32_2d, f32_1d), onp.Array1D[np.float32 | np.float64])
+assert_type(solve_triangular(f32_2d, f32_2d), onp.Array2D[np.float32 | np.float64])
+assert_type(solve_triangular(f32_2d, f32_3d), onp.ArrayND[np.float32 | np.float64])
+assert_type(solve_triangular(f32_3d, f32_1d), onp.ArrayND[np.float32 | np.float64])
 
 assert_type(solve_triangular(f64_2d, f64_1d), onp.Array1D[np.float64])
 assert_type(solve_triangular(f64_2d, f64_2d), onp.Array2D[np.float64])
@@ -129,10 +129,10 @@ assert_type(solve_triangular(f80_2d, f80_2d), onp.Array2D[np.float64])
 assert_type(solve_triangular(f80_2d, f80_3d), onp.ArrayND[np.float64])
 assert_type(solve_triangular(f80_3d, f80_1d), onp.ArrayND[np.float64])
 
-assert_type(solve_triangular(c64_2d, c64_1d), onp.Array1D[np.complex64])
-assert_type(solve_triangular(c64_2d, c64_2d), onp.Array2D[np.complex64])
-assert_type(solve_triangular(c64_2d, c64_3d), onp.ArrayND[np.complex64])
-assert_type(solve_triangular(c64_3d, c64_1d), onp.ArrayND[np.complex64])
+assert_type(solve_triangular(c64_2d, c64_1d), onp.Array1D[np.complex64 | np.complex128])
+assert_type(solve_triangular(c64_2d, c64_2d), onp.Array2D[np.complex64 | np.complex128])
+assert_type(solve_triangular(c64_2d, c64_3d), onp.ArrayND[np.complex64 | np.complex128])
+assert_type(solve_triangular(c64_3d, c64_1d), onp.ArrayND[np.complex64 | np.complex128])
 
 assert_type(solve_triangular(c128_2d, c128_1d), onp.Array1D[np.complex128])
 assert_type(solve_triangular(c128_2d, c128_2d), onp.Array2D[np.complex128])
@@ -155,22 +155,22 @@ assert_type(solve_triangular(py_c_2d, py_c_3d), onp.ArrayND[np.complex128])
 assert_type(solve_triangular(py_c_3d, py_c_1d), onp.ArrayND[np.complex128])
 
 ###
-# solve_banded
+# solve_banded  (equivalent overload structure to `solveh_banded`)
 
 assert_type(solve_banded((1, 2), i8_2d, i8_1d), onp.Array1D[np.float64])
 assert_type(solve_banded((1, 2), i8_2d, i8_2d), onp.Array2D[np.float64])
 assert_type(solve_banded((1, 2), i8_2d, i8_3d), onp.ArrayND[np.float64])
 assert_type(solve_banded((1, 2), i8_3d, i8_1d), onp.ArrayND[np.float64])
 
-assert_type(solve_banded((1, 2), f16_2d, f16_1d), onp.Array1D[np.float32])
-assert_type(solve_banded((1, 2), f16_2d, f16_2d), onp.Array2D[np.float32])
-assert_type(solve_banded((1, 2), f16_2d, f16_3d), onp.ArrayND[np.float32])
-assert_type(solve_banded((1, 2), f16_3d, f16_1d), onp.ArrayND[np.float32])
+assert_type(solve_banded((1, 2), f16_2d, f16_1d), onp.Array1D[np.float32 | np.float64])
+assert_type(solve_banded((1, 2), f16_2d, f16_2d), onp.Array2D[np.float32 | np.float64])
+assert_type(solve_banded((1, 2), f16_2d, f16_3d), onp.ArrayND[np.float32 | np.float64])
+assert_type(solve_banded((1, 2), f16_3d, f16_1d), onp.ArrayND[np.float32 | np.float64])
 
-assert_type(solve_banded((1, 2), f32_2d, f32_1d), onp.Array1D[np.float32])
-assert_type(solve_banded((1, 2), f32_2d, f32_2d), onp.Array2D[np.float32])
-assert_type(solve_banded((1, 2), f32_2d, f32_3d), onp.ArrayND[np.float32])
-assert_type(solve_banded((1, 2), f32_3d, f32_1d), onp.ArrayND[np.float32])
+assert_type(solve_banded((1, 2), f32_2d, f32_1d), onp.Array1D[np.float32 | np.float64])
+assert_type(solve_banded((1, 2), f32_2d, f32_2d), onp.Array2D[np.float32 | np.float64])
+assert_type(solve_banded((1, 2), f32_2d, f32_3d), onp.ArrayND[np.float32 | np.float64])
+assert_type(solve_banded((1, 2), f32_3d, f32_1d), onp.ArrayND[np.float32 | np.float64])
 
 assert_type(solve_banded((1, 2), f64_2d, f64_1d), onp.Array1D[np.float64])
 assert_type(solve_banded((1, 2), f64_2d, f64_2d), onp.Array2D[np.float64])
@@ -182,10 +182,10 @@ assert_type(solve_banded((1, 2), f80_2d, f80_2d), onp.Array2D[np.float64])
 assert_type(solve_banded((1, 2), f80_2d, f80_3d), onp.ArrayND[np.float64])
 assert_type(solve_banded((1, 2), f80_3d, f80_1d), onp.ArrayND[np.float64])
 
-assert_type(solve_banded((1, 2), c64_2d, c64_1d), onp.Array1D[np.complex64])
-assert_type(solve_banded((1, 2), c64_2d, c64_2d), onp.Array2D[np.complex64])
-assert_type(solve_banded((1, 2), c64_2d, c64_3d), onp.ArrayND[np.complex64])
-assert_type(solve_banded((1, 2), c64_3d, c64_1d), onp.ArrayND[np.complex64])
+assert_type(solve_banded((1, 2), c64_2d, c64_1d), onp.Array1D[np.complex64 | np.complex128])
+assert_type(solve_banded((1, 2), c64_2d, c64_2d), onp.Array2D[np.complex64 | np.complex128])
+assert_type(solve_banded((1, 2), c64_2d, c64_3d), onp.ArrayND[np.complex64 | np.complex128])
+assert_type(solve_banded((1, 2), c64_3d, c64_1d), onp.ArrayND[np.complex64 | np.complex128])
 
 assert_type(solve_banded((1, 2), c128_2d, c128_1d), onp.Array1D[np.complex128])
 assert_type(solve_banded((1, 2), c128_2d, c128_2d), onp.Array2D[np.complex128])
@@ -206,59 +206,6 @@ assert_type(solve_banded((1, 2), py_c_2d, py_c_1d), onp.Array1D[np.complex128])
 assert_type(solve_banded((1, 2), py_c_2d, py_c_2d), onp.Array2D[np.complex128])
 assert_type(solve_banded((1, 2), py_c_2d, py_c_3d), onp.ArrayND[np.complex128])
 assert_type(solve_banded((1, 2), py_c_3d, py_c_1d), onp.ArrayND[np.complex128])
-
-###
-# solveh_banded
-
-assert_type(solveh_banded(i8_2d, i8_1d), onp.Array1D[np.float64])
-assert_type(solveh_banded(i8_2d, i8_2d), onp.Array2D[np.float64])
-assert_type(solveh_banded(i8_2d, i8_3d), onp.ArrayND[np.float64])
-assert_type(solveh_banded(i8_3d, i8_1d), onp.ArrayND[np.float64])
-
-assert_type(solveh_banded(f16_2d, f16_1d), onp.Array1D[np.float32])
-assert_type(solveh_banded(f16_2d, f16_2d), onp.Array2D[np.float32])
-assert_type(solveh_banded(f16_2d, f16_3d), onp.ArrayND[np.float32])
-assert_type(solveh_banded(f16_3d, f16_1d), onp.ArrayND[np.float32])
-
-assert_type(solveh_banded(f32_2d, f32_1d), onp.Array1D[np.float32])
-assert_type(solveh_banded(f32_2d, f32_2d), onp.Array2D[np.float32])
-assert_type(solveh_banded(f32_2d, f32_3d), onp.ArrayND[np.float32])
-assert_type(solveh_banded(f32_3d, f32_1d), onp.ArrayND[np.float32])
-
-assert_type(solveh_banded(f64_2d, f64_1d), onp.Array1D[np.float64])
-assert_type(solveh_banded(f64_2d, f64_2d), onp.Array2D[np.float64])
-assert_type(solveh_banded(f64_2d, f64_3d), onp.ArrayND[np.float64])
-assert_type(solveh_banded(f64_3d, f64_1d), onp.ArrayND[np.float64])
-
-assert_type(solveh_banded(f80_2d, f80_1d), onp.Array1D[np.float64])
-assert_type(solveh_banded(f80_2d, f80_2d), onp.Array2D[np.float64])
-assert_type(solveh_banded(f80_2d, f80_3d), onp.ArrayND[np.float64])
-assert_type(solveh_banded(f80_3d, f80_1d), onp.ArrayND[np.float64])
-
-assert_type(solveh_banded(c64_2d, c64_1d), onp.Array1D[np.complex64])
-assert_type(solveh_banded(c64_2d, c64_2d), onp.Array2D[np.complex64])
-assert_type(solveh_banded(c64_2d, c64_3d), onp.ArrayND[np.complex64])
-assert_type(solveh_banded(c64_3d, c64_1d), onp.ArrayND[np.complex64])
-
-assert_type(solveh_banded(c128_2d, c128_1d), onp.Array1D[np.complex128])
-assert_type(solveh_banded(c128_2d, c128_2d), onp.Array2D[np.complex128])
-assert_type(solveh_banded(c128_2d, c128_3d), onp.ArrayND[np.complex128])
-assert_type(solveh_banded(c128_3d, c128_1d), onp.ArrayND[np.complex128])
-
-assert_type(solveh_banded(c160_2d, c160_1d), onp.Array1D[np.complex128])
-assert_type(solveh_banded(c160_2d, c160_2d), onp.Array2D[np.complex128])
-assert_type(solveh_banded(c160_2d, c160_3d), onp.ArrayND[np.complex128])
-assert_type(solveh_banded(c160_3d, c160_1d), onp.ArrayND[np.complex128])
-
-assert_type(solveh_banded(py_f_2d, py_f_1d), onp.Array1D[np.float64])
-assert_type(solveh_banded(py_f_2d, py_f_2d), onp.Array2D[np.float64])
-assert_type(solveh_banded(py_f_2d, py_f_3d), onp.ArrayND[np.float64])
-assert_type(solveh_banded(py_f_3d, py_f_1d), onp.ArrayND[np.float64])
-
-assert_type(solveh_banded(py_c_2d, py_c_1d), onp.Array1D[np.complex128])
-assert_type(solveh_banded(py_c_2d, py_c_2d), onp.Array2D[np.complex128])
-assert_type(solveh_banded(py_c_2d, py_c_3d), onp.ArrayND[np.complex128])
-assert_type(solveh_banded(py_c_3d, py_c_1d), onp.ArrayND[np.complex128])
 
 ###
 # solve_toeplitz
@@ -321,15 +268,15 @@ assert_type(solve_circulant(i8_1d, i8_2d), onp.Array2D[np.float64])
 assert_type(solve_circulant(i8_1d, i8_3d), onp.ArrayND[np.float64])
 assert_type(solve_circulant(i8_2d, i8_1d), onp.ArrayND[np.float64])
 
-assert_type(solve_circulant(f16_1d, f16_1d), onp.Array1D[np.float32])
-assert_type(solve_circulant(f16_1d, f16_2d), onp.Array2D[np.float32])
-assert_type(solve_circulant(f16_1d, f16_3d), onp.ArrayND[np.float32])
-assert_type(solve_circulant(f16_2d, f16_1d), onp.ArrayND[np.float32])
+assert_type(solve_circulant(f16_1d, f16_1d), onp.Array1D[npc.floating])
+assert_type(solve_circulant(f16_1d, f16_2d), onp.Array2D[npc.floating])
+assert_type(solve_circulant(f16_1d, f16_3d), onp.ArrayND[npc.floating])
+assert_type(solve_circulant(f16_2d, f16_1d), onp.ArrayND[npc.floating])
 
-assert_type(solve_circulant(f32_1d, f32_1d), onp.Array1D[np.float32])
-assert_type(solve_circulant(f32_1d, f32_2d), onp.Array2D[np.float32])
-assert_type(solve_circulant(f32_1d, f32_3d), onp.ArrayND[np.float32])
-assert_type(solve_circulant(f32_2d, f32_1d), onp.ArrayND[np.float32])
+assert_type(solve_circulant(f32_1d, f32_1d), onp.Array1D[npc.floating])
+assert_type(solve_circulant(f32_1d, f32_2d), onp.Array2D[npc.floating])
+assert_type(solve_circulant(f32_1d, f32_3d), onp.ArrayND[npc.floating])
+assert_type(solve_circulant(f32_2d, f32_1d), onp.ArrayND[npc.floating])
 
 assert_type(solve_circulant(f64_1d, f64_1d), onp.Array1D[np.float64])
 assert_type(solve_circulant(f64_1d, f64_2d), onp.Array2D[np.float64])
@@ -341,10 +288,10 @@ assert_type(solve_circulant(f80_1d, f80_2d), onp.Array2D[npc.floating])
 assert_type(solve_circulant(f80_1d, f80_3d), onp.ArrayND[npc.floating])
 assert_type(solve_circulant(f80_2d, f80_1d), onp.ArrayND[npc.floating])
 
-assert_type(solve_circulant(c64_1d, c64_1d), onp.Array1D[np.complex64])
-assert_type(solve_circulant(c64_1d, c64_2d), onp.Array2D[np.complex64])
-assert_type(solve_circulant(c64_1d, c64_3d), onp.ArrayND[np.complex64])
-assert_type(solve_circulant(c64_2d, c64_1d), onp.ArrayND[np.complex64])
+assert_type(solve_circulant(c64_1d, c64_1d), onp.Array1D[npc.complexfloating])
+assert_type(solve_circulant(c64_1d, c64_2d), onp.Array2D[npc.complexfloating])
+assert_type(solve_circulant(c64_1d, c64_3d), onp.ArrayND[npc.complexfloating])
+assert_type(solve_circulant(c64_2d, c64_1d), onp.ArrayND[npc.complexfloating])
 
 assert_type(solve_circulant(c128_1d, c128_1d), onp.Array1D[np.complex128])
 assert_type(solve_circulant(c128_1d, c128_2d), onp.Array2D[np.complex128])

--- a/tests/linalg/test__basic.pyi
+++ b/tests/linalg/test__basic.pyi
@@ -1,0 +1,370 @@
+# type-tests for `linalg/_basic.pyi`
+
+from typing import assert_type
+
+import numpy as np
+import optype.numpy as onp
+import optype.numpy.compat as npc
+
+from scipy.linalg import solve, solve_banded, solve_circulant, solve_toeplitz, solve_triangular, solveh_banded
+
+i8_1d: onp.Array1D[np.int8]
+i8_2d: onp.Array2D[np.int8]
+i8_3d: onp.Array3D[np.int8]
+
+f16_1d: onp.Array1D[np.float16]
+f16_2d: onp.Array2D[np.float16]
+f16_3d: onp.Array3D[np.float16]
+
+f32_1d: onp.Array1D[np.float32]
+f32_2d: onp.Array2D[np.float32]
+f32_3d: onp.Array3D[np.float32]
+
+f64_1d: onp.Array1D[np.float64]
+f64_2d: onp.Array2D[np.float64]
+f64_3d: onp.Array3D[np.float64]
+
+f80_1d: onp.Array1D[np.longdouble]
+f80_2d: onp.Array2D[np.longdouble]
+f80_3d: onp.Array3D[np.longdouble]
+
+c64_1d: onp.Array1D[np.complex64]
+c64_2d: onp.Array2D[np.complex64]
+c64_3d: onp.Array3D[np.complex64]
+
+c128_1d: onp.Array1D[np.complex128]
+c128_2d: onp.Array2D[np.complex128]
+c128_3d: onp.Array3D[np.complex128]
+
+c160_1d: onp.Array1D[np.clongdouble]
+c160_2d: onp.Array2D[np.clongdouble]
+c160_3d: onp.Array3D[np.clongdouble]
+
+py_f_1d: list[float]
+py_f_2d: list[list[float]]
+py_f_3d: list[list[list[float]]]
+
+py_c_1d: list[complex]
+py_c_2d: list[list[complex]]
+py_c_3d: list[list[list[complex]]]
+
+###
+# solve
+
+assert_type(solve(i8_2d, i8_1d), onp.Array2D[np.float64])
+assert_type(solve(i8_2d, i8_2d), onp.Array2D[np.float64])
+assert_type(solve(i8_2d, i8_3d), onp.ArrayND[np.float64])
+assert_type(solve(i8_3d, i8_1d), onp.ArrayND[np.float64])
+
+assert_type(solve(f16_2d, f16_1d), onp.Array2D[np.float32])
+assert_type(solve(f16_2d, f16_2d), onp.Array2D[np.float32])
+assert_type(solve(f16_2d, f16_3d), onp.ArrayND[np.float32])
+assert_type(solve(f16_3d, f16_1d), onp.ArrayND[np.float32])
+
+assert_type(solve(f32_2d, f32_1d), onp.Array2D[np.float32])
+assert_type(solve(f32_2d, f32_2d), onp.Array2D[np.float32])
+assert_type(solve(f32_2d, f32_3d), onp.ArrayND[np.float32])
+assert_type(solve(f32_3d, f32_1d), onp.ArrayND[np.float32])
+
+assert_type(solve(f64_2d, f64_1d), onp.Array2D[np.float64])
+assert_type(solve(f64_2d, f64_2d), onp.Array2D[np.float64])
+assert_type(solve(f64_2d, f64_3d), onp.ArrayND[np.float64])
+assert_type(solve(f64_3d, f64_1d), onp.ArrayND[np.float64])
+
+assert_type(solve(f80_2d, f80_1d), onp.Array2D[np.float64])
+assert_type(solve(f80_2d, f80_2d), onp.Array2D[np.float64])
+assert_type(solve(f80_2d, f80_3d), onp.ArrayND[np.float64])
+assert_type(solve(f80_3d, f80_1d), onp.ArrayND[np.float64])
+
+assert_type(solve(c64_2d, c64_1d), onp.Array2D[np.complex64])
+assert_type(solve(c64_2d, c64_2d), onp.Array2D[np.complex64])
+assert_type(solve(c64_2d, c64_3d), onp.ArrayND[np.complex64])
+assert_type(solve(c64_3d, c64_1d), onp.ArrayND[np.complex64])
+
+assert_type(solve(c128_2d, c128_1d), onp.Array2D[np.complex128])
+assert_type(solve(c128_2d, c128_2d), onp.Array2D[np.complex128])
+assert_type(solve(c128_2d, c128_3d), onp.ArrayND[np.complex128])
+assert_type(solve(c128_3d, c128_1d), onp.ArrayND[np.complex128])
+
+assert_type(solve(c160_2d, c160_1d), onp.Array2D[np.complex128])
+assert_type(solve(c160_2d, c160_2d), onp.Array2D[np.complex128])
+assert_type(solve(c160_2d, c160_3d), onp.ArrayND[np.complex128])
+assert_type(solve(c160_3d, c160_1d), onp.ArrayND[np.complex128])
+
+assert_type(solve(py_f_2d, py_f_1d), onp.Array2D[np.float64])
+assert_type(solve(py_f_2d, py_f_2d), onp.Array2D[np.float64])
+assert_type(solve(py_f_2d, py_f_3d), onp.ArrayND[np.float64])
+assert_type(solve(py_f_3d, py_f_1d), onp.ArrayND[np.float64])
+
+assert_type(solve(py_c_2d, py_c_1d), onp.Array2D[np.complex128])
+assert_type(solve(py_c_2d, py_c_2d), onp.Array2D[np.complex128])
+assert_type(solve(py_c_2d, py_c_3d), onp.ArrayND[np.complex128])
+assert_type(solve(py_c_3d, py_c_1d), onp.ArrayND[np.complex128])
+
+###
+# solve_triangular
+
+assert_type(solve_triangular(i8_2d, i8_1d), onp.Array1D[np.float64])
+assert_type(solve_triangular(i8_2d, i8_2d), onp.Array2D[np.float64])
+assert_type(solve_triangular(i8_2d, i8_3d), onp.ArrayND[np.float64])
+assert_type(solve_triangular(i8_3d, i8_1d), onp.ArrayND[np.float64])
+
+assert_type(solve_triangular(f16_2d, f16_1d), onp.Array1D[np.float32])
+assert_type(solve_triangular(f16_2d, f16_2d), onp.Array2D[np.float32])
+assert_type(solve_triangular(f16_2d, f16_3d), onp.ArrayND[np.float32])
+assert_type(solve_triangular(f16_3d, f16_1d), onp.ArrayND[np.float32])
+
+assert_type(solve_triangular(f32_2d, f32_1d), onp.Array1D[np.float32])
+assert_type(solve_triangular(f32_2d, f32_2d), onp.Array2D[np.float32])
+assert_type(solve_triangular(f32_2d, f32_3d), onp.ArrayND[np.float32])
+assert_type(solve_triangular(f32_3d, f32_1d), onp.ArrayND[np.float32])
+
+assert_type(solve_triangular(f64_2d, f64_1d), onp.Array1D[np.float64])
+assert_type(solve_triangular(f64_2d, f64_2d), onp.Array2D[np.float64])
+assert_type(solve_triangular(f64_2d, f64_3d), onp.ArrayND[np.float64])
+assert_type(solve_triangular(f64_3d, f64_1d), onp.ArrayND[np.float64])
+
+assert_type(solve_triangular(f80_2d, f80_1d), onp.Array1D[np.float64])
+assert_type(solve_triangular(f80_2d, f80_2d), onp.Array2D[np.float64])
+assert_type(solve_triangular(f80_2d, f80_3d), onp.ArrayND[np.float64])
+assert_type(solve_triangular(f80_3d, f80_1d), onp.ArrayND[np.float64])
+
+assert_type(solve_triangular(c64_2d, c64_1d), onp.Array1D[np.complex64])
+assert_type(solve_triangular(c64_2d, c64_2d), onp.Array2D[np.complex64])
+assert_type(solve_triangular(c64_2d, c64_3d), onp.ArrayND[np.complex64])
+assert_type(solve_triangular(c64_3d, c64_1d), onp.ArrayND[np.complex64])
+
+assert_type(solve_triangular(c128_2d, c128_1d), onp.Array1D[np.complex128])
+assert_type(solve_triangular(c128_2d, c128_2d), onp.Array2D[np.complex128])
+assert_type(solve_triangular(c128_2d, c128_3d), onp.ArrayND[np.complex128])
+assert_type(solve_triangular(c128_3d, c128_1d), onp.ArrayND[np.complex128])
+
+assert_type(solve_triangular(c160_2d, c160_1d), onp.Array1D[np.complex128])
+assert_type(solve_triangular(c160_2d, c160_2d), onp.Array2D[np.complex128])
+assert_type(solve_triangular(c160_2d, c160_3d), onp.ArrayND[np.complex128])
+assert_type(solve_triangular(c160_3d, c160_1d), onp.ArrayND[np.complex128])
+
+assert_type(solve_triangular(py_f_2d, py_f_1d), onp.Array1D[np.float64])
+assert_type(solve_triangular(py_f_2d, py_f_2d), onp.Array2D[np.float64])
+assert_type(solve_triangular(py_f_2d, py_f_3d), onp.ArrayND[np.float64])
+assert_type(solve_triangular(py_f_3d, py_f_1d), onp.ArrayND[np.float64])
+
+assert_type(solve_triangular(py_c_2d, py_c_1d), onp.Array1D[np.complex128])
+assert_type(solve_triangular(py_c_2d, py_c_2d), onp.Array2D[np.complex128])
+assert_type(solve_triangular(py_c_2d, py_c_3d), onp.ArrayND[np.complex128])
+assert_type(solve_triangular(py_c_3d, py_c_1d), onp.ArrayND[np.complex128])
+
+###
+# solve_banded
+
+assert_type(solve_banded((1, 2), i8_2d, i8_1d), onp.Array1D[np.float64])
+assert_type(solve_banded((1, 2), i8_2d, i8_2d), onp.Array2D[np.float64])
+assert_type(solve_banded((1, 2), i8_2d, i8_3d), onp.ArrayND[np.float64])
+assert_type(solve_banded((1, 2), i8_3d, i8_1d), onp.ArrayND[np.float64])
+
+assert_type(solve_banded((1, 2), f16_2d, f16_1d), onp.Array1D[np.float32])
+assert_type(solve_banded((1, 2), f16_2d, f16_2d), onp.Array2D[np.float32])
+assert_type(solve_banded((1, 2), f16_2d, f16_3d), onp.ArrayND[np.float32])
+assert_type(solve_banded((1, 2), f16_3d, f16_1d), onp.ArrayND[np.float32])
+
+assert_type(solve_banded((1, 2), f32_2d, f32_1d), onp.Array1D[np.float32])
+assert_type(solve_banded((1, 2), f32_2d, f32_2d), onp.Array2D[np.float32])
+assert_type(solve_banded((1, 2), f32_2d, f32_3d), onp.ArrayND[np.float32])
+assert_type(solve_banded((1, 2), f32_3d, f32_1d), onp.ArrayND[np.float32])
+
+assert_type(solve_banded((1, 2), f64_2d, f64_1d), onp.Array1D[np.float64])
+assert_type(solve_banded((1, 2), f64_2d, f64_2d), onp.Array2D[np.float64])
+assert_type(solve_banded((1, 2), f64_2d, f64_3d), onp.ArrayND[np.float64])
+assert_type(solve_banded((1, 2), f64_3d, f64_1d), onp.ArrayND[np.float64])
+
+assert_type(solve_banded((1, 2), f80_2d, f80_1d), onp.Array1D[np.float64])
+assert_type(solve_banded((1, 2), f80_2d, f80_2d), onp.Array2D[np.float64])
+assert_type(solve_banded((1, 2), f80_2d, f80_3d), onp.ArrayND[np.float64])
+assert_type(solve_banded((1, 2), f80_3d, f80_1d), onp.ArrayND[np.float64])
+
+assert_type(solve_banded((1, 2), c64_2d, c64_1d), onp.Array1D[np.complex64])
+assert_type(solve_banded((1, 2), c64_2d, c64_2d), onp.Array2D[np.complex64])
+assert_type(solve_banded((1, 2), c64_2d, c64_3d), onp.ArrayND[np.complex64])
+assert_type(solve_banded((1, 2), c64_3d, c64_1d), onp.ArrayND[np.complex64])
+
+assert_type(solve_banded((1, 2), c128_2d, c128_1d), onp.Array1D[np.complex128])
+assert_type(solve_banded((1, 2), c128_2d, c128_2d), onp.Array2D[np.complex128])
+assert_type(solve_banded((1, 2), c128_2d, c128_3d), onp.ArrayND[np.complex128])
+assert_type(solve_banded((1, 2), c128_3d, c128_1d), onp.ArrayND[np.complex128])
+
+assert_type(solve_banded((1, 2), c160_2d, c160_1d), onp.Array1D[np.complex128])
+assert_type(solve_banded((1, 2), c160_2d, c160_2d), onp.Array2D[np.complex128])
+assert_type(solve_banded((1, 2), c160_2d, c160_3d), onp.ArrayND[np.complex128])
+assert_type(solve_banded((1, 2), c160_3d, c160_1d), onp.ArrayND[np.complex128])
+
+assert_type(solve_banded((1, 2), py_f_2d, py_f_1d), onp.Array1D[np.float64])
+assert_type(solve_banded((1, 2), py_f_2d, py_f_2d), onp.Array2D[np.float64])
+assert_type(solve_banded((1, 2), py_f_2d, py_f_3d), onp.ArrayND[np.float64])
+assert_type(solve_banded((1, 2), py_f_3d, py_f_1d), onp.ArrayND[np.float64])
+
+assert_type(solve_banded((1, 2), py_c_2d, py_c_1d), onp.Array1D[np.complex128])
+assert_type(solve_banded((1, 2), py_c_2d, py_c_2d), onp.Array2D[np.complex128])
+assert_type(solve_banded((1, 2), py_c_2d, py_c_3d), onp.ArrayND[np.complex128])
+assert_type(solve_banded((1, 2), py_c_3d, py_c_1d), onp.ArrayND[np.complex128])
+
+###
+# solveh_banded
+
+assert_type(solveh_banded(i8_2d, i8_1d), onp.Array1D[np.float64])
+assert_type(solveh_banded(i8_2d, i8_2d), onp.Array2D[np.float64])
+assert_type(solveh_banded(i8_2d, i8_3d), onp.ArrayND[np.float64])
+assert_type(solveh_banded(i8_3d, i8_1d), onp.ArrayND[np.float64])
+
+assert_type(solveh_banded(f16_2d, f16_1d), onp.Array1D[np.float32])
+assert_type(solveh_banded(f16_2d, f16_2d), onp.Array2D[np.float32])
+assert_type(solveh_banded(f16_2d, f16_3d), onp.ArrayND[np.float32])
+assert_type(solveh_banded(f16_3d, f16_1d), onp.ArrayND[np.float32])
+
+assert_type(solveh_banded(f32_2d, f32_1d), onp.Array1D[np.float32])
+assert_type(solveh_banded(f32_2d, f32_2d), onp.Array2D[np.float32])
+assert_type(solveh_banded(f32_2d, f32_3d), onp.ArrayND[np.float32])
+assert_type(solveh_banded(f32_3d, f32_1d), onp.ArrayND[np.float32])
+
+assert_type(solveh_banded(f64_2d, f64_1d), onp.Array1D[np.float64])
+assert_type(solveh_banded(f64_2d, f64_2d), onp.Array2D[np.float64])
+assert_type(solveh_banded(f64_2d, f64_3d), onp.ArrayND[np.float64])
+assert_type(solveh_banded(f64_3d, f64_1d), onp.ArrayND[np.float64])
+
+assert_type(solveh_banded(f80_2d, f80_1d), onp.Array1D[np.float64])
+assert_type(solveh_banded(f80_2d, f80_2d), onp.Array2D[np.float64])
+assert_type(solveh_banded(f80_2d, f80_3d), onp.ArrayND[np.float64])
+assert_type(solveh_banded(f80_3d, f80_1d), onp.ArrayND[np.float64])
+
+assert_type(solveh_banded(c64_2d, c64_1d), onp.Array1D[np.complex64])
+assert_type(solveh_banded(c64_2d, c64_2d), onp.Array2D[np.complex64])
+assert_type(solveh_banded(c64_2d, c64_3d), onp.ArrayND[np.complex64])
+assert_type(solveh_banded(c64_3d, c64_1d), onp.ArrayND[np.complex64])
+
+assert_type(solveh_banded(c128_2d, c128_1d), onp.Array1D[np.complex128])
+assert_type(solveh_banded(c128_2d, c128_2d), onp.Array2D[np.complex128])
+assert_type(solveh_banded(c128_2d, c128_3d), onp.ArrayND[np.complex128])
+assert_type(solveh_banded(c128_3d, c128_1d), onp.ArrayND[np.complex128])
+
+assert_type(solveh_banded(c160_2d, c160_1d), onp.Array1D[np.complex128])
+assert_type(solveh_banded(c160_2d, c160_2d), onp.Array2D[np.complex128])
+assert_type(solveh_banded(c160_2d, c160_3d), onp.ArrayND[np.complex128])
+assert_type(solveh_banded(c160_3d, c160_1d), onp.ArrayND[np.complex128])
+
+assert_type(solveh_banded(py_f_2d, py_f_1d), onp.Array1D[np.float64])
+assert_type(solveh_banded(py_f_2d, py_f_2d), onp.Array2D[np.float64])
+assert_type(solveh_banded(py_f_2d, py_f_3d), onp.ArrayND[np.float64])
+assert_type(solveh_banded(py_f_3d, py_f_1d), onp.ArrayND[np.float64])
+
+assert_type(solveh_banded(py_c_2d, py_c_1d), onp.Array1D[np.complex128])
+assert_type(solveh_banded(py_c_2d, py_c_2d), onp.Array2D[np.complex128])
+assert_type(solveh_banded(py_c_2d, py_c_3d), onp.ArrayND[np.complex128])
+assert_type(solveh_banded(py_c_3d, py_c_1d), onp.ArrayND[np.complex128])
+
+###
+# solve_toeplitz
+
+assert_type(solve_toeplitz(i8_1d, i8_1d), onp.Array1D[np.float64])
+assert_type(solve_toeplitz(i8_1d, i8_2d), onp.Array2D[np.float64])
+assert_type(solve_toeplitz(i8_1d, i8_3d), onp.ArrayND[np.float64])
+assert_type(solve_toeplitz(i8_2d, i8_1d), onp.ArrayND[np.float64])
+
+assert_type(solve_toeplitz(f16_1d, f16_1d), onp.Array1D[np.float64])
+assert_type(solve_toeplitz(f16_1d, f16_2d), onp.Array2D[np.float64])
+assert_type(solve_toeplitz(f16_1d, f16_3d), onp.ArrayND[np.float64])
+assert_type(solve_toeplitz(f16_2d, f16_1d), onp.ArrayND[np.float64])
+
+assert_type(solve_toeplitz(f32_1d, f32_1d), onp.Array1D[np.float64])
+assert_type(solve_toeplitz(f32_1d, f32_2d), onp.Array2D[np.float64])
+assert_type(solve_toeplitz(f32_1d, f32_3d), onp.ArrayND[np.float64])
+assert_type(solve_toeplitz(f32_2d, f32_1d), onp.ArrayND[np.float64])
+
+assert_type(solve_toeplitz(f64_1d, f64_1d), onp.Array1D[np.float64])
+assert_type(solve_toeplitz(f64_1d, f64_2d), onp.Array2D[np.float64])
+assert_type(solve_toeplitz(f64_1d, f64_3d), onp.ArrayND[np.float64])
+assert_type(solve_toeplitz(f64_2d, f64_1d), onp.ArrayND[np.float64])
+
+assert_type(solve_toeplitz(f80_1d, f80_1d), onp.Array1D[np.float64])
+assert_type(solve_toeplitz(f80_1d, f80_2d), onp.Array2D[np.float64])
+assert_type(solve_toeplitz(f80_1d, f80_3d), onp.ArrayND[np.float64])
+assert_type(solve_toeplitz(f80_2d, f80_1d), onp.ArrayND[np.float64])
+
+assert_type(solve_toeplitz(c64_1d, c64_1d), onp.Array1D[np.complex128])
+assert_type(solve_toeplitz(c64_1d, c64_2d), onp.Array2D[np.complex128])
+assert_type(solve_toeplitz(c64_1d, c64_3d), onp.ArrayND[np.complex128])
+assert_type(solve_toeplitz(c64_2d, c64_1d), onp.ArrayND[np.complex128])
+
+assert_type(solve_toeplitz(c128_1d, c128_1d), onp.Array1D[np.complex128])
+assert_type(solve_toeplitz(c128_1d, c128_2d), onp.Array2D[np.complex128])
+assert_type(solve_toeplitz(c128_1d, c128_3d), onp.ArrayND[np.complex128])
+assert_type(solve_toeplitz(c128_2d, c128_1d), onp.ArrayND[np.complex128])
+
+assert_type(solve_toeplitz(c160_1d, c160_1d), onp.Array1D[np.complex128])
+assert_type(solve_toeplitz(c160_1d, c160_2d), onp.Array2D[np.complex128])
+assert_type(solve_toeplitz(c160_1d, c160_3d), onp.ArrayND[np.complex128])
+assert_type(solve_toeplitz(c160_2d, c160_1d), onp.ArrayND[np.complex128])
+
+assert_type(solve_toeplitz(py_f_1d, py_f_1d), onp.Array1D[np.float64])
+assert_type(solve_toeplitz(py_f_1d, py_f_2d), onp.Array2D[np.float64])
+assert_type(solve_toeplitz(py_f_1d, py_f_3d), onp.ArrayND[np.float64])
+assert_type(solve_toeplitz(py_f_2d, py_f_1d), onp.ArrayND[np.float64])
+
+assert_type(solve_toeplitz(py_c_1d, py_c_1d), onp.Array1D[np.complex128])
+assert_type(solve_toeplitz(py_c_1d, py_c_2d), onp.Array2D[np.complex128])
+assert_type(solve_toeplitz(py_c_1d, py_c_3d), onp.ArrayND[np.complex128])
+assert_type(solve_toeplitz(py_c_2d, py_c_1d), onp.ArrayND[np.complex128])
+
+###
+# solve_circulant
+
+assert_type(solve_circulant(i8_1d, i8_1d), onp.Array1D[np.float64])
+assert_type(solve_circulant(i8_1d, i8_2d), onp.Array2D[np.float64])
+assert_type(solve_circulant(i8_1d, i8_3d), onp.ArrayND[np.float64])
+assert_type(solve_circulant(i8_2d, i8_1d), onp.ArrayND[np.float64])
+
+assert_type(solve_circulant(f16_1d, f16_1d), onp.Array1D[np.float32])
+assert_type(solve_circulant(f16_1d, f16_2d), onp.Array2D[np.float32])
+assert_type(solve_circulant(f16_1d, f16_3d), onp.ArrayND[np.float32])
+assert_type(solve_circulant(f16_2d, f16_1d), onp.ArrayND[np.float32])
+
+assert_type(solve_circulant(f32_1d, f32_1d), onp.Array1D[np.float32])
+assert_type(solve_circulant(f32_1d, f32_2d), onp.Array2D[np.float32])
+assert_type(solve_circulant(f32_1d, f32_3d), onp.ArrayND[np.float32])
+assert_type(solve_circulant(f32_2d, f32_1d), onp.ArrayND[np.float32])
+
+assert_type(solve_circulant(f64_1d, f64_1d), onp.Array1D[np.float64])
+assert_type(solve_circulant(f64_1d, f64_2d), onp.Array2D[np.float64])
+assert_type(solve_circulant(f64_1d, f64_3d), onp.ArrayND[np.float64])
+assert_type(solve_circulant(f64_2d, f64_1d), onp.ArrayND[np.float64])
+
+assert_type(solve_circulant(f80_1d, f80_1d), onp.Array1D[npc.floating])
+assert_type(solve_circulant(f80_1d, f80_2d), onp.Array2D[npc.floating])
+assert_type(solve_circulant(f80_1d, f80_3d), onp.ArrayND[npc.floating])
+assert_type(solve_circulant(f80_2d, f80_1d), onp.ArrayND[npc.floating])
+
+assert_type(solve_circulant(c64_1d, c64_1d), onp.Array1D[np.complex64])
+assert_type(solve_circulant(c64_1d, c64_2d), onp.Array2D[np.complex64])
+assert_type(solve_circulant(c64_1d, c64_3d), onp.ArrayND[np.complex64])
+assert_type(solve_circulant(c64_2d, c64_1d), onp.ArrayND[np.complex64])
+
+assert_type(solve_circulant(c128_1d, c128_1d), onp.Array1D[np.complex128])
+assert_type(solve_circulant(c128_1d, c128_2d), onp.Array2D[np.complex128])
+assert_type(solve_circulant(c128_1d, c128_3d), onp.ArrayND[np.complex128])
+assert_type(solve_circulant(c128_2d, c128_1d), onp.ArrayND[np.complex128])
+
+assert_type(solve_circulant(c160_1d, c160_1d), onp.Array1D[npc.complexfloating])
+assert_type(solve_circulant(c160_1d, c160_2d), onp.Array2D[npc.complexfloating])
+assert_type(solve_circulant(c160_1d, c160_3d), onp.ArrayND[npc.complexfloating])
+assert_type(solve_circulant(c160_2d, c160_1d), onp.ArrayND[npc.complexfloating])
+
+assert_type(solve_circulant(py_f_1d, py_f_1d), onp.Array1D[np.float64])
+assert_type(solve_circulant(py_f_1d, py_f_2d), onp.Array2D[np.float64])
+assert_type(solve_circulant(py_f_1d, py_f_3d), onp.ArrayND[np.float64])
+assert_type(solve_circulant(py_f_2d, py_f_1d), onp.ArrayND[np.float64])
+
+assert_type(solve_circulant(py_c_1d, py_c_1d), onp.Array1D[np.complex128])
+assert_type(solve_circulant(py_c_1d, py_c_2d), onp.Array2D[np.complex128])
+assert_type(solve_circulant(py_c_1d, py_c_3d), onp.ArrayND[np.complex128])
+assert_type(solve_circulant(py_c_2d, py_c_1d), onp.ArrayND[np.complex128])
+
+###
+# TODO(jorenham): inv, pinv, pinvh, det, lstsq, matrix_balance, matmul_toeplitz


### PR DESCRIPTION
This improves the following "basic" `scipy.linalg` functions:

- `solve`
- `solve_triangular`
- `solve_banded`
- `solveh_banded`
- `solve_toeplitz`
- `solve_circulant`

A total of 240 type-tests have been added for these functions.