### PR TITLE
🔨 fix type-test coverage script

### DIFF
--- a/scripts/test_coverage.py
+++ b/scripts/test_coverage.py
@@ -19,7 +19,7 @@ _SCIPY_SUBPACKAGES: Final = (
     "datasets",
     "differentiate",
     "fft",
-    "fftpack",
+    # "fftpack",  # almost the safe as fft
     "integrate",
     "interpolate",
     "io",


### PR DESCRIPTION
it was missing a whole bunch of tests. Specifically, the ones for `datasets` and `constants` were missing. So the coverage actually turns out to be 16.9% rather than 6.6%