### PR TITLE
🔖 prepare for further development

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ source-include = [".mypyignore"] # for scipy-stubs-feedstock
 
 [project]
 name = "scipy-stubs"
-version = "1.16.2.0"
+version = "1.16.2.1.dev0"
 description = "Type annotations for SciPy"
 readme = "README.md"
 authors = [
@@ -61,7 +61,7 @@ type = [
   { include-group = "ci" },
   "array-api-compat==1.12.0", # bundled as `scipy._lib.array_api_compat`
   "basedpyright>=1.31.4",
-  "mypy[faster-cache]>=1.17.1",
+  "mypy[faster-cache]>=1.17.1,<1.18",
 ]
 dev = [
   { include-group = "lint" },

--- a/uv.lock
+++ b/uv.lock
@@ -526,7 +526,7 @@ wheels = [
 
 [[package]]
 name = "scipy-stubs"
-version = "1.16.2.0"
+version = "1.16.2.1.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "optype", extra = ["numpy"] },
@@ -581,7 +581,7 @@ dev = [
     { name = "array-api-compat", specifier = "==1.12.0" },
     { name = "basedpyright", specifier = ">=1.31.4" },
     { name = "dprint-py", specifier = ">=0.50.1.4" },
-    { name = "mypy", extras = ["faster-cache"], specifier = ">=1.17.1" },
+    { name = "mypy", extras = ["faster-cache"], specifier = ">=1.17.1,<1.18.0" },
     { name = "packaging", specifier = ">=25.0" },
     { name = "ruff", specifier = ">=0.13.0" },
     { name = "scipy-stubs", extras = ["scipy"] },
@@ -597,7 +597,7 @@ lint = [
 type = [
     { name = "array-api-compat", specifier = "==1.12.0" },
     { name = "basedpyright", specifier = ">=1.31.4" },
-    { name = "mypy", extras = ["faster-cache"], specifier = ">=1.17.1" },
+    { name = "mypy", extras = ["faster-cache"], specifier = ">=1.17.1,<1.18.0" },
     { name = "packaging", specifier = ">=25.0" },
     { name = "scipy-stubs", extras = ["scipy"] },
 ]


### PR DESCRIPTION
The mypy pin is needed because mypy 1.18.1 just dropped (causing CI to turn red on master during the release...)