### PR TITLE
 workaround for path-dependent pyright bug by shuffling disjoint overloads

### DIFF
--- a/scipy-stubs/fft/_basic.pyi
+++ b/scipy-stubs/fft/_basic.pyi
@@ -13,32 +13,25 @@ _ShapeT = TypeVar("_ShapeT", bound=tuple[int, ...])
 _Norm: TypeAlias = Literal["backward", "ortho", "forward"]
 _Unused: TypeAlias = Never  # not used by scipy
 
+_CoInteger: TypeAlias = npc.integer | np.bool_
+
 _AsFloat32: TypeAlias = onp.CanArrayND[npc.floating32, _ShapeT]
-_AsFloat64: TypeAlias = onp.CanArrayND[np.bool_ | npc.integer | npc.floating64, _ShapeT]
+_AsFloat64: TypeAlias = onp.CanArrayND[npc.floating64 | _CoInteger, _ShapeT]
 _AsFloat80: TypeAlias = onp.CanArrayND[np.longdouble, _ShapeT]
 
-_AsComplex64: TypeAlias = onp.CanArrayND[np.float32 | np.complex64, _ShapeT]
-_AsComplex128: TypeAlias = onp.CanArrayND[np.bool_ | npc.integer | np.float64 | np.complex128, _ShapeT]
+_AsComplex64: TypeAlias = onp.CanArrayND[npc.inexact32, _ShapeT]
+_AsComplex128: TypeAlias = onp.CanArrayND[npc.inexact64 | _CoInteger, _ShapeT]
 _AsComplex160: TypeAlias = onp.CanArrayND[np.longdouble | np.clongdouble, _ShapeT]
 
-_ToFloat64_ND: TypeAlias = onp.ToArrayND[float, np.bool_ | npc.integer | np.float64]
-_ToComplex128_ND: TypeAlias = onp.ToArrayND[complex, np.bool_ | npc.integer | npc.inexact64]
+_ToFloat64_ND: TypeAlias = onp.ToArrayND[float, npc.floating64 | _CoInteger]
+_ToComplex128_ND: TypeAlias = onp.ToArrayND[complex, npc.inexact64 | _CoInteger]
+
+# NOTE: The order of overloads is carefully chosen to avoid a pyright bug.
 
 ###
 # 1-D
 
 # keep in sync with `ifft`
-@overload
-def fft(  # type: ignore[overload-overlap]
-    x: _AsComplex64[_ShapeT],
-    n: int | None = None,
-    axis: int = -1,
-    norm: _Norm | None = None,
-    overwrite_x: onp.ToBool = False,
-    workers: int | None = None,
-    *,
-    plan: _Unused | None = None,
-) -> onp.Array[_ShapeT, np.complex64]: ...
 @overload
 def fft(
     x: _AsComplex128[_ShapeT],
@@ -50,6 +43,17 @@ def fft(
     *,
     plan: _Unused | None = None,
 ) -> onp.Array[_ShapeT, np.complex128]: ...
+@overload
+def fft(
+    x: _AsComplex64[_ShapeT],
+    n: int | None = None,
+    axis: int = -1,
+    norm: _Norm | None = None,
+    overwrite_x: onp.ToBool = False,
+    workers: int | None = None,
+    *,
+    plan: _Unused | None = None,
+) -> onp.Array[_ShapeT, np.complex64]: ...
 @overload
 def fft(
     x: _AsComplex160[_ShapeT],
@@ -97,17 +101,6 @@ def fft(
 
 # keep in sync with `fft`
 @overload
-def ifft(  # type: ignore[overload-overlap]
-    x: _AsComplex64[_ShapeT],
-    n: int | None = None,
-    axis: int = -1,
-    norm: _Norm | None = None,
-    overwrite_x: onp.ToBool = False,
-    workers: int | None = None,
-    *,
-    plan: _Unused | None = None,
-) -> onp.Array[_ShapeT, np.complex64]: ...
-@overload
 def ifft(
     x: _AsComplex128[_ShapeT],
     n: int | None = None,
@@ -118,6 +111,17 @@ def ifft(
     *,
     plan: _Unused | None = None,
 ) -> onp.Array[_ShapeT, np.complex128]: ...
+@overload
+def ifft(
+    x: _AsComplex64[_ShapeT],
+    n: int | None = None,
+    axis: int = -1,
+    norm: _Norm | None = None,
+    overwrite_x: onp.ToBool = False,
+    workers: int | None = None,
+    *,
+    plan: _Unused | None = None,
+) -> onp.Array[_ShapeT, np.complex64]: ...
 @overload
 def ifft(
     x: _AsComplex160[_ShapeT],
@@ -165,17 +169,6 @@ def ifft(
 
 # keep in sync with `ihfft`
 @overload
-def rfft(  # type: ignore[overload-overlap]
-    x: _AsFloat32[_ShapeT],
-    n: int | None = None,
-    axis: int = -1,
-    norm: _Norm | None = None,
-    overwrite_x: onp.ToBool = False,
-    workers: int | None = None,
-    *,
-    plan: _Unused | None = None,
-) -> onp.Array[_ShapeT, np.complex64]: ...
-@overload
 def rfft(
     x: _AsFloat64[_ShapeT],
     n: int | None = None,
@@ -186,6 +179,17 @@ def rfft(
     *,
     plan: _Unused | None = None,
 ) -> onp.Array[_ShapeT, np.complex128]: ...
+@overload
+def rfft(
+    x: _AsFloat32[_ShapeT],
+    n: int | None = None,
+    axis: int = -1,
+    norm: _Norm | None = None,
+    overwrite_x: onp.ToBool = False,
+    workers: int | None = None,
+    *,
+    plan: _Unused | None = None,
+) -> onp.Array[_ShapeT, np.complex64]: ...
 @overload
 def rfft(
     x: _AsFloat80[_ShapeT],
@@ -233,17 +237,6 @@ def rfft(
 
 # keep in sync with `hfft`
 @overload
-def irfft(  # type: ignore[overload-overlap]
-    x: _AsComplex64[_ShapeT],
-    n: int | None = None,
-    axis: int = -1,
-    norm: _Norm | None = None,
-    overwrite_x: onp.ToBool = False,
-    workers: int | None = None,
-    *,
-    plan: _Unused | None = None,
-) -> onp.Array[_ShapeT, np.float32]: ...
-@overload
 def irfft(
     x: _AsComplex128[_ShapeT],
     n: int | None = None,
@@ -254,6 +247,17 @@ def irfft(
     *,
     plan: _Unused | None = None,
 ) -> onp.Array[_ShapeT, np.float64]: ...
+@overload
+def irfft(
+    x: _AsComplex64[_ShapeT],
+    n: int | None = None,
+    axis: int = -1,
+    norm: _Norm | None = None,
+    overwrite_x: onp.ToBool = False,
+    workers: int | None = None,
+    *,
+    plan: _Unused | None = None,
+) -> onp.Array[_ShapeT, np.float32]: ...
 @overload
 def irfft(
     x: _AsComplex160[_ShapeT],
@@ -301,17 +305,6 @@ def irfft(
 
 # keep in sync with `irfft`
 @overload
-def hfft(  # type: ignore[overload-overlap]
-    x: _AsComplex64[_ShapeT],
-    n: int | None = None,
-    axis: int = -1,
-    norm: _Norm | None = None,
-    overwrite_x: onp.ToBool = False,
-    workers: int | None = None,
-    *,
-    plan: _Unused | None = None,
-) -> onp.Array[_ShapeT, np.float32]: ...
-@overload
 def hfft(
     x: _AsComplex128[_ShapeT],
     n: int | None = None,
@@ -322,6 +315,17 @@ def hfft(
     *,
     plan: _Unused | None = None,
 ) -> onp.Array[_ShapeT, np.float64]: ...
+@overload
+def hfft(
+    x: _AsComplex64[_ShapeT],
+    n: int | None = None,
+    axis: int = -1,
+    norm: _Norm | None = None,
+    overwrite_x: onp.ToBool = False,
+    workers: int | None = None,
+    *,
+    plan: _Unused | None = None,
+) -> onp.Array[_ShapeT, np.float32]: ...
 @overload
 def hfft(
     x: _AsComplex160[_ShapeT],
@@ -370,17 +374,6 @@ def hfft(
 #
 # keep in sync with `rfft`
 @overload
-def ihfft(  # type: ignore[overload-overlap]
-    x: _AsFloat32[_ShapeT],
-    n: int | None = None,
-    axis: int = -1,
-    norm: _Norm | None = None,
-    overwrite_x: onp.ToBool = False,
-    workers: int | None = None,
-    *,
-    plan: _Unused | None = None,
-) -> onp.Array[_ShapeT, np.complex64]: ...
-@overload
 def ihfft(
     x: _AsFloat64[_ShapeT],
     n: int | None = None,
@@ -391,6 +384,17 @@ def ihfft(
     *,
     plan: _Unused | None = None,
 ) -> onp.Array[_ShapeT, np.complex128]: ...
+@overload
+def ihfft(
+    x: _AsFloat32[_ShapeT],
+    n: int | None = None,
+    axis: int = -1,
+    norm: _Norm | None = None,
+    overwrite_x: onp.ToBool = False,
+    workers: int | None = None,
+    *,
+    plan: _Unused | None = None,
+) -> onp.Array[_ShapeT, np.complex64]: ...
 @overload
 def ihfft(
     x: _AsFloat80[_ShapeT],
@@ -441,17 +445,6 @@ def ihfft(
 
 # keep in sync with `ifft2`
 @overload
-def fft2(  # type: ignore[overload-overlap]
-    x: _AsComplex64[_ShapeT],
-    s: onp.ToJustInt1D | None = None,
-    axes: AnyShape = (-2, -1),
-    norm: _Norm | None = None,
-    overwrite_x: onp.ToBool = False,
-    workers: int | None = None,
-    *,
-    plan: _Unused | None = None,
-) -> onp.Array[_ShapeT, np.complex64]: ...
-@overload
 def fft2(
     x: _AsComplex128[_ShapeT],
     s: onp.ToJustInt1D | None = None,
@@ -462,6 +455,17 @@ def fft2(
     *,
     plan: _Unused | None = None,
 ) -> onp.Array[_ShapeT, np.complex128]: ...
+@overload
+def fft2(
+    x: _AsComplex64[_ShapeT],
+    s: onp.ToJustInt1D | None = None,
+    axes: AnyShape = (-2, -1),
+    norm: _Norm | None = None,
+    overwrite_x: onp.ToBool = False,
+    workers: int | None = None,
+    *,
+    plan: _Unused | None = None,
+) -> onp.Array[_ShapeT, np.complex64]: ...
 @overload
 def fft2(
     x: _AsComplex160[_ShapeT],
@@ -509,17 +513,6 @@ def fft2(
 
 # keep in sync with `fft2`
 @overload
-def ifft2(  # type: ignore[overload-overlap]
-    x: _AsComplex64[_ShapeT],
-    s: onp.ToJustInt1D | None = None,
-    axes: AnyShape = (-2, -1),
-    norm: _Norm | None = None,
-    overwrite_x: onp.ToBool = False,
-    workers: int | None = None,
-    *,
-    plan: _Unused | None = None,
-) -> onp.Array[_ShapeT, np.complex64]: ...
-@overload
 def ifft2(
     x: _AsComplex128[_ShapeT],
     s: onp.ToJustInt1D | None = None,
@@ -530,6 +523,17 @@ def ifft2(
     *,
     plan: _Unused | None = None,
 ) -> onp.Array[_ShapeT, np.complex128]: ...
+@overload
+def ifft2(
+    x: _AsComplex64[_ShapeT],
+    s: onp.ToJustInt1D | None = None,
+    axes: AnyShape = (-2, -1),
+    norm: _Norm | None = None,
+    overwrite_x: onp.ToBool = False,
+    workers: int | None = None,
+    *,
+    plan: _Unused | None = None,
+) -> onp.Array[_ShapeT, np.complex64]: ...
 @overload
 def ifft2(
     x: _AsComplex160[_ShapeT],
@@ -577,17 +581,6 @@ def ifft2(
 
 # keep in sync with `ihfft2`
 @overload
-def rfft2(  # type: ignore[overload-overlap]
-    x: _AsFloat32[_ShapeT],
-    s: onp.ToJustInt1D | None = None,
-    axes: AnyShape = (-2, -1),
-    norm: _Norm | None = None,
-    overwrite_x: onp.ToBool = False,
-    workers: int | None = None,
-    *,
-    plan: _Unused | None = None,
-) -> onp.Array[_ShapeT, np.complex64]: ...
-@overload
 def rfft2(
     x: _AsFloat64[_ShapeT],
     s: onp.ToJustInt1D | None = None,
@@ -598,6 +591,17 @@ def rfft2(
     *,
     plan: _Unused | None = None,
 ) -> onp.Array[_ShapeT, np.complex128]: ...
+@overload
+def rfft2(
+    x: _AsFloat32[_ShapeT],
+    s: onp.ToJustInt1D | None = None,
+    axes: AnyShape = (-2, -1),
+    norm: _Norm | None = None,
+    overwrite_x: onp.ToBool = False,
+    workers: int | None = None,
+    *,
+    plan: _Unused | None = None,
+) -> onp.Array[_ShapeT, np.complex64]: ...
 @overload
 def rfft2(
     x: _AsFloat80[_ShapeT],
@@ -645,17 +649,6 @@ def rfft2(
 
 # keep in sync with `hfft2`
 @overload
-def irfft2(  # type: ignore[overload-overlap]
-    x: _AsComplex64[_ShapeT],
-    s: onp.ToJustInt1D | None = None,
-    axes: AnyShape = (-2, -1),
-    norm: _Norm | None = None,
-    overwrite_x: onp.ToBool = False,
-    workers: int | None = None,
-    *,
-    plan: _Unused | None = None,
-) -> onp.Array[_ShapeT, np.float32]: ...
-@overload
 def irfft2(
     x: _AsComplex128[_ShapeT],
     s: onp.ToJustInt1D | None = None,
@@ -666,6 +659,17 @@ def irfft2(
     *,
     plan: _Unused | None = None,
 ) -> onp.Array[_ShapeT, np.float64]: ...
+@overload
+def irfft2(
+    x: _AsComplex64[_ShapeT],
+    s: onp.ToJustInt1D | None = None,
+    axes: AnyShape = (-2, -1),
+    norm: _Norm | None = None,
+    overwrite_x: onp.ToBool = False,
+    workers: int | None = None,
+    *,
+    plan: _Unused | None = None,
+) -> onp.Array[_ShapeT, np.float32]: ...
 @overload
 def irfft2(
     x: _AsComplex160[_ShapeT],
@@ -713,17 +717,6 @@ def irfft2(
 
 # keep in sync with `irfft2`
 @overload
-def hfft2(  # type: ignore[overload-overlap]
-    x: _AsComplex64[_ShapeT],
-    s: onp.ToJustInt1D | None = None,
-    axes: AnyShape = (-2, -1),
-    norm: _Norm | None = None,
-    overwrite_x: onp.ToBool = False,
-    workers: int | None = None,
-    *,
-    plan: _Unused | None = None,
-) -> onp.Array[_ShapeT, np.float32]: ...
-@overload
 def hfft2(
     x: _AsComplex128[_ShapeT],
     s: onp.ToJustInt1D | None = None,
@@ -734,6 +727,17 @@ def hfft2(
     *,
     plan: _Unused | None = None,
 ) -> onp.Array[_ShapeT, np.float64]: ...
+@overload
+def hfft2(
+    x: _AsComplex64[_ShapeT],
+    s: onp.ToJustInt1D | None = None,
+    axes: AnyShape = (-2, -1),
+    norm: _Norm | None = None,
+    overwrite_x: onp.ToBool = False,
+    workers: int | None = None,
+    *,
+    plan: _Unused | None = None,
+) -> onp.Array[_ShapeT, np.float32]: ...
 @overload
 def hfft2(
     x: _AsComplex160[_ShapeT],
@@ -781,17 +785,6 @@ def hfft2(
 
 # keep in sync with `rfft2`
 @overload
-def ihfft2(  # type: ignore[overload-overlap]
-    x: _AsFloat32[_ShapeT],
-    s: onp.ToJustInt1D | None = None,
-    axes: AnyShape = (-2, -1),
-    norm: _Norm | None = None,
-    overwrite_x: onp.ToBool = False,
-    workers: int | None = None,
-    *,
-    plan: _Unused | None = None,
-) -> onp.Array[_ShapeT, np.complex64]: ...
-@overload
 def ihfft2(
     x: _AsFloat64[_ShapeT],
     s: onp.ToJustInt1D | None = None,
@@ -802,6 +795,17 @@ def ihfft2(
     *,
     plan: _Unused | None = None,
 ) -> onp.Array[_ShapeT, np.complex128]: ...
+@overload
+def ihfft2(
+    x: _AsFloat32[_ShapeT],
+    s: onp.ToJustInt1D | None = None,
+    axes: AnyShape = (-2, -1),
+    norm: _Norm | None = None,
+    overwrite_x: onp.ToBool = False,
+    workers: int | None = None,
+    *,
+    plan: _Unused | None = None,
+) -> onp.Array[_ShapeT, np.complex64]: ...
 @overload
 def ihfft2(
     x: _AsFloat80[_ShapeT],
@@ -852,17 +856,6 @@ def ihfft2(
 
 # keep in sync with `ifftn`
 @overload
-def fftn(  # type: ignore[overload-overlap]
-    x: _AsComplex64[_ShapeT],
-    s: onp.ToJustIntND | None = None,
-    axes: AnyShape | None = None,
-    norm: _Norm | None = None,
-    overwrite_x: onp.ToBool = False,
-    workers: int | None = None,
-    *,
-    plan: _Unused | None = None,
-) -> onp.Array[_ShapeT, np.complex64]: ...
-@overload
 def fftn(
     x: _AsComplex128[_ShapeT],
     s: onp.ToJustIntND | None = None,
@@ -873,6 +866,17 @@ def fftn(
     *,
     plan: _Unused | None = None,
 ) -> onp.Array[_ShapeT, np.complex128]: ...
+@overload
+def fftn(
+    x: _AsComplex64[_ShapeT],
+    s: onp.ToJustIntND | None = None,
+    axes: AnyShape | None = None,
+    norm: _Norm | None = None,
+    overwrite_x: onp.ToBool = False,
+    workers: int | None = None,
+    *,
+    plan: _Unused | None = None,
+) -> onp.Array[_ShapeT, np.complex64]: ...
 @overload
 def fftn(
     x: _AsComplex160[_ShapeT],
@@ -909,17 +913,6 @@ def fftn(
 
 # keep in sync with `fftn`
 @overload
-def ifftn(  # type: ignore[overload-overlap]
-    x: _AsComplex64[_ShapeT],
-    s: onp.ToJustIntND | None = None,
-    axes: AnyShape | None = None,
-    norm: _Norm | None = None,
-    overwrite_x: onp.ToBool = False,
-    workers: int | None = None,
-    *,
-    plan: _Unused | None = None,
-) -> onp.Array[_ShapeT, np.complex64]: ...
-@overload
 def ifftn(
     x: _AsComplex128[_ShapeT],
     s: onp.ToJustIntND | None = None,
@@ -930,6 +923,17 @@ def ifftn(
     *,
     plan: _Unused | None = None,
 ) -> onp.Array[_ShapeT, np.complex128]: ...
+@overload
+def ifftn(
+    x: _AsComplex64[_ShapeT],
+    s: onp.ToJustIntND | None = None,
+    axes: AnyShape | None = None,
+    norm: _Norm | None = None,
+    overwrite_x: onp.ToBool = False,
+    workers: int | None = None,
+    *,
+    plan: _Unused | None = None,
+) -> onp.Array[_ShapeT, np.complex64]: ...
 @overload
 def ifftn(
     x: _AsComplex160[_ShapeT],
@@ -966,17 +970,6 @@ def ifftn(
 
 # keep in sync with `ihfftn`
 @overload
-def rfftn(  # type: ignore[overload-overlap]
-    x: _AsFloat32[_ShapeT],
-    s: onp.ToJustIntND | None = None,
-    axes: AnyShape | None = None,
-    norm: _Norm | None = None,
-    overwrite_x: onp.ToBool = False,
-    workers: int | None = None,
-    *,
-    plan: _Unused | None = None,
-) -> onp.Array[_ShapeT, np.complex64]: ...
-@overload
 def rfftn(
     x: _AsFloat64[_ShapeT],
     s: onp.ToJustIntND | None = None,
@@ -987,6 +980,17 @@ def rfftn(
     *,
     plan: _Unused | None = None,
 ) -> onp.Array[_ShapeT, np.complex128]: ...
+@overload
+def rfftn(
+    x: _AsFloat32[_ShapeT],
+    s: onp.ToJustIntND | None = None,
+    axes: AnyShape | None = None,
+    norm: _Norm | None = None,
+    overwrite_x: onp.ToBool = False,
+    workers: int | None = None,
+    *,
+    plan: _Unused | None = None,
+) -> onp.Array[_ShapeT, np.complex64]: ...
 @overload
 def rfftn(
     x: _AsFloat80[_ShapeT],
@@ -1023,17 +1027,6 @@ def rfftn(
 
 # keep in sync with `hfftn`
 @overload
-def irfftn(  # type: ignore[overload-overlap]
-    x: _AsComplex64[_ShapeT],
-    s: onp.ToJustIntND | None = None,
-    axes: AnyShape | None = None,
-    norm: _Norm | None = None,
-    overwrite_x: onp.ToBool = False,
-    workers: int | None = None,
-    *,
-    plan: _Unused | None = None,
-) -> onp.Array[_ShapeT, np.float32]: ...
-@overload
 def irfftn(
     x: _AsComplex128[_ShapeT],
     s: onp.ToJustIntND | None = None,
@@ -1044,6 +1037,17 @@ def irfftn(
     *,
     plan: _Unused | None = None,
 ) -> onp.Array[_ShapeT, np.float64]: ...
+@overload
+def irfftn(
+    x: _AsComplex64[_ShapeT],
+    s: onp.ToJustIntND | None = None,
+    axes: AnyShape | None = None,
+    norm: _Norm | None = None,
+    overwrite_x: onp.ToBool = False,
+    workers: int | None = None,
+    *,
+    plan: _Unused | None = None,
+) -> onp.Array[_ShapeT, np.float32]: ...
 @overload
 def irfftn(
     x: _AsComplex160[_ShapeT],
@@ -1080,17 +1084,6 @@ def irfftn(
 
 # keep in sync with `irfftn`
 @overload
-def hfftn(  # type: ignore[overload-overlap]
-    x: _AsComplex64[_ShapeT],
-    s: onp.ToJustIntND | None = None,
-    axes: AnyShape | None = None,
-    norm: _Norm | None = None,
-    overwrite_x: onp.ToBool = False,
-    workers: int | None = None,
-    *,
-    plan: _Unused | None = None,
-) -> onp.Array[_ShapeT, np.float32]: ...
-@overload
 def hfftn(
     x: _AsComplex128[_ShapeT],
     s: onp.ToJustIntND | None = None,
@@ -1101,6 +1094,17 @@ def hfftn(
     *,
     plan: _Unused | None = None,
 ) -> onp.Array[_ShapeT, np.float64]: ...
+@overload
+def hfftn(
+    x: _AsComplex64[_ShapeT],
+    s: onp.ToJustIntND | None = None,
+    axes: AnyShape | None = None,
+    norm: _Norm | None = None,
+    overwrite_x: onp.ToBool = False,
+    workers: int | None = None,
+    *,
+    plan: _Unused | None = None,
+) -> onp.Array[_ShapeT, np.float32]: ...
 @overload
 def hfftn(
     x: _AsComplex160[_ShapeT],
@@ -1137,17 +1141,6 @@ def hfftn(
 
 # keep in sync with `rfftn`
 @overload
-def ihfftn(  # type: ignore[overload-overlap]
-    x: _AsFloat32[_ShapeT],
-    s: onp.ToJustIntND | None = None,
-    axes: AnyShape | None = None,
-    norm: _Norm | None = None,
-    overwrite_x: onp.ToBool = False,
-    workers: int | None = None,
-    *,
-    plan: _Unused | None = None,
-) -> onp.Array[_ShapeT, np.complex64]: ...
-@overload
 def ihfftn(
     x: _AsFloat64[_ShapeT],
     s: onp.ToJustIntND | None = None,
@@ -1158,6 +1151,17 @@ def ihfftn(
     *,
     plan: _Unused | None = None,
 ) -> onp.Array[_ShapeT, np.complex128]: ...
+@overload
+def ihfftn(
+    x: _AsFloat32[_ShapeT],
+    s: onp.ToJustIntND | None = None,
+    axes: AnyShape | None = None,
+    norm: _Norm | None = None,
+    overwrite_x: onp.ToBool = False,
+    workers: int | None = None,
+    *,
+    plan: _Unused | None = None,
+) -> onp.Array[_ShapeT, np.complex64]: ...
 @overload
 def ihfftn(
     x: _AsFloat80[_ShapeT],

--- a/scipy-stubs/linalg/_misc.pyi
+++ b/scipy-stubs/linalg/_misc.pyi
@@ -1,4 +1,4 @@
-from typing import Literal, TypeAlias, TypeVar, overload
+from typing import Any, Literal, TypeAlias, TypeVar, overload
 
 import numpy as np
 import optype as op
@@ -11,8 +11,7 @@ __all__ = ["LinAlgError", "LinAlgWarning", "norm"]
 _Inf: TypeAlias = float
 _Order: TypeAlias = Literal["fro", "nuc", 0, 1, -1, 2, -2] | _Inf
 _Axis: TypeAlias = op.CanIndex | tuple[op.CanIndex, op.CanIndex]
-
-_SubScalar: TypeAlias = np.complex128 | np.float64 | npc.integer | np.bool_
+_SubScalar: TypeAlias = npc.inexact64 | npc.integer | np.bool_
 
 _ShapeT = TypeVar("_ShapeT", bound=tuple[int, ...])
 
@@ -23,7 +22,7 @@ class LinAlgWarning(RuntimeWarning): ...
 # NOTE: the mypy errors are false positives (join vs union)
 
 @overload  # scalar, axis: None = ...
-def norm(  # type: ignore[overload-overlap]
+def norm(
     a: complex | _SubScalar,
     ord: _Order | None = None,
     axis: None = None,
@@ -32,11 +31,7 @@ def norm(  # type: ignore[overload-overlap]
 ) -> np.float64: ...
 @overload  # inexact32, axis: None = ...
 def norm(
-    a: np.float32 | np.complex64,
-    ord: _Order | None = None,
-    axis: None = None,
-    keepdims: op.CanBool = False,
-    check_finite: onp.ToBool = True,
+    a: npc.inexact32, ord: _Order | None = None, axis: None = None, keepdims: op.CanBool = False, check_finite: onp.ToBool = True
 ) -> np.float32: ...
 @overload  # longdouble, axis: None = ...
 def norm(
@@ -55,7 +50,7 @@ def norm(
     check_finite: onp.ToBool = True,
 ) -> np.float64: ...
 @overload  # float64-coercible array, keepdims: True (positional)
-def norm(  # type: ignore[overload-overlap]
+def norm(
     a: onp.ArrayND[_SubScalar, _ShapeT],
     ord: _Order | None,
     axis: _Axis | None,
@@ -63,7 +58,7 @@ def norm(  # type: ignore[overload-overlap]
     check_finite: onp.ToBool = True,
 ) -> onp.ArrayND[np.float64, _ShapeT]: ...
 @overload  # float64-coercible array, keepdims: True (keyword)
-def norm(  # type: ignore[overload-overlap]
+def norm(
     a: onp.ArrayND[_SubScalar, _ShapeT],
     ord: _Order | None = None,
     axis: _Axis | None = None,
@@ -72,7 +67,7 @@ def norm(  # type: ignore[overload-overlap]
     check_finite: onp.ToBool = True,
 ) -> onp.ArrayND[np.float64, _ShapeT]: ...
 @overload  # float64-coercible array-like, keepdims: True (positional)
-def norm(  # type: ignore[overload-overlap]
+def norm(
     a: onp.SequenceND[onp.CanArrayND[_SubScalar]] | onp.SequenceND[complex | _SubScalar],
     ord: _Order | None,
     axis: _Axis | None,
@@ -80,7 +75,7 @@ def norm(  # type: ignore[overload-overlap]
     check_finite: onp.ToBool = True,
 ) -> onp.ArrayND[np.float64]: ...
 @overload  # float64-coercible array-like, keepdims: True (keyword)
-def norm(  # type: ignore[overload-overlap]
+def norm(
     a: onp.SequenceND[onp.CanArrayND[_SubScalar]] | onp.SequenceND[complex | _SubScalar],
     ord: _Order | None = None,
     axis: _Axis | None = None,
@@ -90,7 +85,7 @@ def norm(  # type: ignore[overload-overlap]
 ) -> onp.ArrayND[np.float64]: ...
 @overload  # shaped inexact32 array, keepdims: True (positional)
 def norm(
-    a: onp.ArrayND[np.float32 | np.complex64, _ShapeT],
+    a: onp.ArrayND[npc.inexact32, _ShapeT],
     ord: _Order | None,
     axis: _Axis | None,
     keepdims: onp.ToTrue,
@@ -106,7 +101,7 @@ def norm(
 ) -> onp.ArrayND[np.longdouble, _ShapeT]: ...
 @overload  # shaped inexact32 array, keepdims: True (keyword)
 def norm(
-    a: onp.ArrayND[np.float32 | np.complex64, _ShapeT],
+    a: onp.ArrayND[npc.inexact32, _ShapeT],
     ord: _Order | None = None,
     axis: _Axis | None = None,
     *,
@@ -124,7 +119,7 @@ def norm(
 ) -> onp.ArrayND[np.longdouble, _ShapeT]: ...
 @overload  # scalar array-like, keepdims: True (positional)
 def norm(
-    a: onp.SequenceND[onp.CanArrayND[np.float32 | np.complex64]] | onp.SequenceND[np.float32 | np.complex64],
+    a: onp.SequenceND[onp.CanArrayND[npc.inexact32]] | onp.SequenceND[npc.inexact32],
     ord: _Order | None,
     axis: _Axis | None,
     keepdims: onp.ToTrue,
@@ -140,7 +135,7 @@ def norm(
 ) -> onp.ArrayND[np.longdouble]: ...
 @overload  # scalar array-like, keepdims: True (keyword)
 def norm(
-    a: onp.SequenceND[onp.CanArrayND[np.float32 | np.complex64]] | onp.SequenceND[np.float32 | np.complex64],
+    a: onp.SequenceND[onp.CanArrayND[npc.inexact32]] | onp.SequenceND[npc.inexact32],
     ord: _Order | None = None,
     axis: _Axis | None = None,
     *,
@@ -187,4 +182,4 @@ def norm(
 ) -> npc.floating | onp.ArrayND[npc.floating]: ...
 
 #
-def _datacopied(arr: onp.ArrayND, original: onp.CanArrayND) -> bool: ...  # undocumented
+def _datacopied(arr: onp.ArrayND[Any], original: onp.CanArrayND[Any]) -> bool: ...  # undocumented


### PR DESCRIPTION
When [`jorenham/optype@aff7f6b`](https://github.com/jorenham/optype/pull/349/commits/aff7f6bed327823553a49de18fb23d9fb2d6fdaa) is installed, these changes will resolve the 75 false-positive pyright errors that are reported when running `pyright tests` or `basedpyright tests` (without a path these weren't reported).

The changes here should not directly affect the users of static type-checkers other than pyright (assuming they follow the typing spec correctly).

This workaround is a lot more subtle than #742, but requires a releasing a new `optype` version that removes the first type parameter default for `optype.numpy.CanArrayND` (which is a breaking change). 

Personally, I prefer this workaround over #742. So I'll work on a new optype `0.12` release for this. It's no problem to merge this before that time, since this doesn't cause any new false-positives without the new optype release.