### PR TITLE
📝 add MolPipeline to the list of downstream projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ Gurobi ([gurobi-logtools](https://github.com/Gurobi/gurobi-logtools)) |
 [linearmodels](https://github.com/bashtage/linearmodels) |
 [Lmo](https://github.com/jorenham/Lmo) |
 [MaxText](https://github.com/AI-Hypercomputer/maxtext) |
+[MolPipeline](https://github.com/basf/MolPipeline) |
 [MouseTracks](https://github.com/huntfx/MouseTracks) |
 Mozilla ([mozanalysis](https://github.com/mozilla/mozanalysis)) |
 [mypy_primer](https://github.com/hauntsaninja/mypy_primer) |


### PR DESCRIPTION
210 stars
https://github.com/basf/MolPipeline