### PR TITLE
📝 `scipy.stats`: document the generic result classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,32 +270,20 @@ See the `scipy` columns below for which classes are subscriptable at runtime.
 
 ### `scipy.stats`
 
-| generic type                                                                   | `scipy-stubs` | `scipy`  |                                                                                            |
-| ------------------------------------------------------------------------------ | ------------- | -------- | ------------------------------------------------------------------------------------------ |
-| `Covariance[T: real]`                                                          | `>=1.14.0.0`  | `>=1.17` | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.Covariance.html)   |
-| `Uniform[S: (int, ...), T: floating]`                                          | `>=1.15.0.0`  | `>=1.17` | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.Uniform.html)      |
-| `Normal[S: (int, ...), T: floating]`                                           | `>=1.15.0.0`  | `>=1.17` | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.Normal.html)       |
-| `Binomial[S: (int, ...), T: floating]`                                         | `>=1.16.0.0`  | `>=1.17` | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.Binomial.html)     |
-| `Mixture[T: floating]`                                                         | `>=1.15.0.0`  | `>=1.17` | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.Mixture.html)      |
-| `rv_frozen[D: rv_generic, T: scalar or array]`                                 | `>=1.14.0.0`  | `>=1.17` |                                                                                            |
-| `multi_rv_frozen[D: rv_generic]`                                               | `>=1.14.0.0`  | `>=1.17` |                                                                                            |
-| `CensoredData[X: f64 \| c128, L: f64 \| c128, R: f64 \| c128, I: f64 \| c128]` | `>=1.17.0.2`  | `>=1.18` | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.CensoredData.html) |
-| `gaussian_kde[T: floating]`                                                    | `>=1.17.0.2`  | `>=1.18` | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.gaussian_kde.html) |
-
-### `scipy.stats` Classes
-
-| Class                           | Description                                                | SciPy Reference                                                                                         |
-| ------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| `RelativeRiskResult`            | Result of `scipy.stats.contingency.relative_risk`          | [Docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.contingency.relative_risk.html) |
-| `BinomTestResult`               | Result of `scipy.stats.binomtest`                          | [Docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.binomtest.html)                 |
-| `TukeyHSDResult`                | Result of `scipy.stats.tukey_hsd`                          | [Docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.tukey_hsd.html)                 |
-| `DunnettResult`                 | Result object returned by `scipy.stats.dunnett`            | [Docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.dunnett.html)                   |
-| `PearsonRResult`                | Result of `scipy.stats.pearsonr`                           | [Docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.pearsonr.html)                  |
-| `FitResult`                     | Result of fitting a discrete or continuous distribution    | [Docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.rv_continuous.fit.html)         |
-| `OddsRatioResult`               | Result of `scipy.stats.contingency.odds_ratio`             | [Docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.contingency.odds_ratio.html)    |
-| `TtestResult`                   | Result of a t-test                                         | [Docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.TtestResult.html)               |
-| `ECDFResult`                    | Result object returned by `scipy.stats.ecdf`               | [Docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.ecdf.html)                      |
-| `EmpiricalDistributionFunction` | An empirical distribution function from `scipy.stats.ecdf` | [Docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.ecdf.html)                      |
+| generic type                                                                   | `scipy-stubs` | `scipy`  |                                                                                                              |
+| ------------------------------------------------------------------------------ | ------------- | -------- | ------------------------------------------------------------------------------------------------------------ |
+| `Covariance[T: real]`                                                          | `>=1.14.0.0`  | `>=1.17` | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.Covariance.html)                     |
+| `Uniform[S: (int, ...), T: floating]`                                          | `>=1.15.0.0`  | `>=1.17` | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.Uniform.html)                        |
+| `Normal[S: (int, ...), T: floating]`                                           | `>=1.15.0.0`  | `>=1.17` | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.Normal.html)                         |
+| `Binomial[S: (int, ...), T: floating]`                                         | `>=1.16.0.0`  | `>=1.17` | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.Binomial.html)                       |
+| `Mixture[T: floating]`                                                         | `>=1.15.0.0`  | `>=1.17` | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.Mixture.html)                        |
+| `rv_frozen[D: rv_generic, T: scalar or array]`                                 | `>=1.14.0.0`  | `>=1.17` |                                                                                                              |
+| `multi_rv_frozen[D: rv_generic]`                                               | `>=1.14.0.0`  | `>=1.17` |                                                                                                              |
+| `CensoredData[X: f64 \| c128, L: f64 \| c128, R: f64 \| c128, I: f64 \| c128]` | `>=1.17.0.2`  | `>=1.18` | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.CensoredData.html)                   |
+| `gaussian_kde[T: floating]`                                                    | `>=1.17.0.2`  | `>=1.18` | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.gaussian_kde.html)                   |
+| `FitResult[F: (float, *) -> f64]`                                              | `>=15.0.0.0`  |          | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats._result_classes.FitResult.html)      |
+| `PearsonRResult[T: floating scalar/array, P: f64 scalar/array]`                | `>=1.14.1.0`  |          | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats._result_classes.PearsonRResult.html) |
+| `TtestResult[T: floating scalar/array]`                                        | `>=1.14.1.0`  |          | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats._result_classes.TtestResult.html)    |
 
 ## Contributing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,7 @@ executor.type = "uv"
 extend-exclude = ["*.pyi", ".mypyignore"]
 
 [tool.typos.default]
-extend-ignore-identifiers-re = ['ND|Nd|Theis']
+extend-ignore-identifiers-re = ['ND|Nd|Theis|TtestResult']
 
 # mypy
 


### PR DESCRIPTION
Add generic scipy.stats classes and their type parameters to the README.