### PR TITLE
🐛 `differentiate`: support for `preserve_shape=True` in `derivative`

### DIFF
--- a/scipy-stubs/differentiate/_differentiate.pyi
+++ b/scipy-stubs/differentiate/_differentiate.pyi
@@ -1,6 +1,6 @@
 from _typeshed import ConvertibleToInt
 from collections.abc import Callable
-from typing import Any, Concatenate, Generic, TypeAlias, TypedDict, overload, type_check_only
+from typing import Any, Concatenate, Generic, Literal, TypeAlias, TypedDict, overload, type_check_only
 from typing_extensions import TypeVar
 
 import numpy as np
@@ -11,7 +11,6 @@ from scipy._lib._util import _RichResult
 
 _FloatT = TypeVar("_FloatT", bound=npc.floating, default=np.float64)
 _FloatT_co = TypeVar("_FloatT_co", bound=npc.floating, default=np.float64, covariant=True)
-_ShapeT = TypeVar("_ShapeT", bound=tuple[int, *tuple[int, ...]], default=tuple[Any, ...])
 _ShapeT_co = TypeVar("_ShapeT_co", bound=tuple[int, *tuple[int, ...]], default=tuple[Any, ...], covariant=True)
 _ShapeT2_co = TypeVar("_ShapeT2_co", bound=tuple[int, int, *tuple[int, ...]], default=tuple[Any, ...], covariant=True)
 
@@ -77,7 +76,7 @@ def derivative(
     initial_step: onp.ToFloat = 0.5,
     step_factor: onp.ToFloat = 2.0,
     step_direction: onp.ToJustInt = 0,
-    preserve_shape: bool = False,
+    preserve_shape: Literal[False] = False,
     callback: Callable[[_DerivativeResult0D[np.float64]], _Ignored] | None = None,
 ) -> _DerivativeResult0D[np.float64]: ...
 @overload  # 0-d <known>
@@ -92,24 +91,9 @@ def derivative(
     initial_step: onp.ToFloat = 0.5,
     step_factor: onp.ToFloat = 2.0,
     step_direction: onp.ToJustInt = 0,
-    preserve_shape: bool = False,
+    preserve_shape: Literal[False] = False,
     callback: Callable[[_DerivativeResult0D[_FloatT]], _Ignored] | None = None,
 ) -> _DerivativeResult0D[_FloatT]: ...
-@overload  # n-d <known>
-def derivative(
-    f: _FunctionNN[_FloatT],
-    x: onp.CanArrayND[_FloatT, _ShapeT],
-    *,
-    args: tuple[onp.ToScalar | onp.ToArray1D | onp.CanArray[_ShapeT], ...] = (),
-    tolerances: _Tolerances | None = None,
-    maxiter: ConvertibleToInt = 10,
-    order: ConvertibleToInt = 8,
-    initial_step: onp.ToFloat | onp.ToFloat1D | onp.CanArrayND[npc.floating, _ShapeT] = 0.5,
-    step_factor: onp.ToFloat = 2.0,
-    step_direction: onp.ToJustInt | onp.ToJustInt1D | onp.CanArrayND[npc.integer, _ShapeT] = 0,
-    preserve_shape: bool = False,
-    callback: Callable[[_DerivativeResultND[_FloatT, _ShapeT]], _Ignored] | None = None,
-) -> _DerivativeResultND[_FloatT, _ShapeT]: ...
 @overload  # 1-d <unknown>
 def derivative(
     f: _Function11[_FloatT],
@@ -122,13 +106,13 @@ def derivative(
     initial_step: onp.ToFloat | onp.ToFloatStrict1D = 0.5,
     step_factor: onp.ToFloat = 2.0,
     step_direction: onp.ToJustInt | onp.ToJustIntStrict1D = 0,
-    preserve_shape: bool = False,
+    preserve_shape: Literal[False] = False,
     callback: Callable[[_DerivativeResultND[_FloatT, tuple[int]]], _Ignored] | None = None,
 ) -> _DerivativeResultND[_FloatT, tuple[int]]: ...
-@overload  # n-d <unknown>
+@overload  # n-d <known>
 def derivative(
     f: _FunctionNN[_FloatT],
-    x: onp.ToFloatND,
+    x: _FloatT | onp.ToArrayND[_FloatT],
     *,
     args: tuple[onp.ToScalar | onp.ToArrayND, ...] = (),
     tolerances: _Tolerances | None = None,
@@ -138,8 +122,23 @@ def derivative(
     step_factor: onp.ToFloat = 2.0,
     step_direction: onp.ToJustInt | onp.ToJustIntND = 0,
     preserve_shape: bool = False,
-    callback: Callable[[_DerivativeResultND[_FloatT, _ShapeT]], _Ignored] | None = None,
-) -> _DerivativeResultND[_FloatT, _ShapeT]: ...
+    callback: Callable[[_DerivativeResultND[_FloatT]], _Ignored] | None = None,
+) -> _DerivativeResultND[_FloatT]: ...
+@overload  # n-d <unknown>
+def derivative(
+    f: _FunctionNN[_FloatT],
+    x: onp.ToFloat | onp.ToFloatND,
+    *,
+    args: tuple[onp.ToScalar | onp.ToArrayND, ...] = (),
+    tolerances: _Tolerances | None = None,
+    maxiter: ConvertibleToInt = 10,
+    order: ConvertibleToInt = 8,
+    initial_step: onp.ToFloat | onp.ToFloatND = 0.5,
+    step_factor: onp.ToFloat = 2.0,
+    step_direction: onp.ToJustInt | onp.ToJustIntND = 0,
+    preserve_shape: bool = False,
+    callback: Callable[[_DerivativeResultND[_FloatT]], _Ignored] | None = None,
+) -> _DerivativeResultND[_FloatT]: ...
 
 #
 def jacobian(

--- a/tests/differentiate/test_differentiate.pyi
+++ b/tests/differentiate/test_differentiate.pyi
@@ -56,7 +56,7 @@ assert_type(
         initial_step=0.1,
         step_factor=1.5,
         step_direction=1,
-        preserve_shape=True,
+        preserve_shape=False,
         callback=None,
     ),
     _DerivativeResult0D[np.float64],


### PR DESCRIPTION
... in case the function signature is unknown.

ref: https://github.com/scipy/scipy-stubs/issues/1005#issuecomment-3612643403