### PR TITLE
⬆️ bump `uv_build` to `0.9.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["uv_build>=0.8.24,<0.9.0"]
+requires = ["uv_build>=0.9.0,<0.10.0"]
 build-backend = "uv_build"
 
 [tool.uv.build-backend]


### PR DESCRIPTION
There are no breaking changes according to https://github.com/astral-sh/uv/releases/tag/0.9.0