### PR TITLE
📝 `CONTRIBUTING.md` fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,14 +27,14 @@ installed. Now you can install the project with the dev dependencies:
 uv sync --python 3.11
 ```
 
-By installing the lowest support Python version (3.11 in this example), it prevents
+Installing the lowest supported Python version (3.11 in this example) prevents
 your IDE from e.g. auto-importing unsupported `typing` features.
 
 ## Lefthook
 
-[Lefthook] is a modern Git hooks manager, which automatically lints and formats
-your code before you committing it. It will also keep your `uv` environment
-up-to-date with the lockfile when you `git pull`.
+[Lefthook](https://github.com/evilmartians/lefthook) is a modern Git hooks manager,
+which automatically lints and formats your code before you commit it. It will also sync
+your `uv` environment with the lockfile when you `git pull` or `git checkout`.
 
 To install it as a `uv` tool, run
 
@@ -48,7 +48,7 @@ To set it up, navigate to the root of the `scipy-stubs` repo, and run
 uvx lefthook install
 ```
 
-Now let's see it all works:
+Now let's see if it all works:
 
 ```bash
 $ uvx lefthook validate
@@ -108,9 +108,9 @@ See <https://typing.python.org/en/latest/guides/writing_stubs.html#style-guide>.
 
 ## Commit message style
 
-Scipy-stubs recommends using [Gitmoji](https://gitmoji.dev/) for commit messages and PR
-titles. For VSCode and VSCodium users, it is recommended to use the
-[`gitmoji-vscode` extension](https://github.com/seatonjiang/gitmoji-vscode) for this.
+scipy-stubs recommends using [Gitmoji](https://gitmoji.dev/) for commit messages and PR
+titles. For VSCode and VSCodium users, it can be convenient to use the
+[`gitmoji-vscode`](https://github.com/seatonjiang/gitmoji-vscode) extension for this.
 
 [coc]: https://docs.scipy.org/doc/scipy/dev/conduct/code_of_conduct.html
 [license]: https://github.com/scipy/scipy-stubs/blob/master/LICENSE

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,11 @@ mypy: OK ✔ in 16.69 seconds
 
 All [documentation] lives in the `README.md`. Please read it carefully before proposing
 any changes. Ensure that the markdown is formatted correctly with
-[markdownlint](https://github.com/DavidAnson/markdownlint).
+[dprint][dprint] by running:
+
+```shell
+uv run dprint fmt
+```
 
 ## Testing
 
@@ -115,3 +119,4 @@ titles. For VSCode and VSCodium users, it can be convenient to use the
 [coc]: https://docs.scipy.org/doc/scipy/dev/conduct/code_of_conduct.html
 [license]: https://github.com/scipy/scipy-stubs/blob/master/LICENSE
 [tests]: https://github.com/scipy/scipy-stubs/tree/master/tests
+[dprint]: https://github.com/dprint/dprint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ To install it as a `uv` tool, run
 uv tool install lefthook --upgrade
 ```
 
-To set it up, navigate to the root of the `numtype` repo, and run
+To set it up, navigate to the root of the `scipy-stubs` repo, and run
 
 ```shell
 uvx lefthook install


### PR DESCRIPTION
This fixes some stylistic and grammatrical issues, and replaces outdated references to `markdownlint` with `dprint` ones.