### PR TITLE
🏷️ fixed typing in ARPACK stubs

### DIFF
--- a/scipy-stubs/sparse/linalg/_eigen/arpack/arpack.pyi
+++ b/scipy-stubs/sparse/linalg/_eigen/arpack/arpack.pyi
@@ -27,9 +27,13 @@ class ArpackError(RuntimeError):
 
 class ArpackNoConvergence(ArpackError):
     eigenvalues: Final[onp.Array1D[np.float64 | np.complex128]]
-    eigenvectors: Final[onp.Array2D[np.float64]]
+    eigenvectors: Final[onp.Array2D[np.float64 | np.complex128]]
     def __init__(
-        self, /, msg: str, eigenvalues: onp.Array1D[np.float64 | np.complex128], eigenvectors: onp.Array2D[np.float64]
+        self,
+        /,
+        msg: str,
+        eigenvalues: onp.Array1D[np.float64 | np.complex128],
+        eigenvectors: onp.Array2D[np.float64 | np.complex128],
     ) -> None: ...
 
 #
@@ -37,49 +41,49 @@ class ArpackNoConvergence(ArpackError):
 def eigs(
     A: _ToComplexMatrix,
     k: int = 6,
-    M: _ToRealMatrix | None = None,
+    M: _ToComplexMatrix | None = None,
     sigma: onp.ToComplex | None = None,
     which: _Which_eigs = "LM",
-    v0: onp.ToFloat1D | None = None,
+    v0: onp.ToComplex1D | None = None,
     ncv: int | None = None,
     maxiter: int | None = None,
     tol: float = 0,
     return_eigenvectors: onp.ToTrue = True,
-    Minv: _ToRealMatrix | None = None,
-    OPinv: _ToRealMatrix | None = None,
+    Minv: _ToComplexMatrix | None = None,
+    OPinv: _ToComplexMatrix | None = None,
     OPpart: _OPpart | None = None,
-) -> tuple[onp.Array1D[np.complex128], onp.Array2D[np.float64]]: ...
+) -> tuple[onp.Array1D[np.complex128], onp.Array2D[np.complex128]]: ...
 @overload  # returns_eigenvectors: falsy (positional)
 def eigs(
     A: _ToComplexMatrix,
     k: int,
-    M: _ToRealMatrix | None,
+    M: _ToComplexMatrix | None,
     sigma: onp.ToComplex | None,
     which: _Which_eigs,
-    v0: onp.ToFloat1D | None,
+    v0: onp.ToComplex1D | None,
     ncv: int | None,
     maxiter: int | None,
     tol: float,
     return_eigenvectors: onp.ToFalse,
-    Minv: _ToRealMatrix | None = None,
-    OPinv: _ToRealMatrix | None = None,
+    Minv: _ToComplexMatrix | None = None,
+    OPinv: _ToComplexMatrix | None = None,
     OPpart: _OPpart | None = None,
 ) -> onp.Array1D[np.complex128]: ...
 @overload  # returns_eigenvectors: falsy (keyword)
 def eigs(
     A: _ToComplexMatrix,
     k: int = 6,
-    M: _ToRealMatrix | None = None,
+    M: _ToComplexMatrix | None = None,
     sigma: onp.ToComplex | None = None,
     which: _Which_eigs = "LM",
-    v0: onp.ToFloat1D | None = None,
+    v0: onp.ToComplex1D | None = None,
     ncv: int | None = None,
     maxiter: int | None = None,
     tol: float = 0,
     *,
     return_eigenvectors: onp.ToFalse,
-    Minv: _ToRealMatrix | None = None,
-    OPinv: _ToRealMatrix | None = None,
+    Minv: _ToComplexMatrix | None = None,
+    OPinv: _ToComplexMatrix | None = None,
     OPpart: _OPpart | None = None,
 ) -> onp.Array1D[np.complex128]: ...
 
@@ -88,48 +92,48 @@ def eigs(
 def eigsh(
     A: _ToComplexMatrix,
     k: int = 6,
-    M: _ToRealMatrix | None = None,
-    sigma: onp.ToComplex | None = None,
+    M: _ToComplexMatrix | None = None,
+    sigma: onp.ToFloat | None = None,
     which: _Which_eigsh = "LM",
-    v0: onp.ToFloat1D | None = None,
+    v0: onp.ToComplex1D | None = None,
     ncv: int | None = None,
     maxiter: int | None = None,
     tol: float = 0,
     return_eigenvectors: onp.ToTrue = True,
-    Minv: _ToRealMatrix | None = None,
-    OPinv: _ToRealMatrix | None = None,
+    Minv: _ToComplexMatrix | None = None,
+    OPinv: _ToComplexMatrix | None = None,
     mode: _Mode = "normal",
-) -> tuple[onp.Array1D[np.float64], onp.Array2D[np.float64]]: ...
+) -> tuple[onp.Array1D[np.float64], onp.Array2D[np.float64 | np.complex128]]: ...
 @overload  # returns_eigenvectors: falsy (positional)
 def eigsh(
     A: _ToComplexMatrix,
     k: int,
-    M: _ToRealMatrix | None,
-    sigma: onp.ToComplex | None,
+    M: _ToComplexMatrix | None,
+    sigma: onp.ToFloat | None,
     which: _Which_eigsh,
-    v0: onp.ToFloat1D | None,
+    v0: onp.ToComplex1D | None,
     ncv: int | None,
     maxiter: int | None,
     tol: float,
     return_eigenvectors: onp.ToFalse,
-    Minv: _ToRealMatrix | None = None,
-    OPinv: _ToRealMatrix | None = None,
+    Minv: _ToComplexMatrix | None = None,
+    OPinv: _ToComplexMatrix | None = None,
     mode: _Mode = "normal",
 ) -> onp.Array1D[np.float64]: ...
 @overload  # returns_eigenvectors: falsy (keyword)
 def eigsh(
     A: _ToComplexMatrix,
     k: int = 6,
-    M: _ToRealMatrix | None = None,
-    sigma: onp.ToComplex | None = None,
+    M: _ToComplexMatrix | None = None,
+    sigma: onp.ToFloat | None = None,
     which: _Which_eigsh = "LM",
-    v0: onp.ToFloat1D | None = None,
+    v0: onp.ToComplex1D | None = None,
     ncv: int | None = None,
     maxiter: int | None = None,
     tol: float = 0,
     *,
     return_eigenvectors: onp.ToFalse,
-    Minv: _ToRealMatrix | None = None,
-    OPinv: _ToRealMatrix | None = None,
+    Minv: _ToComplexMatrix | None = None,
+    OPinv: _ToComplexMatrix | None = None,
     mode: _Mode = "normal",
 ) -> onp.Array1D[np.float64]: ...

--- a/scipy-stubs/sparse/linalg/_eigen/arpack/arpack.pyi
+++ b/scipy-stubs/sparse/linalg/_eigen/arpack/arpack.pyi
@@ -3,7 +3,6 @@ from typing import Final, Literal, TypeAlias, TypeVar, overload
 
 import numpy as np
 import optype.numpy as onp
-import optype.numpy.compat as npc
 
 from scipy.sparse._base import _spbase
 from scipy.sparse.linalg import LinearOperator
@@ -12,7 +11,6 @@ __all__ = ["ArpackError", "ArpackNoConvergence", "eigs", "eigsh"]
 
 _KT = TypeVar("_KT")
 
-_ToRealMatrix: TypeAlias = onp.ToFloat2D | LinearOperator[npc.floating | npc.integer] | _spbase
 _ToComplexMatrix: TypeAlias = onp.ToComplex2D | LinearOperator | _spbase
 
 _Which_eigs: TypeAlias = Literal["LM", "SM", "LR", "SR", "LI", "SI"]


### PR DESCRIPTION
Hi!

I noticed that my type checker expected the eigenvectors returned by `eigs` to be of type `float64`, while the actual result is always `complex128`. (From a mathematical standpoint the eigenvectors are also not always real.)

After looking at the stubs I noticed room for additional improvements:
* `M`, `Minv`, and `OPinv` can be complex
* `v0` can be complex
* `sigma` should not be complex in `eigsh` (see https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.eigsh.html)

Let me know if I missed anything!

Kind regards,
Jul