### PR TITLE
🐛 `optimize`: fix incorrect `OptimizeResult` import

### DIFF
--- a/scipy-stubs/optimize/_minimize.pyi
+++ b/scipy-stubs/optimize/_minimize.pyi
@@ -7,8 +7,8 @@ import optype.numpy.compat as npc
 from numpy_typing_compat import ABCPolyBase
 
 from ._hessian_update_strategy import HessianUpdateStrategy
+from ._optimize import OptimizeResult as _OptimizeResult
 from ._typing import Bound, Bounds, Constraint, Constraints, MethodMimimize, MethodMinimizeScalar
-from .optimize import OptimizeResult as _OptimizeResult
 from scipy.sparse.linalg import LinearOperator
 
 __all__ = ["minimize", "minimize_scalar"]


### PR DESCRIPTION
`optimize.minimize` was returning the deprecated `OptimizeResult` from `scipy.optimize.optimize` instead of the one from `scipy.optimize._optimize`, which may have caused false positive deprecation warnings to be reported by type-checkers.

See also https://github.com/scipy/scipy-stubs/pull/881#issuecomment-3287359942