### PR TITLE
✨ `ndimage`: improve `label` type hints for conditional return types

### DIFF
--- a/scipy-stubs/ndimage/_measurements.pyi
+++ b/scipy-stubs/ndimage/_measurements.pyi
@@ -47,11 +47,17 @@ _Coord1D: TypeAlias = list[_Coord0D]
 _CoordND: TypeAlias = list[tuple[onp.ArrayND[np.float64], ...]]
 
 #
+@overload
 def label(
     input: onp.ToComplex | onp.ToComplexND,
     structure: onp.ToComplex | onp.ToComplexND | None = None,
-    output: onp.ArrayND[np.int32 | np.intp] | None = None,
-) -> int | tuple[onp.ArrayND[np.int32 | np.intp], int]: ...
+    *,
+    output: onp.ArrayND[np.int32 | np.intp],
+) -> int: ...
+@overload
+def label(
+    input: onp.ToComplex | onp.ToComplexND, structure: onp.ToComplex | onp.ToComplexND | None = None, output: None = None
+) -> tuple[onp.ArrayND[np.int32 | np.intp], int]: ...
 
 #
 def find_objects(input: onp.ToInt | onp.ToIntND, max_label: int = 0) -> list[tuple[slice, ...]]: ...


### PR DESCRIPTION
Update `_measurements.pyi` so that `label()` correctly shows different return types depending on the output parameter:

- Returns `tuple(array, int)` when `output=None`
- Returns `int` when an `output` array is provided

In the stub, the output parameter is marked as keyword-only (*) because:

1. You cannot give a default of `None` to a parameter with a different type
2. You cannot have a positional argument without a default after one with a default.

Happy to discuss or tweak if needed!