### PR TITLE
🐛 `optimize`: fix `minimize_scalar` bracket type

### DIFF
--- a/scipy-stubs/optimize/_minimize.pyi
+++ b/scipy-stubs/optimize/_minimize.pyi
@@ -34,7 +34,7 @@ _Fun1Dp: TypeAlias = Callable[Concatenate[_Float1D, _Float1D, ...], _RT]
 
 _FDMethod: TypeAlias = Literal["2-point", "3-point", "cs"]
 
-_ToBracket: TypeAlias = Sequence[_Tuple2[onp.ToFloat] | _Tuple3[onp.ToFloat]]
+_ToBracket: TypeAlias = _Tuple2[onp.ToFloat] | _Tuple3[onp.ToFloat]
 _ToBound: TypeAlias = _Tuple2[onp.ToFloat]
 _Ignored: TypeAlias = object
 


### PR DESCRIPTION
From the [documentation](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize_scalar.html#scipy.optimize.minimize_scalar), the `bracket` is just a union of a 3-tuple and a 2-tuple (not a sequence of). 

The code also seems to agree with that:
https://github.com/scipy/scipy/blob/c34a104768bfa50e8863cfa626644d1d8acef164/scipy/optimize/_optimize.py#L2459