### PR TITLE
🐛 `sparse`: csc array/matrix constructor fixes

### DIFF
--- a/scipy-stubs/sparse/_csc.pyi
+++ b/scipy-stubs/sparse/_csc.pyi
@@ -106,28 +106,6 @@ class csc_array(_csc_base[_ScalarT_co], sparray[_ScalarT_co, tuple[int, int]], G
         *,
         maxprint: int | None = None,
     ) -> None: ...
-    @overload  # 2-D, dtype: <known> (positional)
-    def __init__(
-        self,
-        /,
-        arg1: _ToAnyCSC,
-        shape: _ToShape2D | None,
-        dtype: onp.ToDType[_ScalarT_co],
-        copy: bool = False,
-        *,
-        maxprint: int | None = None,
-    ) -> None: ...
-    @overload  # 2-D, dtype: <known> (keyword)
-    def __init__(
-        self,
-        /,
-        arg1: _ToAnyCSC,
-        shape: _ToShape2D | None = None,
-        *,
-        dtype: onp.ToDType[_ScalarT_co],
-        copy: bool = False,
-        maxprint: int | None = None,
-    ) -> None: ...
     @overload  # 2-d array-like bool, dtype: bool-like | None
     def __init__(
         self: csc_array[np.bool_],
@@ -257,6 +235,28 @@ class csc_array(_csc_base[_ScalarT_co], sparray[_ScalarT_co, tuple[int, int]], G
         shape: _ToShape2D | None = None,
         *,
         dtype: onp.AnyComplex128DType,
+        copy: bool = False,
+        maxprint: int | None = None,
+    ) -> None: ...
+    @overload  # 2-D, dtype: <known> (positional)
+    def __init__(
+        self,
+        /,
+        arg1: _ToAnyCSC,
+        shape: _ToShape2D | None,
+        dtype: onp.ToDType[_ScalarT_co],
+        copy: bool = False,
+        *,
+        maxprint: int | None = None,
+    ) -> None: ...
+    @overload  # 2-D, dtype: <known> (keyword)
+    def __init__(
+        self,
+        /,
+        arg1: _ToAnyCSC,
+        shape: _ToShape2D | None = None,
+        *,
+        dtype: onp.ToDType[_ScalarT_co],
         copy: bool = False,
         maxprint: int | None = None,
     ) -> None: ...
@@ -295,28 +295,6 @@ class csc_matrix(_csc_base[_ScalarT_co], spmatrix[_ScalarT_co], Generic[_ScalarT
         *,
         maxprint: int | None = None,
     ) -> None: ...
-    @overload  # 2-D, dtype: <known> (positional)
-    def __init__(
-        self,
-        /,
-        arg1: _ToAnyCSC,
-        shape: _ToShape2D | None,
-        dtype: onp.ToDType[_ScalarT_co],
-        copy: bool = False,
-        *,
-        maxprint: int | None = None,
-    ) -> None: ...
-    @overload  # 2-D, dtype: <known> (keyword)
-    def __init__(
-        self,
-        /,
-        arg1: _ToAnyCSC,
-        shape: _ToShape2D | None = None,
-        *,
-        dtype: onp.ToDType[_ScalarT_co],
-        copy: bool = False,
-        maxprint: int | None = None,
-    ) -> None: ...
     @overload  # 2-d array-like bool, dtype: bool-like | None
     def __init__(
         self: csc_matrix[np.bool_],
@@ -446,6 +424,28 @@ class csc_matrix(_csc_base[_ScalarT_co], spmatrix[_ScalarT_co], Generic[_ScalarT
         shape: _ToShape2D | None = None,
         *,
         dtype: onp.AnyComplex128DType,
+        copy: bool = False,
+        maxprint: int | None = None,
+    ) -> None: ...
+    @overload  # 2-D, dtype: <known> (positional)
+    def __init__(
+        self,
+        /,
+        arg1: _ToAnyCSC,
+        shape: _ToShape2D | None,
+        dtype: onp.ToDType[_ScalarT_co],
+        copy: bool = False,
+        *,
+        maxprint: int | None = None,
+    ) -> None: ...
+    @overload  # 2-D, dtype: <known> (keyword)
+    def __init__(
+        self,
+        /,
+        arg1: _ToAnyCSC,
+        shape: _ToShape2D | None = None,
+        *,
+        dtype: onp.ToDType[_ScalarT_co],
         copy: bool = False,
         maxprint: int | None = None,
     ) -> None: ...

--- a/tests/sparse/test_csc.pyi
+++ b/tests/sparse/test_csc.pyi
@@ -6,7 +6,7 @@ import numpy as np
 from ._types import ScalarType, csr_arr, csr_mat
 from scipy.sparse import csc_array, csc_matrix
 
-scalartype: ScalarType
+dtype: np.dtype[ScalarType]
 
 shape2: tuple[int, int]
 
@@ -29,7 +29,7 @@ csc_spec3: tuple[
 
 # csc_matrix(D)
 assert_type(csc_matrix(data2), csc_matrix[ScalarType])
-assert_type(csc_matrix(data2, dtype=scalartype), csc_matrix[ScalarType])
+assert_type(csc_matrix(data2, dtype=dtype), csc_matrix[ScalarType])
 assert_type(csc_matrix(data2, dtype=bool), csc_matrix[np.bool_])
 assert_type(csc_matrix(data2, dtype=int), csc_matrix[np.int_])
 assert_type(csc_matrix(data2, dtype=float), csc_matrix[np.float64])
@@ -41,7 +41,7 @@ assert_type(csc_matrix(csr_mat), csc_matrix[ScalarType])
 
 # csc_matrix((M, N), [dtype])
 assert_type(csc_matrix(shape2), csc_matrix[np.float64])
-assert_type(csc_matrix(shape2, dtype=scalartype), csc_matrix[ScalarType])
+assert_type(csc_matrix(shape2, dtype=dtype), csc_matrix[ScalarType])
 assert_type(csc_matrix(shape2, dtype=bool), csc_matrix[np.bool_])
 assert_type(csc_matrix(shape2, dtype=int), csc_matrix[np.int_])
 assert_type(csc_matrix(shape2, dtype=float), csc_matrix[np.float64])
@@ -52,7 +52,7 @@ assert_type(csc_matrix(csc_spec2), csc_matrix[ScalarType])
 assert_type(csc_matrix(csc_spec2, shape2), csc_matrix[ScalarType])
 assert_type(csc_matrix(csc_spec2, shape=shape2), csc_matrix[ScalarType])
 
-assert_type(csc_matrix(csc_spec2, dtype=scalartype), csc_matrix[ScalarType])
+assert_type(csc_matrix(csc_spec2, dtype=dtype), csc_matrix[ScalarType])
 assert_type(csc_matrix(csc_spec2, dtype=bool), csc_matrix[np.bool_])
 assert_type(csc_matrix(csc_spec2, dtype=int), csc_matrix[np.int_])
 assert_type(csc_matrix(csc_spec2, dtype=float), csc_matrix[np.float64])
@@ -64,7 +64,7 @@ assert_type(csc_matrix(csc_spec3), csc_matrix[ScalarType])  # type: ignore[asser
 assert_type(csc_matrix(csc_spec3, shape2), csc_matrix[ScalarType])  # type: ignore[assert-type]
 assert_type(csc_matrix(csc_spec3, shape=shape2), csc_matrix[ScalarType])  # type: ignore[assert-type]
 
-assert_type(csc_matrix(csc_spec3, dtype=scalartype), csc_matrix[ScalarType])
+assert_type(csc_matrix(csc_spec3, dtype=dtype), csc_matrix[ScalarType])
 assert_type(csc_matrix(csc_spec3, dtype=bool), csc_matrix[np.bool_])
 assert_type(csc_matrix(csc_spec3, dtype=int), csc_matrix[np.int_])
 assert_type(csc_matrix(csc_spec3, dtype=float), csc_matrix[np.float64])
@@ -75,19 +75,19 @@ assert_type(csc_matrix(csc_spec3, dtype=complex), csc_matrix[np.complex128])
 
 # csc_array(D)
 assert_type(csc_array(data2), csc_array[ScalarType])
-assert_type(csc_array(data2, dtype=scalartype), csc_array[ScalarType])
+assert_type(csc_array(data2, dtype=dtype), csc_array[ScalarType])
 assert_type(csc_array(data2, dtype=bool), csc_array[np.bool_])
 assert_type(csc_array(data2, dtype=int), csc_array[np.int_])
 assert_type(csc_array(data2, dtype=float), csc_array[np.float64])
 assert_type(csc_array(data2, dtype=complex), csc_array[np.complex128])
 
-# csc_matrix(S)
+# csc_array(S)
 assert_type(csc_array(csr_arr), csc_array[ScalarType])
 assert_type(csc_array(csr_mat), csc_array[ScalarType])
 
 # csc_array((M, N), [dtype])
 assert_type(csc_array(shape2), csc_array[np.float64])
-assert_type(csc_array(shape2, dtype=scalartype), csc_array[ScalarType])
+assert_type(csc_array(shape2, dtype=dtype), csc_array[ScalarType])
 assert_type(csc_array(shape2, dtype=bool), csc_array[np.bool_])
 assert_type(csc_array(shape2, dtype=int), csc_array[np.int_])
 assert_type(csc_array(shape2, dtype=float), csc_array[np.float64])
@@ -98,7 +98,7 @@ assert_type(csc_array(csc_spec2), csc_array[ScalarType])
 assert_type(csc_array(csc_spec2, shape2), csc_array[ScalarType])
 assert_type(csc_array(csc_spec2, shape=shape2), csc_array[ScalarType])
 
-assert_type(csc_array(csc_spec2, dtype=scalartype), csc_array[ScalarType])
+assert_type(csc_array(csc_spec2, dtype=dtype), csc_array[ScalarType])
 assert_type(csc_array(csc_spec2, dtype=bool), csc_array[np.bool_])
 assert_type(csc_array(csc_spec2, dtype=int), csc_array[np.int_])
 assert_type(csc_array(csc_spec2, dtype=float), csc_array[np.float64])
@@ -110,7 +110,7 @@ assert_type(csc_array(csc_spec3), csc_array[ScalarType])  # type: ignore[assert-
 assert_type(csc_array(csc_spec3, shape2), csc_array[ScalarType])  # type: ignore[assert-type]
 assert_type(csc_array(csc_spec3, shape=shape2), csc_array[ScalarType])  # type: ignore[assert-type]
 
-assert_type(csc_array(csc_spec3, dtype=scalartype), csc_array[ScalarType])
+assert_type(csc_array(csc_spec3, dtype=dtype), csc_array[ScalarType])
 assert_type(csc_array(csc_spec3, dtype=bool), csc_array[np.bool_])
 assert_type(csc_array(csc_spec3, dtype=int), csc_array[np.int_])
 assert_type(csc_array(csc_spec3, dtype=float), csc_array[np.float64])


### PR DESCRIPTION
Closes #748

---

This somehow also managed to trigger the pyright bug, which is the 4th or 5th time I've seen it. As usual, I worked around it by shuffling the overloads. But this time, I also had to pass `np.dtype[SCT]` in the tests, instead of the `SCT`. Otherwise, two `reportCallIssue` were reported at line 44 and 90 in `test_csc.pyi`, which clearly makes no sense, because the `assert_type` still worked, instead of it being inferred as `Unknown`.