### PR TITLE
🐛 `sparse`: add missing `csr_*` constructor signatures

### DIFF
--- a/scipy-stubs/sparse/_csr.pyi
+++ b/scipy-stubs/sparse/_csr.pyi
@@ -27,15 +27,14 @@ _NeitherD: TypeAlias = tuple[Never] | tuple[Never, Never]
 _ToMatrixPy: TypeAlias = Sequence[_T] | Sequence[Sequence[_T]]
 _ToMatrix: TypeAlias = _spbase[_ScalarT] | onp.CanArrayND[_ScalarT] | Sequence[onp.CanArrayND[_ScalarT]] | _ToMatrixPy[_ScalarT]
 
-_ToData2B = TypeAliasType("_ToData2B", tuple[onp.ArrayND[_ScalarT], onp.ArrayND[npc.integer]], type_params=(_ScalarT,))  # bsr
-_ToData2C = TypeAliasType(
-    "_ToData2C", tuple[onp.ArrayND[_ScalarT], tuple[onp.ArrayND[npc.integer], onp.ArrayND[npc.integer]]], type_params=(_ScalarT,)
-)  # csc, csr
-_ToData2 = TypeAliasType("_ToData2", _ToData2B[_ScalarT] | _ToData2C[_ScalarT], type_params=(_ScalarT,))
-_ToData3 = TypeAliasType(
-    "_ToData3", tuple[onp.ArrayND[_ScalarT], onp.ArrayND[npc.integer], onp.ArrayND[npc.integer]], type_params=(_ScalarT,)
+_ToData = TypeAliasType(
+    "_ToData",
+    (
+        tuple[_T, tuple[onp.ToJustInt1D, onp.ToJustInt1D]]  # (data, (row_ind, col_ind))
+        | tuple[_T, onp.ToJustInt1D, onp.ToJustInt1D]  # (data, indices, indptr)
+    ),
+    type_params=(_T,),
 )
-_ToData = TypeAliasType("_ToData", _ToData2[_ScalarT] | _ToData3[_ScalarT], type_params=(_ScalarT,))
 
 ###
 
@@ -106,7 +105,7 @@ class csr_array(_csr_base[_ScalarT_co, _ShapeT_co], sparray[_ScalarT_co, _ShapeT
     def __init__(
         self: csr_array[_ScalarT, tuple[int, int]],
         /,
-        arg1: Sequence[Sequence[_ScalarT] | onp.CanArrayND[_ScalarT]],  # assumes max. 2-d
+        arg1: onp.ToArray2D[_ScalarT, _ScalarT] | _ToData[onp.ToArray1D[_ScalarT, _ScalarT]],
         shape: _ToShape2D | None = None,
         dtype: onp.ToDType[_ScalarT] | None = None,
         copy: bool = False,
@@ -117,7 +116,7 @@ class csr_array(_csr_base[_ScalarT_co, _ShapeT_co], sparray[_ScalarT_co, _ShapeT
     def __init__(
         self: csr_array[_ScalarT, tuple[Any, ...]],
         /,
-        arg1: _ToMatrix[_ScalarT] | _ToData[_ScalarT],
+        arg1: _ToMatrix[_ScalarT],
         shape: _ToShape1D | _ToShape2D | None = None,
         dtype: onp.ToDType[_ScalarT] | None = None,
         copy: bool = False,
@@ -293,7 +292,7 @@ class csr_array(_csr_base[_ScalarT_co, _ShapeT_co], sparray[_ScalarT_co, _ShapeT
     def __init__(
         self: csr_array[np.bool_, tuple[int, int]],
         /,
-        arg1: onp.ToJustBoolStrict2D,
+        arg1: onp.ToJustBoolStrict2D | _ToData[Sequence[bool]],
         shape: _ToShape2D | None = None,
         dtype: onp.AnyBoolDType | None = None,
         copy: bool = False,
@@ -315,7 +314,7 @@ class csr_array(_csr_base[_ScalarT_co, _ShapeT_co], sparray[_ScalarT_co, _ShapeT
     def __init__(
         self: csr_array[np.int64, tuple[int, int]],
         /,
-        arg1: onp.ToJustInt64Strict2D,
+        arg1: onp.ToJustInt64Strict2D | _ToData[list[int]],
         shape: _ToShape2D | None = None,
         dtype: onp.AnyIntDType | None = None,
         copy: bool = False,
@@ -337,7 +336,7 @@ class csr_array(_csr_base[_ScalarT_co, _ShapeT_co], sparray[_ScalarT_co, _ShapeT
     def __init__(
         self: csr_array[np.float64, tuple[int, int]],
         /,
-        arg1: onp.ToJustFloat64Strict2D,
+        arg1: onp.ToJustFloat64Strict2D | _ToData[list[float]],
         shape: _ToShape1D | _ToShape2D | None = None,
         dtype: onp.AnyFloat64DType | None = None,
         copy: bool = False,
@@ -359,7 +358,7 @@ class csr_array(_csr_base[_ScalarT_co, _ShapeT_co], sparray[_ScalarT_co, _ShapeT
     def __init__(
         self: csr_array[np.complex128, tuple[int, int]],
         /,
-        arg1: onp.ToJustComplex128Strict2D,
+        arg1: onp.ToJustComplex128Strict2D | _ToData[list[complex]],
         shape: _ToShape1D | _ToShape2D | None = None,
         dtype: onp.AnyComplex128DType | None = None,
         copy: bool = False,
@@ -454,7 +453,7 @@ class csr_matrix(_csr_base[_ScalarT_co], spmatrix[_ScalarT_co], Generic[_ScalarT
     def __init__(
         self: csr_matrix[_ScalarT],  # this self annotation works around a mypy bug
         /,
-        arg1: _ToMatrix[_ScalarT],
+        arg1: _ToMatrix[_ScalarT] | _ToData[onp.ToArray1D[_ScalarT, _ScalarT]],
         shape: _ToShape2D | None = None,
         dtype: onp.ToDType[_ScalarT] | None = None,
         copy: bool = False,
@@ -476,7 +475,7 @@ class csr_matrix(_csr_base[_ScalarT_co], spmatrix[_ScalarT_co], Generic[_ScalarT
     def __init__(
         self: csr_matrix[np.bool_],
         /,
-        arg1: onp.ToJustBoolStrict2D,
+        arg1: onp.ToJustBoolStrict2D | _ToData[Sequence[bool]],
         shape: _ToShape2D | None = None,
         dtype: onp.AnyBoolDType | None = None,
         copy: bool = False,
@@ -487,7 +486,7 @@ class csr_matrix(_csr_base[_ScalarT_co], spmatrix[_ScalarT_co], Generic[_ScalarT
     def __init__(
         self: csr_matrix[np.int64],
         /,
-        arg1: onp.ToJustInt64Strict2D,
+        arg1: onp.ToJustInt64Strict2D | _ToData[list[int]],
         shape: _ToShape2D | None = None,
         dtype: onp.AnyIntDType | None = None,
         copy: bool = False,
@@ -498,7 +497,7 @@ class csr_matrix(_csr_base[_ScalarT_co], spmatrix[_ScalarT_co], Generic[_ScalarT
     def __init__(
         self: csr_matrix[np.float64],
         /,
-        arg1: onp.ToJustFloat64Strict2D,
+        arg1: onp.ToJustFloat64Strict2D | _ToData[list[float]],
         shape: _ToShape2D | None = None,
         dtype: onp.AnyFloat64DType | None = None,
         copy: bool = False,
@@ -509,7 +508,7 @@ class csr_matrix(_csr_base[_ScalarT_co], spmatrix[_ScalarT_co], Generic[_ScalarT
     def __init__(
         self: csr_matrix[np.complex128],
         /,
-        arg1: onp.ToJustComplex128Strict2D,
+        arg1: onp.ToJustComplex128Strict2D | _ToData[list[complex]],
         shape: _ToShape2D | None = None,
         dtype: onp.AnyComplex128DType | None = None,
         copy: bool = False,

--- a/tests/sparse/test_csr.pyi
+++ b/tests/sparse/test_csr.pyi
@@ -1,4 +1,4 @@
-from typing import Literal, TypeAlias, assert_type
+from typing import Any, Literal, TypeAlias, assert_type
 
 import numpy as np
 
@@ -16,6 +16,9 @@ seq_seq_bool: list[list[bool]]
 seq_seq_int: list[list[int]]
 seq_seq_float: list[list[float]]
 seq_seq_complex: list[list[complex]]
+
+arr_f32_nd: np.ndarray[tuple[Any, ...], np.dtype[np.float32]]
+arr_f32_1d: np.ndarray[tuple[int], np.dtype[np.float32]]
 
 ###
 # NOTE: Keep these tests in sync with the `dok` tests.
@@ -75,6 +78,30 @@ assert_type(csr_matrix(seq_seq_bool), csr_matrix[np.bool_])
 assert_type(csr_matrix(seq_seq_int), csr_matrix[np.int64])
 assert_type(csr_matrix(seq_seq_float), csr_matrix[np.float64])
 assert_type(csr_matrix(seq_seq_complex), csr_matrix[np.complex128])
+
+# https://github.com/scipy/scipy-stubs/issues/1060
+
+assert_type(csr_array((arr_f32_nd, (seq_int, seq_int))), csr_array[np.float32])
+assert_type(csr_array((arr_f32_1d, (seq_int, seq_int))), csr_array[np.float32])
+assert_type(csr_array((seq_bool, (seq_int, seq_int))), csr_array[np.bool_])
+assert_type(csr_array((seq_int, (seq_int, seq_int))), csr_array[np.int64])
+assert_type(csr_array((seq_float, (seq_int, seq_int))), csr_array[np.float64])
+assert_type(csr_array((seq_complex, (seq_int, seq_int))), csr_array[np.complex128])
+csr_array((seq_seq_bool, (seq_int, seq_int)))  # type: ignore[type-var] # pyright: ignore[reportArgumentType, reportCallIssue]
+csr_array((seq_seq_int, (seq_int, seq_int)))  # type: ignore[type-var] # pyright: ignore[reportArgumentType, reportCallIssue]
+csr_array((seq_seq_float, (seq_int, seq_int)))  # type: ignore[type-var] # pyright: ignore[reportArgumentType, reportCallIssue]
+csr_array((seq_seq_complex, (seq_int, seq_int)))  # type: ignore[type-var] # pyright: ignore[reportArgumentType, reportCallIssue]
+
+assert_type(csr_matrix((arr_f32_nd, (seq_int, seq_int))), csr_matrix[np.float32])
+assert_type(csr_matrix((arr_f32_1d, (seq_int, seq_int))), csr_matrix[np.float32])
+assert_type(csr_matrix((seq_bool, (seq_int, seq_int))), csr_matrix[np.bool_])
+assert_type(csr_matrix((seq_int, (seq_int, seq_int))), csr_matrix[np.int64])
+assert_type(csr_matrix((seq_float, (seq_int, seq_int))), csr_matrix[np.float64])
+assert_type(csr_matrix((seq_complex, (seq_int, seq_int))), csr_matrix[np.complex128])
+csr_matrix((seq_seq_bool, (seq_int, seq_int)))  # type: ignore[arg-type] # pyright: ignore[reportArgumentType, reportCallIssue]
+csr_matrix((seq_seq_int, (seq_int, seq_int)))  # type: ignore[arg-type] # pyright: ignore[reportArgumentType, reportCallIssue]
+csr_matrix((seq_seq_float, (seq_int, seq_int)))  # type: ignore[arg-type] # pyright: ignore[reportArgumentType, reportCallIssue]
+csr_matrix((seq_seq_complex, (seq_int, seq_int)))  # type: ignore[arg-type] # pyright: ignore[reportArgumentType, reportCallIssue]
 
 ###
 # CSR-specific tests


### PR DESCRIPTION
This adds missing constructor signatures to `sparse.csr_array` and `sparse.csr_matrix` for the `(data, (row_ind, col_ind))` and `(data, indices, indptr)` cases. These added call signatures support shape-typing and precise dtype specialization.

This additionally modifies some of the related helper type-alias, simplifying them, and making them more flexible (in terms of generics) and broader (in terms of assignability).

Closes #1060