### PR TITLE
✅ `linalg`: test `interpolative.*`

### DIFF
--- a/scipy-stubs/linalg/interpolative.pyi
+++ b/scipy-stubs/linalg/interpolative.pyi
@@ -37,8 +37,8 @@ def reconstruct_interp_matrix(
 
 #
 def reconstruct_skel_matrix(
-    A: np.ndarray[tuple[int, ...], _DTypeT], k: SupportsIndex, idx: onp.ArrayND[npc.integer]
-) -> np.ndarray[tuple[int, ...], _DTypeT]: ...
+    A: np.ndarray[tuple[Any, ...], _DTypeT], k: SupportsIndex, idx: onp.ArrayND[npc.integer]
+) -> np.ndarray[tuple[Any, ...], _DTypeT]: ...
 
 #
 def id_to_svd(

--- a/tests/linalg/test_interpolative.pyi
+++ b/tests/linalg/test_interpolative.pyi
@@ -43,7 +43,7 @@ assert_type(interp.reconstruct_interp_matrix(intp_1d, f64_proj), onp.ArrayND[np.
 ###
 # reconstruct_skel_matrix
 
-assert_type(interp.reconstruct_skel_matrix(f64_2d, 3, intp_1d), np.ndarray[tuple[int, ...], np.dtype[np.float64]])
+assert_type(interp.reconstruct_skel_matrix(f64_2d, 3, intp_1d), onp.ArrayND[np.float64])
 
 ###
 # id_to_svd


### PR DESCRIPTION
towards #1099

this also cleans up the stubs a bit, and fixes an awkward non-gradual shape-type in `reconstruct_skel_matrix`