### PR TITLE
👷 require stubs for all modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,25 +34,20 @@ jobs:
 
       - uses: astral-sh/setup-uv@v6.8.0
         with:
-          activate-environment: true
           python-version: "3.13"
+          activate-environment: true
 
-      - name: ruff
-        run: |
-          uv run ruff check --output-format=github
-          uv run ruff format --check
+      - name: ruff check
+        run: uv run ruff check --output-format=github
 
-      - name: check version literals
-        run: uv run scripts/check_version_literals.py
+      - name: ruff format
+        run: uv run ruff format --check
 
       # mypy_primer expects pyright to pass
       - name: pyright
         uses: jakebailey/pyright-action@v2.3.3
-        with:
-          # see https://github.com/microsoft/pyright/issues/10832
-          version: 1.1.403
 
-  stubdefaulter:
+  validate_stubs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -63,15 +58,18 @@ jobs:
         with:
           python-version: "3.13"
 
+      - name: check version literals
+        run: uv run scripts/check_version_literals.py
+
+      - name: check for unstubbed modules
+        run: uv run scripts/unstubbed_modules.py
+
       # avoid stubdefaulter checking the tests as if they were stubs
       - name: exclude tests
         run: rm -rf tests
 
-      - name: stubdefaulter check
+      - name: run stubdefaulter
         run: uv run stubdefaulter --check --exit-zero --packages .
-
-  # NOTE: mypy ignores `uv run --with=...` (and `--isolated` does not help), so we
-  # manually (re)install the desired version directly in the environment.
 
   typecheck:
     runs-on: ubuntu-latest
@@ -85,6 +83,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5.0.0
+
+      # NOTE: mypy ignores `uv run --with=...` (and `--isolated` does not help), so we
+      # manually (re)install the desired version directly in the environment.
 
       - name: setup uv
         uses: astral-sh/setup-uv@v6.8.0

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -31,6 +31,9 @@ pre-commit:
     - name: check-version-literals
       run: uv {run} scripts/check_version_literals.py
 
+    - name: unstubbed-modules
+      run: uv {run} scripts/unstubbed_modules.py
+
 post-checkout:
   jobs:
     - run: uv sync


### PR DESCRIPTION
Stubtest doesn't require stubs for private modules. But we do. 