### PR TITLE
🐛 missing `__slots__`

### DIFF
--- a/scipy-stubs/_lib/_util.pyi
+++ b/scipy-stubs/_lib/_util.pyi
@@ -45,6 +45,8 @@ if sys.version_info >= (3, 14):
     __conditional_annotations__: Final[set[int]] = ...
 
 class AxisError(ValueError, IndexError):
+    __slots__ = "_msg", "axis", "ndim"
+
     _msg: Final[str | None]
     axis: Final[int | None]
     ndim: Final[onp.NDim | None]

--- a/scipy-stubs/interpolate/_interpolate.pyi
+++ b/scipy-stubs/interpolate/_interpolate.pyi
@@ -77,6 +77,8 @@ class interp1d(_Interpolator1D):  # legacy
     ) -> None: ...
 
 class _PPolyBase(Generic[_CT_co]):
+    __slots__ = "axis", "c", "extrapolate", "x"
+
     c: onp.Array[onp.AtLeast2D, _CT_co]
     x: onp.Array1D[np.float64]
     extrapolate: Final[_Extrapolate]

--- a/scipy-stubs/io/_mmio.pyi
+++ b/scipy-stubs/io/_mmio.pyi
@@ -26,6 +26,8 @@ class _MMFileKwargs(TypedDict, total=False):
 ###
 
 class MMFile:
+    __slots__ = "_cols", "_entries", "_field", "_format", "_rows", "_symmetry"
+
     FORMAT_COORDINATE: ClassVar[str] = "coordinate"
     FORMAT_ARRAY: ClassVar[str] = "array"
     FORMAT_VALUES: ClassVar[tuple[str, ...]] = "coordinate", "array"


### PR DESCRIPTION
Caught by [stubdefaulter](https://github.com/JelleZijlstra/stubdefaulter) (`stubdefaulter --only missing-slots -p .`):

- `scipy.io._mmio.MMFile`
- `scipy._lib._util.AxisError`
- `scipy.interpolate._interpolate._PPolyBase`

Towads #895