### PR TITLE
✅ `sparse.linalg`: increase type-test coverage even more

### DIFF
--- a/tests/sparse/linalg/test__gcrotmk.pyi
+++ b/tests/sparse/linalg/test__gcrotmk.pyi
@@ -1,0 +1,16 @@
+from typing import assert_type
+
+import numpy as np
+import optype.numpy as onp
+
+from scipy.sparse import csr_array
+from scipy.sparse.linalg import gcrotmk
+
+a_f: csr_array[np.float64]
+a_c: csr_array[np.complex128]
+b_f: onp.Array1D[np.float64]
+b_c: onp.Array1D[np.complex128]
+
+# gcrotmk
+assert_type(gcrotmk(a_f, b_f), tuple[onp.Array1D[np.float64], int])
+assert_type(gcrotmk(a_c, b_c), tuple[onp.Array1D[np.complex128], int])

--- a/tests/sparse/linalg/test__lgmres.pyi
+++ b/tests/sparse/linalg/test__lgmres.pyi
@@ -1,0 +1,16 @@
+from typing import assert_type
+
+import numpy as np
+import optype.numpy as onp
+
+from scipy.sparse import csr_array
+from scipy.sparse.linalg import lgmres
+
+a_f: csr_array[np.float64]
+a_c: csr_array[np.complex128]
+b_f: onp.Array1D[np.float64]
+b_c: onp.Array1D[np.complex128]
+
+# lgmres
+assert_type(lgmres(a_f, b_f), tuple[onp.Array1D[np.float64], int])
+assert_type(lgmres(a_c, b_c), tuple[onp.Array1D[np.complex128], int])

--- a/tests/sparse/linalg/test__lobpcg.pyi
+++ b/tests/sparse/linalg/test__lobpcg.pyi
@@ -1,0 +1,46 @@
+from typing import assert_type
+
+import numpy as np
+import optype.numpy as onp
+
+from scipy.sparse.linalg._eigen.lobpcg.lobpcg import lobpcg
+
+a: onp.Array2D[np.float64]
+x: onp.Array2D[np.float64]
+
+# lobpcg
+assert_type(lobpcg(a, x), tuple[onp.Array1D[np.float64], onp.Array2D[np.float64 | np.complex64 | np.complex128]])
+assert_type(
+    lobpcg(a, x, None, None, None, None, None, True, 0, False, True),
+    tuple[onp.Array1D[np.float64], onp.Array2D[np.float64 | np.complex64 | np.complex128], list[onp.Array0D[np.float64]]],
+)
+assert_type(
+    lobpcg(a, x, retResidualNormsHistory=True),
+    tuple[onp.Array1D[np.float64], onp.Array2D[np.float64 | np.complex64 | np.complex128], list[onp.Array0D[np.float64]]],
+)
+assert_type(
+    lobpcg(a, x, None, None, None, None, None, True, 0, True, False),
+    tuple[onp.Array1D[np.float64], onp.Array2D[np.float64 | np.complex64 | np.complex128], list[onp.Array0D[np.float64]]],
+)
+assert_type(
+    lobpcg(a, x, retLambdaHistory=True),
+    tuple[onp.Array1D[np.float64], onp.Array2D[np.float64 | np.complex64 | np.complex128], list[onp.Array0D[np.float64]]],
+)
+assert_type(
+    lobpcg(a, x, None, None, None, None, None, True, 0, True, True),
+    tuple[
+        onp.Array1D[np.float64],
+        onp.Array2D[np.float64 | np.complex64 | np.complex128],
+        list[onp.Array0D[np.float64]],
+        list[onp.Array0D[np.float64]],
+    ],
+)
+assert_type(
+    lobpcg(a, x, retLambdaHistory=True, retResidualNormsHistory=True),
+    tuple[
+        onp.Array1D[np.float64],
+        onp.Array2D[np.float64 | np.complex64 | np.complex128],
+        list[onp.Array0D[np.float64]],
+        list[onp.Array0D[np.float64]],
+    ],
+)

--- a/tests/sparse/linalg/test__lsmr.pyi
+++ b/tests/sparse/linalg/test__lsmr.pyi
@@ -1,0 +1,13 @@
+from typing import Literal, assert_type
+
+import numpy as np
+import optype.numpy as onp
+
+from scipy.sparse import csr_array
+from scipy.sparse.linalg import lsmr
+
+a: csr_array[np.float64]
+b: onp.Array1D[np.float64]
+
+# lsmr
+assert_type(lsmr(a, b), tuple[onp.Array1D[np.float64], Literal[0, 1, 2, 3, 4, 5, 6, 7], int, float, float, float, float, float])

--- a/tests/sparse/linalg/test__lsqr.pyi
+++ b/tests/sparse/linalg/test__lsqr.pyi
@@ -1,0 +1,27 @@
+from typing import Literal, assert_type
+
+import numpy as np
+import optype.numpy as onp
+
+from scipy.sparse import csr_array
+from scipy.sparse.linalg import lsqr
+
+a: csr_array[np.float64]
+b: onp.Array1D[np.float64]
+
+# lsqr
+assert_type(
+    lsqr(a, b),
+    tuple[
+        onp.Array1D[np.float64],
+        Literal[0, 1, 2, 3, 4, 5, 6, 7],
+        int,
+        float,
+        float,
+        float,
+        float,
+        float,
+        float,
+        onp.Array1D[np.float64],
+    ],
+)

--- a/tests/sparse/linalg/test__minres.pyi
+++ b/tests/sparse/linalg/test__minres.pyi
@@ -1,0 +1,13 @@
+from typing import assert_type
+
+import numpy as np
+import optype.numpy as onp
+
+from scipy.sparse import csr_array
+from scipy.sparse.linalg import minres
+
+a: csr_array[np.float64]
+b: onp.Array1D[np.float64]
+
+# minres
+assert_type(minres(a, b), tuple[onp.Array1D[np.float64], int])

--- a/tests/sparse/linalg/test__onenormest.pyi
+++ b/tests/sparse/linalg/test__onenormest.pyi
@@ -1,0 +1,18 @@
+from typing import assert_type
+
+import numpy as np
+import optype.numpy as onp
+
+from scipy.sparse import csr_array
+from scipy.sparse.linalg import onenormest
+
+a: csr_array[np.float64]
+
+# onenormest
+assert_type(onenormest(a), np.float64)
+assert_type(onenormest(a, 2, 5, False, True), tuple[np.float64, onp.Array1D[np.float64]])
+assert_type(onenormest(a, compute_w=True), tuple[np.float64, onp.Array1D[np.float64]])
+assert_type(onenormest(a, 2, 5, True, False), tuple[np.float64, onp.Array1D[np.float64]])
+assert_type(onenormest(a, compute_v=True), tuple[np.float64, onp.Array1D[np.float64]])
+assert_type(onenormest(a, 2, 5, True, True), tuple[np.float64, onp.Array1D[np.float64], onp.Array1D[np.float64]])
+assert_type(onenormest(a, compute_v=True, compute_w=True), tuple[np.float64, onp.Array1D[np.float64], onp.Array1D[np.float64]])

--- a/tests/sparse/linalg/test__special_sparse_arrays.pyi
+++ b/tests/sparse/linalg/test__special_sparse_arrays.pyi
@@ -1,0 +1,23 @@
+from typing import Any, assert_type
+
+import numpy as np
+import optype.numpy as onp
+
+from scipy.sparse.linalg import LaplacianNd
+
+gs: tuple[int, int]
+
+lap_i8 = LaplacianNd(gs)
+assert_type(lap_i8, LaplacianNd[np.int8])
+
+lap_f64 = LaplacianNd(gs, dtype=np.dtype(np.float64))
+assert_type(lap_f64, LaplacianNd[np.float64])
+
+lap_any = LaplacianNd(gs, dtype="float64")
+assert_type(lap_any, LaplacianNd[Any])
+
+# methods
+lap: LaplacianNd[np.float64]
+assert_type(lap.eigenvalues(), onp.Array1D[np.float64])
+assert_type(lap.eigenvectors(), onp.Array2D[np.float64])
+assert_type(lap.toarray(), onp.Array2D[np.float64])

--- a/tests/sparse/linalg/test__svds.pyi
+++ b/tests/sparse/linalg/test__svds.pyi
@@ -1,0 +1,17 @@
+from typing import assert_type
+
+import numpy as np
+import optype.numpy as onp
+
+from scipy.sparse.linalg import svds
+
+a_f32: onp.Array2D[np.float32]
+a_f64: onp.Array2D[np.float64]
+a_c64: onp.Array2D[np.complex64]
+a_c128: onp.Array2D[np.complex128]
+
+# svds
+assert_type(svds(a_f32), tuple[onp.Array2D[np.float32], onp.ArrayND[np.float32 | np.float64], onp.ArrayND[np.float32]])
+assert_type(svds(a_f64), tuple[onp.Array2D[np.float64], onp.ArrayND[np.float32 | np.float64], onp.ArrayND[np.float64]])
+assert_type(svds(a_c64), tuple[onp.Array2D[np.complex64], onp.ArrayND[np.float32 | np.float64], onp.ArrayND[np.complex64]])
+assert_type(svds(a_c128), tuple[onp.Array2D[np.complex128], onp.ArrayND[np.float32 | np.float64], onp.ArrayND[np.complex128]])

--- a/tests/sparse/linalg/test__tfqmr.pyi
+++ b/tests/sparse/linalg/test__tfqmr.pyi
@@ -1,0 +1,16 @@
+from typing import assert_type
+
+import numpy as np
+import optype.numpy as onp
+
+from scipy.sparse import csr_array
+from scipy.sparse.linalg import tfqmr
+
+a_f: csr_array[np.float64]
+a_c: csr_array[np.complex128]
+b_f: onp.Array1D[np.float64]
+b_c: onp.Array1D[np.complex128]
+
+# tfqmr
+assert_type(tfqmr(a_f, b_f), tuple[onp.Array1D[np.float64], int])
+assert_type(tfqmr(a_c, b_c), tuple[onp.Array1D[np.complex128], int])


### PR DESCRIPTION
towards #1099