### PR TITLE
✅ custom stub-test script for the `scipy.version` literals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
           uv run ruff check --output-format=github
           uv run ruff format --check
 
+      - name: check version literals
+        run: uv run scripts/check_version_literals.py
+
       # mypy_primer expects pyright to pass
       - name: pyright
         uses: jakebailey/pyright-action@v2.3.3

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -21,6 +21,8 @@ pre-commit:
     - name: basedpyright
       glob: "*.{py,pyi}"
       run: uv {run} basedpyright --threads=3 {staged_files}
+    - name: check-version-literals
+      run: uv {run} scripts/check_version_literals.py
 
 post-checkout:
   jobs:

--- a/scripts/check_version_literals.py
+++ b/scripts/check_version_literals.py
@@ -1,0 +1,45 @@
+"""Test that the `scipy.version` stub literals match runtime."""
+
+# ruff: noqa: S101
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+from scipy import version as version_scipy
+
+PATH_STUBS = Path(__file__).parent.parent / "scipy-stubs"
+
+
+def _import_pyi(name: str, path: str | Path) -> types.ModuleType:
+    """Hack to import a `.pyi` file as a module."""
+    spec = importlib.util.spec_from_loader(name, loader=None)
+    if spec is None:
+        raise ImportError(name=name, path=str(path))
+    module = importlib.util.module_from_spec(spec)
+
+    source = Path(path).read_text(encoding="utf-8")
+    exec(source, module.__dict__)  # noqa: S102
+
+    sys.modules[spec.name] = module
+    return module
+
+
+def main() -> None:
+    version_scipyi = _import_pyi("scipyi.version", PATH_STUBS / "version.pyi")
+    literals_scipyi = {
+        n: v
+        for n, v in vars(version_scipyi).items()
+        if not n.startswith("_") and v is not Ellipsis
+    }
+    assert literals_scipyi, "No literals found in scipy-stubs/version.pyi"
+
+    for name, val in literals_scipyi.items():
+        val_expect = getattr(version_scipy, name, "<MISSING>")
+        qname = f"scipy.version.{name}"
+        assert val == val_expect, f"Expected `{qname} = {val_expect!r}`, got {val!r}."
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
... because `stubtest` itself doesn't do this for some reason, and I forgot about them once before.

It's a bit hacky (it executres the `version.pyi` stub as if it's a python script), but I still think it's cool.