### PR TITLE
✨ `optimize`: have `linprog` return a specialized `OptimizeResult`

### DIFF
--- a/scipy-stubs/optimize/_linprog.pyi
+++ b/scipy-stubs/optimize/_linprog.pyi
@@ -77,9 +77,6 @@ class _OptionsSimplex(_OptionsCommonLegacy, TypedDict, total=False):
 
 ###
 
-__docformat__: Final = "restructuredtext en"  # undocumented
-LINPROG_METHODS: Final[Sequence[MethodLinprog | MethodLinprogLegacy]] = ...  # undocumented
-
 class OptimizeResult(_OptimizeResult):
     x: onp.Array1D[np.float64] | None
     fun: float | None
@@ -89,6 +86,27 @@ class OptimizeResult(_OptimizeResult):
     status: Literal[0, 1, 2, 3, 4]
     message: str
     nit: int
+
+@type_check_only
+class _OptimizeResultSensitivity(_OptimizeResult):
+    residual: onp.Array1D[np.float64]
+    marginals: onp.Array1D[np.float64]
+
+@type_check_only
+class _OptimizeResultHighs(OptimizeResult):
+    crossover_nit: int
+    lower: _OptimizeResultSensitivity
+    upper: _OptimizeResultSensitivity
+    eqlin: _OptimizeResultSensitivity
+    ineqlin: _OptimizeResultSensitivity
+    mip_node_count: int  # only exists if `success=True`
+    mip_dual_bound: float  # only exists if `success=True`
+    mip_gap: float  # only exists if `success=True`
+
+###
+
+__docformat__: Final = "restructuredtext en"  # undocumented
+LINPROG_METHODS: Final[Sequence[MethodLinprog | MethodLinprogLegacy]] = ...  # undocumented
 
 def linprog_verbose_callback(res: OptimizeResult) -> None: ...
 def linprog_terse_callback(res: OptimizeResult) -> None: ...
@@ -107,7 +125,7 @@ def linprog(
     options: _OptionsHighs | None = None,
     x0: onp.ToFloat1D | None = None,
     integrality: _Max3 | Sequence[_Max3] | onp.CanArrayND[npc.integer] | None = None,
-) -> OptimizeResult: ...
+) -> _OptimizeResultHighs: ...
 @overload  # highs-ds
 def linprog(
     c: onp.ToFloat1D,
@@ -122,7 +140,7 @@ def linprog(
     options: _OptionsHighsDS | None = None,
     x0: onp.ToFloat1D | None = None,
     integrality: _Max3 | Sequence[_Max3] | onp.CanArrayND[npc.integer] | None = None,
-) -> OptimizeResult: ...
+) -> _OptimizeResultHighs: ...
 @overload  # highs-ipm
 def linprog(
     c: onp.ToFloat1D,
@@ -137,7 +155,7 @@ def linprog(
     options: _OptionsHighsIPM | None = None,
     x0: onp.ToFloat1D | None = None,
     integrality: _Max3 | Sequence[_Max3] | onp.CanArrayND[npc.integer] | None = None,
-) -> OptimizeResult: ...
+) -> _OptimizeResultHighs: ...
 @overload  # interior-point (legacy, see https://github.com/scipy/scipy/issues/15707)
 @deprecated("`method='interior-point'` is deprecated and will be removed in SciPy 1.17. Please use one of the HIGHS solvers.")
 def linprog(
@@ -199,4 +217,4 @@ def linprog(
     options: _OptionsHighs | None = None,
     x0: onp.ToFloat1D | None = None,
     integrality: _Max3 | Sequence[_Max3] | onp.CanArrayND[npc.integer] | None = None,
-) -> OptimizeResult: ...
+) -> _OptimizeResultHighs: ...

--- a/tests/.ruff.toml
+++ b/tests/.ruff.toml
@@ -1,4 +1,4 @@
 extend = "../pyproject.toml"
 
 [lint]
-extend-ignore = ["B018", "PYI015", "PYI017"]
+extend-ignore = ["B018", "PYI002", "PYI015", "PYI017"]

--- a/tests/optimize/test_linprog.pyi
+++ b/tests/optimize/test_linprog.pyi
@@ -16,7 +16,6 @@ bounds: Sequence[Bound]
 res = linprog(c, bounds=bounds)
 assert_type(res.fun, float | None)
 assert_type(res.x, np.ndarray[tuple[int], np.dtype[np.float64]] | None)
-assert_type(res.fun, float | None)
 assert_type(res.success, bool)
 assert_type(res.message, str)
 

--- a/tests/optimize/test_linprog.pyi
+++ b/tests/optimize/test_linprog.pyi
@@ -1,15 +1,24 @@
 from collections.abc import Sequence
 from typing import assert_type
 
+import numpy as np
+
 from scipy.optimize import OptimizeResult, linprog
 from scipy.optimize._typing import Bound
 
 c: list[float]
 
 bound: Bound
-uniformly_bounded = linprog(c, bounds=bound)
-assert_type(uniformly_bounded, OptimizeResult)
-
 bounds: Sequence[Bound]
-variably_bounded = linprog(c, bounds=bounds)
-assert_type(variably_bounded, OptimizeResult)
+
+###
+
+res = linprog(c, bounds=bounds)
+assert_type(res.fun, float | None)
+assert_type(res.x, np.ndarray[tuple[int], np.dtype[np.float64]] | None)
+assert_type(res.fun, float | None)
+assert_type(res.success, bool)
+assert_type(res.message, str)
+
+_1: OptimizeResult = linprog(c, bounds=bound)
+_2: OptimizeResult = linprog(c, bounds=bounds)


### PR DESCRIPTION
closes #861

This also adds method-specific specialization of `OptimizeResult` for "highs" methods (used by default).