### PR TITLE
🐛 `interpolate`: Fix incorrect return type for `make_lsq_spline`

### DIFF
--- a/scipy-stubs/interpolate/_bsplines.pyi
+++ b/scipy-stubs/interpolate/_bsplines.pyi
@@ -184,7 +184,7 @@ def make_smoothing_spline(
     lam: onp.ToFloat | None = None,
     *,
     axis: op.CanIndex = 0,
-) -> BSpline[np.float64]: ...
+) -> BSpline[np.complex128]: ...
 
 #
 def fpcheck(x: onp.ToFloat1D, t: onp.ToFloat1D, k: onp.ToJustInt) -> None: ...  # undocumented

--- a/scipy-stubs/interpolate/_bsplines.pyi
+++ b/scipy-stubs/interpolate/_bsplines.pyi
@@ -162,7 +162,7 @@ def make_lsq_spline(
     check_finite: onp.ToBool = True,
     *,
     method: _LSQMethod = "qr",
-) -> BSpline[np.complex128]: ...
+) -> BSpline[np.float64]: ...
 @overload
 def make_lsq_spline(
     x: onp.ToFloat1D,

--- a/scipy-stubs/interpolate/_bsplines.pyi
+++ b/scipy-stubs/interpolate/_bsplines.pyi
@@ -142,7 +142,7 @@ def make_interp_spline(
 @overload
 def make_lsq_spline(
     x: onp.ToFloat1D,
-    y: onp.ToJustComplexND,
+    y: onp.ToFloatND,
     t: onp.ToFloat1D,
     k: op.CanIndex = 3,
     w: onp.ToFloat1D | None = None,
@@ -154,7 +154,7 @@ def make_lsq_spline(
 @overload
 def make_lsq_spline(
     x: onp.ToFloat1D,
-    y: onp.ToFloatND,
+    y: onp.ToJustComplexND,
     t: onp.ToFloat1D,
     k: op.CanIndex = 3,
     w: onp.ToFloat1D | None = None,
@@ -162,7 +162,7 @@ def make_lsq_spline(
     check_finite: onp.ToBool = True,
     *,
     method: _LSQMethod = "qr",
-) -> BSpline[np.float64]: ...
+) -> BSpline[np.complex128]: ...
 @overload
 def make_lsq_spline(
     x: onp.ToFloat1D,
@@ -184,7 +184,7 @@ def make_smoothing_spline(
     lam: onp.ToFloat | None = None,
     *,
     axis: op.CanIndex = 0,
-) -> BSpline[np.complex128]: ...
+) -> BSpline[np.float64]: ...
 
 #
 def fpcheck(x: onp.ToFloat1D, t: onp.ToFloat1D, k: onp.ToJustInt) -> None: ...  # undocumented


### PR DESCRIPTION
The overloads for `make_lsq_spline` in `_bsplines.pyi` had their return types for float and complex `y` inputs swapped.

This change corrects the type hints to ensure that:
- `make_lsq_spline` with a float `y` array correctly returns `BSpline[np.float64]`.
- `make_lsq_spline` with a complex `y` array correctly returns `BSpline[np.complex128]`.

Hopefully this resolves incorrect type checker errors for valid float-only spline creation. 😄 