### PR TITLE
👷 fix mypy_primer comment workflow for forks

### DIFF
--- a/.github/workflows/mypy_primer_comment.yml
+++ b/.github/workflows/mypy_primer_comment.yml
@@ -41,6 +41,7 @@ jobs:
           path: ${{ runner.temp }}/artifacts
           pr: ${{ steps.pr-number.outputs.pr-number }}
           workflow_conclusion: completed
+          allow_forks: true
 
       - name: generate comment content
         id: generate-comment


### PR DESCRIPTION
mypy_primer ran succesfully in #950, but the comment workflow failed because it wasn't able to download the artifact across forks: https://github.com/scipy/scipy-stubs/actions/runs/18679624332/job/53257503076

```
==> Repository: scipy/scipy-stubs
==> Artifact name: mypy_primer-diff
==> Local path: /home/runner/work/_temp/artifacts
==> Workflow name: mypy_primer.yml
==> Workflow conclusion: completed
==> PR: 950
==> Commit: 53f06334b510b56616845f00c94432ddd87a0b3b
==> Allow forks: false
==> Skipping run from fork: wangenau/scipy-stubs
Error: no matching workflow run found with any artifacts?
```

This should fix it