### PR TITLE
✅ `sparse.linalg`: increase type-test coverage

### DIFF
--- a/tests/sparse/linalg/test__isolve.pyi
+++ b/tests/sparse/linalg/test__isolve.pyi
@@ -1,0 +1,32 @@
+from typing import assert_type
+
+import numpy as np
+import optype.numpy as onp
+
+from scipy.sparse import csr_array
+from scipy.sparse.linalg import bicg, bicgstab, cg, gmres, qmr
+
+a_f64: csr_array[np.float64]
+a_c128: csr_array[np.complex128]
+b_f: onp.Array1D[np.float64]
+b_c: onp.Array1D[np.complex128]
+
+# bicg
+assert_type(bicg(a_f64, b_f), tuple[onp.Array1D[np.float64], int])
+assert_type(bicg(a_c128, b_c), tuple[onp.Array1D[np.complex128], int])
+
+# bicgstab
+assert_type(bicgstab(a_f64, b_f), tuple[onp.Array1D[np.float64], int])
+assert_type(bicgstab(a_c128, b_c), tuple[onp.Array1D[np.complex128], int])
+
+# cg
+assert_type(cg(a_f64, b_f), tuple[onp.Array1D[np.float64], int])
+assert_type(cg(a_c128, b_c), tuple[onp.Array1D[np.complex128], int])
+
+# gmres
+assert_type(gmres(a_f64, b_f), tuple[onp.Array1D[np.float64], int])
+assert_type(gmres(a_c128, b_c), tuple[onp.Array1D[np.complex128], int])
+
+# qmr
+assert_type(qmr(a_f64, b_f), tuple[onp.Array1D[np.float64], int])
+assert_type(qmr(a_c128, b_c), tuple[onp.Array1D[np.complex128], int])

--- a/tests/sparse/linalg/test__matfuncs.pyi
+++ b/tests/sparse/linalg/test__matfuncs.pyi
@@ -1,0 +1,19 @@
+from typing import assert_type
+
+from scipy.sparse import csc_array, csr_array
+from scipy.sparse.linalg import expm, inv, matrix_power
+
+a_csr: csr_array
+a_csc: csc_array
+
+# inv
+assert_type(inv(a_csr), csr_array)
+assert_type(inv(a_csc), csc_array)
+
+# expm
+assert_type(expm(a_csr), csr_array)
+assert_type(expm(a_csc), csc_array)
+
+# matrix_power
+assert_type(matrix_power(a_csr, 3), csr_array)
+assert_type(matrix_power(a_csc, 3), csc_array)

--- a/tests/sparse/linalg/test__norm.pyi
+++ b/tests/sparse/linalg/test__norm.pyi
@@ -1,0 +1,18 @@
+from typing import TypeAlias, assert_type
+
+import numpy as np
+import optype.numpy as onp
+
+from scipy.sparse import csr_array
+from scipy.sparse.linalg import norm
+
+_Real: TypeAlias = np.int32 | np.int64 | np.float64
+
+a: csr_array
+
+assert_type(norm(a), _Real)
+assert_type(norm(a, ord="fro"), _Real)
+assert_type(norm(a, ord=1), _Real)
+assert_type(norm(a, axis=(0, 1)), _Real)
+assert_type(norm(a, ord=None, axis=0), onp.Array1D[_Real])
+assert_type(norm(a, axis=1), onp.Array1D[_Real])


### PR DESCRIPTION
towards #1099