### PR TITLE
🐛✨ `integrate`: fix and improve `tanhsinh` and `nsum`

### DIFF
--- a/scipy-stubs/integrate/_tanhsinh.pyi
+++ b/scipy-stubs/integrate/_tanhsinh.pyi
@@ -10,10 +10,46 @@ from scipy._lib._util import _RichResult
 
 __all__ = ["nsum"]
 
-_IntegralT_co = TypeVar("_IntegralT_co", covariant=True)
-_ShapeT = TypeVar("_ShapeT", bound=tuple[int, ...])
+_ScalarT = TypeVar("_ScalarT", bound=np.generic)
+_InT = TypeVar("_InT")
+_ResultT = TypeVar("_ResultT")
+_ResultT_co = TypeVar("_ResultT_co", covariant=True)
+_SuccessT_co = TypeVar("_SuccessT_co", covariant=True)
+_StatusT_co = TypeVar("_StatusT_co", covariant=True)
+_MaxLevelT_co = TypeVar("_MaxLevelT_co", covariant=True)
 
-_Args: TypeAlias = tuple[onp.ToScalar | onp.ToArrayND, ...]
+_ArgsND: TypeAlias = tuple[onp.ToScalar | onp.ToArrayND, ...]
+_Callback: TypeAlias = Callable[[_ResultT], object]  # return value is ignored
+
+_Integrand: TypeAlias = Callable[Concatenate[_InT, ...], onp.ArrayND[_ScalarT]]
+_IntegrandReal: TypeAlias = _Integrand[onp.ArrayND[np.float64], npc.floating]
+_IntegrandComplex: TypeAlias = _Integrand[onp.ArrayND[np.float64] | onp.ArrayND[np.complex128], npc.complexfloating]
+
+@type_check_only
+class _TanhSinhResult(
+    _RichResult[_ResultT_co | _SuccessT_co | _StatusT_co | _MaxLevelT_co],
+    Generic[_ResultT_co, _SuccessT_co, _StatusT_co, _MaxLevelT_co],
+):
+    integral: _ResultT_co
+    error: _ResultT_co
+    success: _SuccessT_co
+    status: _StatusT_co
+    nfev: _StatusT_co
+    maxlevel: _MaxLevelT_co
+
+_TanhSinhResult0: TypeAlias = _TanhSinhResult[_ScalarT, np.bool_, np.int32, np.int64]
+_TanhSinhResultN: TypeAlias = _TanhSinhResult[
+    onp.ArrayND[_ScalarT],
+    onp.ArrayND[np.bool_],
+    onp.ArrayND[np.int32],
+    onp.ArrayND[np.int64],
+]  # fmt: skip
+_TanhSinhResultN_: TypeAlias = _TanhSinhResult[
+    onp.ArrayND[_ScalarT] | Any,
+    onp.ArrayND[np.bool_] | Any,
+    onp.ArrayND[np.int32] | Any,
+    onp.ArrayND[np.int64] | Any,
+]  # fmt: skip
 
 @type_check_only
 class _Tolerances(TypedDict, total=False):
@@ -21,171 +57,190 @@ class _Tolerances(TypedDict, total=False):
     atol: float
 
 @type_check_only
-class _TanhSinhResult(_RichResult[int | _IntegralT_co], Generic[_IntegralT_co]):
-    success: Final[bool]
-    status: Final[Literal[0, -1, -2, -3, -4, 1]]
-    integral: _IntegralT_co
-    error: _IntegralT_co
-    maxlevel: Final[int]
-    nfev: Final[int]
-
-@type_check_only
 class _NSumResult0(_RichResult[np.bool_ | np.int32 | np.float64]):
-    success: Final[np.bool_]
-    status: Final[np.int32]
     sum: Final[np.float64]
     error: Final[np.float64]
+    success: Final[np.bool_]
+    status: Final[np.int32]
     nfev: Final[np.int32]
 
 @type_check_only
 class _NSumResultN(_RichResult[onp.ArrayND[np.bool_] | onp.ArrayND[np.int32] | onp.ArrayND[np.float64]]):
-    success: Final[onp.ArrayND[np.bool_]]
-    status: Final[onp.ArrayND[np.int32]]
     sum: Final[onp.ArrayND[np.float64]]
     error: Final[onp.ArrayND[np.float64]]
+    success: Final[onp.ArrayND[np.bool_]]
+    status: Final[onp.ArrayND[np.int32]]
     nfev: Final[onp.ArrayND[np.int32]]
 
 ###
 
-# The resulting integral type depends on the shape-types of the function signature, as well as the types of a, b, and args.
-# This makes it infeasible to type precisely, as we cannot expect *every* user to annotate their functions with precise shape
-# information. For an example of this, see https://github.com/scipy/scipy-stubs/issues/1005
-@overload  # real f, scalar a, scalar b
+#
+@overload  # real f, scalar a, scalar b, preserve_shape=False
 def tanhsinh(
-    f: Callable[Concatenate[onp.ArrayND[np.float64], ...], onp.ArrayND[npc.floating]],
+    f: _IntegrandReal,
     a: onp.ToFloat,
     b: onp.ToFloat,
     *,
-    args: _Args = (),
+    args: tuple[onp.ToScalar, ...] = (),
     log: bool = False,
     maxlevel: int | None = None,
     minlevel: int | None = 2,
     atol: float | None = None,
     rtol: float | None = None,
-    preserve_shape: bool = False,
-    callback: Callable[[_TanhSinhResult[np.float64 | Any]], None] | None = None,
-) -> _TanhSinhResult[np.float64 | Any]: ...
+    preserve_shape: Literal[False] = False,
+    callback: _Callback[_TanhSinhResult0[np.float64]] | None = None,
+) -> _TanhSinhResult0[np.float64]: ...
 @overload  # real f, scalar/array a, array b
 def tanhsinh(
-    f: Callable[Concatenate[onp.ArrayND[np.float64], ...], onp.ArrayND[npc.floating]],
+    f: _IntegrandReal,
     a: onp.ToFloat | onp.ToFloatND,
     b: onp.ToFloatND,
     *,
-    args: _Args = (),
+    args: _ArgsND = (),
     log: bool = False,
     maxlevel: int | None = None,
     minlevel: int | None = 2,
     atol: float | None = None,
     rtol: float | None = None,
     preserve_shape: bool = False,
-    callback: Callable[[_TanhSinhResult[onp.ArrayND[np.float64]]], None] | None = None,
-) -> _TanhSinhResult[onp.ArrayND[np.float64]]: ...
+    callback: _Callback[_TanhSinhResultN[np.float64]] | None = None,
+) -> _TanhSinhResultN[np.float64]: ...
 @overload  # real f, array a, scalar/array b
 def tanhsinh(
-    f: Callable[Concatenate[onp.ArrayND[np.float64], ...], onp.ArrayND[npc.floating]],
+    f: _IntegrandReal,
     a: onp.ToFloatND,
     b: onp.ToFloat | onp.ToFloatND,
     *,
-    args: _Args = (),
+    args: _ArgsND = (),
     log: bool = False,
     maxlevel: int | None = None,
     minlevel: int | None = 2,
     atol: float | None = None,
     rtol: float | None = None,
     preserve_shape: bool = False,
-    callback: Callable[[_TanhSinhResult[onp.ArrayND[np.float64]]], None] | None = None,
-) -> _TanhSinhResult[onp.ArrayND[np.float64]]: ...
+    callback: _Callback[_TanhSinhResultN[np.float64]] | None = None,
+) -> _TanhSinhResultN[np.float64]: ...
+@overload  # real f, fallback
+def tanhsinh(
+    f: _IntegrandReal,
+    a: onp.ToFloat | onp.ToFloatND,
+    b: onp.ToFloat | onp.ToFloatND,
+    *,
+    args: _ArgsND = (),
+    log: bool = False,
+    maxlevel: int | None = None,
+    minlevel: int | None = 2,
+    atol: float | None = None,
+    rtol: float | None = None,
+    preserve_shape: bool = False,
+    callback: _Callback[_TanhSinhResultN_[np.float64]] | None = None,
+) -> _TanhSinhResultN_[np.float64]: ...
 @overload  # complex f, scalar a, scalar b
 def tanhsinh(
-    f: Callable[Concatenate[onp.ArrayND[np.float64] | onp.ArrayND[np.complex128], ...], onp.ArrayND[npc.complexfloating]],
+    f: _IntegrandComplex,
     a: onp.ToFloat,
     b: onp.ToFloat,
     *,
-    args: _Args = (),
+    args: tuple[onp.ToScalar, ...] = (),
     log: bool = False,
     maxlevel: int | None = None,
     minlevel: int | None = 2,
     atol: float | None = None,
     rtol: float | None = None,
-    preserve_shape: bool = False,
-    callback: Callable[[_TanhSinhResult[np.complex128 | Any]], None] | None = None,
-) -> _TanhSinhResult[np.complex128 | Any]: ...
+    preserve_shape: Literal[False] = False,
+    callback: _Callback[_TanhSinhResult0[np.complex128]] | None = None,
+) -> _TanhSinhResult0[np.complex128]: ...
 @overload  # complex f, scalar/array a, array b
 def tanhsinh(
-    f: Callable[Concatenate[onp.ArrayND[np.float64] | onp.ArrayND[np.complex128], ...], onp.ArrayND[npc.complexfloating]],
+    f: _IntegrandComplex,
     a: onp.ToFloat | onp.ToFloatND,
     b: onp.ToFloatND,
     *,
-    args: _Args = (),
+    args: _ArgsND = (),
     log: bool = False,
     maxlevel: int | None = None,
     minlevel: int | None = 2,
     atol: float | None = None,
     rtol: float | None = None,
     preserve_shape: bool = False,
-    callback: Callable[[_TanhSinhResult[onp.ArrayND[np.complex128]]], None] | None = None,
-) -> _TanhSinhResult[onp.ArrayND[np.complex128]]: ...
+    callback: _Callback[_TanhSinhResultN[np.complex128]] | None = None,
+) -> _TanhSinhResultN[np.complex128]: ...
 @overload  # complex f, array a, scalar/array b
 def tanhsinh(
-    f: Callable[Concatenate[onp.ArrayND[np.float64] | onp.ArrayND[np.complex128], ...], onp.ArrayND[npc.complexfloating]],
+    f: _IntegrandComplex,
     a: onp.ToFloatND,
     b: onp.ToFloat | onp.ToFloatND,
     *,
-    args: _Args = (),
+    args: _ArgsND = (),
     log: bool = False,
     maxlevel: int | None = None,
     minlevel: int | None = 2,
     atol: float | None = None,
     rtol: float | None = None,
     preserve_shape: bool = False,
-    callback: Callable[[_TanhSinhResult[onp.ArrayND[np.complex128]]], None] | None = None,
-) -> _TanhSinhResult[onp.ArrayND[np.complex128]]: ...
+    callback: _Callback[_TanhSinhResultN[np.complex128]] | None = None,
+) -> _TanhSinhResultN[np.complex128]: ...
+@overload  # complex f, fallback
+def tanhsinh(
+    f: _IntegrandComplex,
+    a: onp.ToFloat | onp.ToFloatND,
+    b: onp.ToFloat | onp.ToFloatND,
+    *,
+    args: _ArgsND = (),
+    log: bool = False,
+    maxlevel: int | None = None,
+    minlevel: int | None = 2,
+    atol: float | None = None,
+    rtol: float | None = None,
+    preserve_shape: bool = False,
+    callback: _Callback[_TanhSinhResultN_[np.complex128]] | None = None,
+) -> _TanhSinhResultN_[np.complex128]: ...
 
 #
-@overload
+@overload  # scalar a, scalar b, scalar step
 def nsum(
-    f: Callable[Concatenate[onp.ArrayND[np.float64, _ShapeT], ...], onp.ArrayND[npc.floating, _ShapeT]],
+    f: _IntegrandReal,
     a: onp.ToFloat,
     b: onp.ToFloat,
     *,
     step: onp.ToFloat = 1,
-    args: _Args = (),
+    args: tuple[onp.ToScalar, ...] = (),
     log: bool = False,
     maxterms: int = 0x10_00_00,
     tolerances: _Tolerances | None = None,
 ) -> _NSumResult0: ...
-@overload
+@overload  # scalar/array a, array b, scalar/array step
 def nsum(
-    f: Callable[Concatenate[onp.ArrayND[np.float64, _ShapeT], ...], onp.ArrayND[npc.floating, _ShapeT]],
+    f: _IntegrandReal,
     a: onp.ToFloat | onp.ToFloatND,
     b: onp.ToFloatND,
     *,
     step: onp.ToFloat | onp.ToFloatND = 1,
-    args: _Args = (),
+    args: _ArgsND = (),
     log: bool = False,
     maxterms: int = 0x10_00_00,
     tolerances: _Tolerances | None = None,
 ) -> _NSumResultN: ...
-@overload
+@overload  # array a, scalar/array b, array step
 def nsum(
-    f: Callable[Concatenate[onp.ArrayND[np.float64, _ShapeT], ...], onp.ArrayND[npc.floating, _ShapeT]],
+    f: _IntegrandReal,
     a: onp.ToFloatND,
     b: onp.ToFloat | onp.ToFloatND,
     *,
     step: onp.ToFloat | onp.ToFloatND = 1,
-    args: _Args = (),
+    args: _ArgsND = (),
     log: bool = False,
     maxterms: int = 0x10_00_00,
     tolerances: _Tolerances | None = None,
 ) -> _NSumResultN: ...
-@overload
+@overload  # scalar/array a, scalar/array b, array step
 def nsum(
-    f: Callable[Concatenate[onp.ArrayND[np.float64, _ShapeT], ...], onp.ArrayND[npc.floating, _ShapeT]],
+    f: _IntegrandReal,
     a: onp.ToFloat | onp.ToFloatND,
     b: onp.ToFloat | onp.ToFloatND,
     *,
     step: onp.ToFloatND,
-    args: _Args = (),
+    args: _ArgsND = (),
     log: bool = False,
     maxterms: int = 0x10_00_00,
     tolerances: _Tolerances | None = None,

--- a/tests/integrate/test_tanhsinh.pyi
+++ b/tests/integrate/test_tanhsinh.pyi
@@ -5,34 +5,39 @@ import optype.numpy as onp
 
 from scipy.integrate import nsum, tanhsinh
 
-def integrand_f_f(x: onp.ArrayND[np.float64]) -> onp.ArrayND[np.float64]: ...
-def integrand_fc_f(x: onp.ArrayND[np.float64 | np.complex128]) -> onp.ArrayND[np.float64]: ...
-def integrand_fc_c(x: onp.ArrayND[np.float64 | np.complex128]) -> onp.ArrayND[np.complex128]: ...
+def integrand_f(x: onp.ArrayND[np.float64]) -> onp.ArrayND[np.float64]: ...
+def integrand_c(x: onp.ArrayND[np.float64 | np.complex128]) -> onp.ArrayND[np.complex128]: ...
 
 ###
 # tanhsinh
 
-assert_type(tanhsinh(integrand_f_f, 0.0, 1.0).integral, np.float64 | Any)
-assert_type(tanhsinh(integrand_fc_f, 0.0, 1.0).error, np.float64 | Any)
-assert_type(tanhsinh(integrand_fc_c, 0.0, 1.0).error, np.complex128 | Any)
+assert_type(tanhsinh(integrand_f, 0.0, 1.0).integral, np.float64)
+assert_type(tanhsinh(integrand_c, 0.0, 1.0).integral, np.complex128)
 
-assert_type(tanhsinh(integrand_f_f, [0.0, 0.5], 1.0).integral, onp.ArrayND[np.float64])
-assert_type(tanhsinh(integrand_fc_f, [0.0, 0.5], 1.0).error, onp.ArrayND[np.float64])
-assert_type(tanhsinh(integrand_fc_c, [0.0, 0.5], 1.0).error, onp.ArrayND[np.complex128])
+assert_type(tanhsinh(integrand_f, 0.0, 1.0, preserve_shape=True).integral, onp.ArrayND[np.float64] | Any)
+assert_type(tanhsinh(integrand_c, 0.0, 1.0, preserve_shape=True).integral, onp.ArrayND[np.complex128] | Any)
 
-assert_type(tanhsinh(integrand_f_f, 0.0, [1.0, 2.0]).integral, onp.ArrayND[np.float64])
-assert_type(tanhsinh(integrand_fc_f, 0.0, [1.0, 2.0]).error, onp.ArrayND[np.float64])
-assert_type(tanhsinh(integrand_fc_c, 0.0, [1.0, 2.0]).error, onp.ArrayND[np.complex128])
+assert_type(tanhsinh(integrand_f, [0.0, 0.5], 1.0).integral, onp.ArrayND[np.float64])
+assert_type(tanhsinh(integrand_c, [0.0, 0.5], 1.0).error, onp.ArrayND[np.complex128])
+assert_type(tanhsinh(integrand_f, [0.0, 0.5], 1.0, preserve_shape=True).integral, onp.ArrayND[np.float64])
+assert_type(tanhsinh(integrand_c, [0.0, 0.5], 1.0, preserve_shape=True).error, onp.ArrayND[np.complex128])
 
-assert_type(tanhsinh(integrand_f_f, [0.0, 1.0], [1.0, 2.0]).integral, onp.ArrayND[np.float64])
-assert_type(tanhsinh(integrand_fc_f, [0.0, 1.0], [1.0, 2.0]).error, onp.ArrayND[np.float64])
-assert_type(tanhsinh(integrand_fc_c, [0.0, 1.0], [1.0, 2.0]).error, onp.ArrayND[np.complex128])
+assert_type(tanhsinh(integrand_f, 0.0, [1.0, 2.0]).integral, onp.ArrayND[np.float64])
+assert_type(tanhsinh(integrand_c, 0.0, [1.0, 2.0]).error, onp.ArrayND[np.complex128])
+assert_type(tanhsinh(integrand_f, 0.0, [1.0, 2.0], preserve_shape=True).integral, onp.ArrayND[np.float64])
+assert_type(tanhsinh(integrand_c, 0.0, [1.0, 2.0], preserve_shape=True).error, onp.ArrayND[np.complex128])
+
+assert_type(tanhsinh(integrand_f, [0.0, 1.0], [1.0, 2.0]).integral, onp.ArrayND[np.float64])
+assert_type(tanhsinh(integrand_c, [0.0, 1.0], [1.0, 2.0]).error, onp.ArrayND[np.complex128])
+assert_type(tanhsinh(integrand_f, [0.0, 1.0], [1.0, 2.0], preserve_shape=True).integral, onp.ArrayND[np.float64])
+assert_type(tanhsinh(integrand_c, [0.0, 1.0], [1.0, 2.0], preserve_shape=True).error, onp.ArrayND[np.complex128])
 
 ###
 # nsum (only reals)
 
-assert_type(nsum(integrand_f_f, 0.0, 1.0).sum, np.float64)
-assert_type(nsum(integrand_f_f, [0.0], 1.0).sum, onp.ArrayND[np.float64])
-assert_type(nsum(integrand_f_f, 0.0, [1.0]).sum, onp.ArrayND[np.float64])
-assert_type(nsum(integrand_f_f, [0.0], [1.0]).sum, onp.ArrayND[np.float64])
-assert_type(nsum(integrand_f_f, 0.0, 1.0, step=[1, 2]).sum, onp.ArrayND[np.float64])
+assert_type(nsum(integrand_f, 0.0, 1.0).sum, np.float64)
+assert_type(nsum(integrand_f, [0.0], 1.0).sum, onp.ArrayND[np.float64])
+assert_type(nsum(integrand_f, 0.0, [1.0]).sum, onp.ArrayND[np.float64])
+assert_type(nsum(integrand_f, [0.0], [1.0]).sum, onp.ArrayND[np.float64])
+assert_type(nsum(integrand_f, 0.0, 1.0, step=[1, 2]).sum, onp.ArrayND[np.float64])
+assert_type(nsum(integrand_f, [0.0], [1.0], step=[1, 2]).sum, onp.ArrayND[np.float64])


### PR DESCRIPTION
@JaRoSchm noted in https://github.com/scipy/scipy-stubs/issues/1005#issuecomment-3595080563 that #1009 only partially addressed #1005. Upon closer inspection, I found several other inaccuracies in the return types of `scipy.integrate.tanhsinh` and `scipy.integrate.nsum`.

This fixes the result types returned by `tanhsinh` and `nsum`, so that they now have numpy scalar attribute types for scalar->scalar integration, and ndarray attributes for multidimensional/vectorized integrands. 

This also adds overloads to `tanhsinh` that specialize the return type based on the value (or abscence) of the `preserve_shape` kwarg.

Note that `tanhsinh` now no longer returns `np.float64 | Any` for the "default" scalar->scalar use-case, making this a more type-safe solution than #1009.

I confirmed that this now indeed resolves #1005 for both cases. 