### PR TITLE
✨🐛 `stats`: fixed and improved shape-typing in the multivariate `.rvs()` methods

### DIFF
--- a/tests/stats/test_multivariate.pyi
+++ b/tests/stats/test_multivariate.pyi
@@ -24,7 +24,8 @@ from scipy.stats import (
 ###
 # rvs dtype checks
 
-# the pyright ignore comments are needed due to  https://github.com/microsoft/pyright/issues/11127
+# this pyright ignore is needed because of https://github.com/microsoft/pyright/issues/11127
+# pyright: reportUnknownMemberType=false
 
 assert_type(multivariate_normal.rvs().dtype, np.dtype[np.float64])
 assert_type(multivariate_normal().rvs().dtype, np.dtype[np.float64])
@@ -32,8 +33,8 @@ assert_type(multivariate_normal().rvs().dtype, np.dtype[np.float64])
 assert_type(matrix_normal.rvs().dtype, np.dtype[np.float64])
 assert_type(matrix_normal().rvs().dtype, np.dtype[np.float64])
 
-assert_type(dirichlet.rvs([1, 2]).dtype, np.dtype[np.float64])  # pyright: ignore[reportUnknownMemberType]
-assert_type(dirichlet([1, 2]).rvs().dtype, np.dtype[np.float64])  # pyright: ignore[reportUnknownMemberType]
+assert_type(dirichlet.rvs([1, 2]).dtype, np.dtype[np.float64])
+assert_type(dirichlet([1, 2]).rvs().dtype, np.dtype[np.float64])
 
 assert_type(wishart.rvs(1, 1).dtype, np.dtype[np.float64])
 assert_type(wishart().rvs().dtype, np.dtype[np.float64])
@@ -41,8 +42,8 @@ assert_type(wishart().rvs().dtype, np.dtype[np.float64])
 assert_type(invwishart.rvs(1, 1).dtype, np.dtype[np.float64])
 assert_type(invwishart().rvs().dtype, np.dtype[np.float64])
 
-assert_type(multinomial.rvs([1], [0.5]).dtype, np.dtype[np.float64])  # pyright: ignore[reportUnknownMemberType]
-assert_type(multinomial([1], [0.5]).rvs().dtype, np.dtype[np.float64])  # pyright: ignore[reportUnknownMemberType]
+assert_type(multinomial.rvs([1], [0.5]).dtype, np.dtype[np.float64])
+assert_type(multinomial([1], [0.5]).rvs().dtype, np.dtype[np.float64])
 
 assert_type(ortho_group.rvs(3).dtype, np.dtype[np.float64])
 assert_type(ortho_group().rvs(3).dtype, np.dtype[np.float64])
@@ -53,25 +54,25 @@ assert_type(special_ortho_group().rvs(3).dtype, np.dtype[np.float64])
 assert_type(unitary_group.rvs(3).dtype, np.dtype[np.complex128])
 assert_type(unitary_group().rvs(3).dtype, np.dtype[np.complex128])
 
-assert_type(uniform_direction.rvs(3).dtype, np.dtype[np.float64])
-assert_type(uniform_direction(1).rvs(3).dtype, np.dtype[np.float64])
+assert_type(uniform_direction.rvs(2).dtype, np.dtype[np.float64])
+assert_type(uniform_direction(2).rvs().dtype, np.dtype[np.float64])
 
 assert_type(random_correlation.rvs([1, 1]).dtype, np.dtype[np.float64])
 assert_type(random_correlation([1, 1]).rvs().dtype, np.dtype[np.float64])
 
-assert_type(multivariate_t.rvs().dtype, np.dtype[np.float64])  # pyright: ignore[reportUnknownMemberType]
-assert_type(multivariate_t().rvs().dtype, np.dtype[np.float64])  # pyright: ignore[reportUnknownMemberType]
+assert_type(multivariate_t.rvs().dtype, np.dtype[np.float64])
+assert_type(multivariate_t().rvs().dtype, np.dtype[np.float64])
 
-assert_type(multivariate_hypergeom.rvs([1], 1).dtype, np.dtype[np.float64])  # pyright: ignore[reportUnknownMemberType]
-assert_type(multivariate_hypergeom([1], 1).rvs().dtype, np.dtype[np.float64])  # pyright: ignore[reportUnknownMemberType]
+assert_type(multivariate_hypergeom.rvs([1], 1).dtype, np.dtype[np.float64])
+assert_type(multivariate_hypergeom([1], 1).rvs().dtype, np.dtype[np.float64])
 
 assert_type(random_table.rvs([1, 2], [2, 1]).dtype, np.dtype[np.float64])
 assert_type(random_table([1, 2], [2, 1]).rvs().dtype, np.dtype[np.float64])
 
 # `dirichlet_multinomial` has no `rvs` method
 
-assert_type(vonmises_fisher.rvs([0.8, 0.6]).dtype, np.dtype[np.float64])  # pyright: ignore[reportUnknownMemberType]
-assert_type(vonmises_fisher([0.8, 0.6]).rvs().dtype, np.dtype[np.float64])  # pyright: ignore[reportUnknownMemberType]
+assert_type(vonmises_fisher.rvs([0.8, 0.6]).dtype, np.dtype[np.float64])
+assert_type(vonmises_fisher([0.8, 0.6]).rvs().dtype, np.dtype[np.float64])
 
 assert_type(normal_inverse_gamma.rvs()[0].dtype, np.dtype[np.float64])
 assert_type(normal_inverse_gamma().rvs()[0].dtype, np.dtype[np.float64])


### PR DESCRIPTION
This also simplifies several integer annotations. I'll revert those if mypy_primer complains about them, but I'd be pretty surprised if that'd be the case.