### PR TITLE
🐛`stats.unitary_group.rvs`: fix return dtype

### DIFF
--- a/scipy-stubs/stats/_multivariate.pyi
+++ b/scipy-stubs/stats/_multivariate.pyi
@@ -560,7 +560,7 @@ class multivariate_t_frozen(multi_rv_frozen[multivariate_t_gen]):
     @overload
     def rvs(self, /, size: onp.AtLeast2D, random_state: onp.random.ToRNG | None = None) -> _Array3ND: ...
 
-# NOTE: `m` and `n` are broadcastable (but doing so will break `.rvs()` at runtime...)``
+# NOTE: `m` and `n` are broadcastable (but doing so will break `.rvs()` at runtime...)
 class multivariate_hypergeom_gen(multi_rv_generic):
     def __call__(
         self, /, m: onp.ToJustIntND, n: onp.ToJustInt | onp.ToJustIntND, seed: onp.random.ToRNG | None = None

--- a/tests/stats/test_multivariate.pyi
+++ b/tests/stats/test_multivariate.pyi
@@ -68,7 +68,7 @@ assert_type(multivariate_hypergeom([1], 1).rvs().dtype, np.dtype[np.float64])  #
 assert_type(random_table.rvs([1, 2], [2, 1]).dtype, np.dtype[np.float64])
 assert_type(random_table([1, 2], [2, 1]).rvs().dtype, np.dtype[np.float64])
 
-# `dirichlet_multinomial` has  has no `rvs` method
+# `dirichlet_multinomial` has no `rvs` method
 
 assert_type(vonmises_fisher.rvs([0.8, 0.6]).dtype, np.dtype[np.float64])  # pyright: ignore[reportUnknownMemberType]
 assert_type(vonmises_fisher([0.8, 0.6]).rvs().dtype, np.dtype[np.float64])  # pyright: ignore[reportUnknownMemberType]


### PR DESCRIPTION
Closes #987

This also adds a couple of hand-verified regression tests for the other multivariate distribution `rvs` return dtypes.