### PR TITLE
🐛 `sparse.linalg`: fix `lobpcg` import issue

### DIFF
--- a/scipy-stubs/sparse/linalg/__init__.pyi
+++ b/scipy-stubs/sparse/linalg/__init__.pyi
@@ -11,7 +11,8 @@ from ._dsolve import (
     spsolve_triangular,
     use_solver,
 )
-from ._eigen import ArpackError, ArpackNoConvergence, eigs, eigsh, lobpcg, svds
+from ._eigen import ArpackError, ArpackNoConvergence, eigs, eigsh, svds
+from ._eigen.lobpcg import lobpcg  # type: ignore[no-redef]
 from ._expm_multiply import expm_multiply
 from ._funm_multiply_krylov import funm_multiply_krylov
 from ._interface import LinearOperator, aslinearoperator


### PR DESCRIPTION
It accidentally exported the `sparse.linalg._eigen.lobpcg` **module** rather than the `sparse.linalg._eigen.lobpcg.lobpcg` function (clearly pretty confusing).