### PR TITLE
✅ `sparse.linalg`: increase type-test coverage to 100%

### DIFF
--- a/tests/sparse/linalg/test__arpack.pyi
+++ b/tests/sparse/linalg/test__arpack.pyi
@@ -4,11 +4,16 @@ import numpy as np
 import optype.numpy as onp
 
 from scipy.sparse import csr_array
-from scipy.sparse.linalg import eigs, eigsh
+from scipy.sparse.linalg import ArpackNoConvergence, eigs, eigsh
 
 a_f: csr_array[np.float64]
 a_c: csr_array[np.complex128]
 a_fc: csr_array[np.float64] | csr_array[np.complex128]
+
+# ArpackNoConvergence
+exc: ArpackNoConvergence
+assert_type(exc.eigenvalues, onp.Array1D[np.float64 | np.complex128])
+assert_type(exc.eigenvectors, onp.Array2D[np.float64 | np.complex128])
 
 # eigs
 assert_type(eigs(a_f), tuple[onp.Array1D[np.complex128], onp.Array2D[np.complex128]])

--- a/tests/sparse/linalg/test__funm_multiply_krylov.pyi
+++ b/tests/sparse/linalg/test__funm_multiply_krylov.pyi
@@ -1,0 +1,18 @@
+from typing import assert_type
+
+import numpy as np
+import optype.numpy as onp
+
+from scipy.sparse.linalg import funm_multiply_krylov
+
+def f_f64(A: onp.Array2D[np.float64]) -> onp.ArrayND[np.float64]: ...
+def f_c128(A: onp.Array2D[np.complex128]) -> onp.ArrayND[np.complex128]: ...
+
+A_f: onp.Array2D[np.float64]
+A_c: onp.Array2D[np.complex128]
+b_f: onp.Array1D[np.float64]
+b_c: onp.Array1D[np.complex128]
+
+# funm_multiply_krylov
+assert_type(funm_multiply_krylov(f_f64, A_f, b_f), onp.Array1D[np.float64])
+assert_type(funm_multiply_krylov(f_c128, A_c, b_c), onp.Array1D[np.complex128])

--- a/tests/sparse/linalg/test__interface.pyi
+++ b/tests/sparse/linalg/test__interface.pyi
@@ -2,9 +2,11 @@ from typing import Any, assert_type
 
 import numpy as np
 import numpy.typing as npt
+import optype.numpy as onp
 
-from scipy.sparse.linalg import LinearOperator
-from scipy.sparse.linalg._interface import _CustomLinearOperator
+from scipy.sparse import csr_array
+from scipy.sparse.linalg import LinearOperator, aslinearoperator
+from scipy.sparse.linalg._interface import MatrixLinearOperator, _CustomLinearOperator
 
 int_type: type[int]
 float_type: type[float]
@@ -20,5 +22,15 @@ assert_type(LinearOperator((2, 2), matvec=mv, dtype=float), _CustomLinearOperato
 assert_type(LinearOperator((2, 2), matvec=mv, dtype=complex), _CustomLinearOperator[np.complex128])
 assert_type(LinearOperator((2, 2), matvec=mv), _CustomLinearOperator[np.int8 | Any])
 
-# TODO(jorenham): add more tests for `LinearOperator`
-# TODO(jorenham): add tests for `aslinearoperator`
+# aslinearoperator
+a_f64: onp.Array2D[np.float64]
+a_c128: onp.Array2D[np.complex128]
+a_i64: onp.Array2D[np.int64]
+sp_f64: csr_array[np.float64]
+sp_c128: csr_array[np.complex128]
+
+assert_type(aslinearoperator(a_f64), MatrixLinearOperator[np.float64])
+assert_type(aslinearoperator(a_c128), MatrixLinearOperator[np.complex128])
+assert_type(aslinearoperator(a_i64), MatrixLinearOperator[np.float64])
+assert_type(aslinearoperator(sp_f64), MatrixLinearOperator[np.float64])
+assert_type(aslinearoperator(sp_c128), MatrixLinearOperator[np.complex128])

--- a/tests/sparse/linalg/test__isolve.pyi
+++ b/tests/sparse/linalg/test__isolve.pyi
@@ -4,7 +4,7 @@ import numpy as np
 import optype.numpy as onp
 
 from scipy.sparse import csr_array
-from scipy.sparse.linalg import bicg, bicgstab, cg, gmres, qmr
+from scipy.sparse.linalg import bicg, bicgstab, cg, cgs, gmres, qmr
 
 a_f64: csr_array[np.float64]
 a_c128: csr_array[np.complex128]
@@ -23,9 +23,14 @@ assert_type(bicgstab(a_c128, b_c), tuple[onp.Array1D[np.complex128], int])
 assert_type(cg(a_f64, b_f), tuple[onp.Array1D[np.float64], int])
 assert_type(cg(a_c128, b_c), tuple[onp.Array1D[np.complex128], int])
 
+# cgs
+assert_type(cgs(a_f64, b_f), tuple[onp.Array1D[np.float64], int])
+
 # gmres
 assert_type(gmres(a_f64, b_f), tuple[onp.Array1D[np.float64], int])
+assert_type(gmres(a_f64, b_f, callback_type="x"), tuple[onp.Array1D[np.float64], int])
 assert_type(gmres(a_c128, b_c), tuple[onp.Array1D[np.complex128], int])
+assert_type(gmres(a_c128, b_c, callback_type="x"), tuple[onp.Array1D[np.complex128], int])
 
 # qmr
 assert_type(qmr(a_f64, b_f), tuple[onp.Array1D[np.float64], int])

--- a/tests/sparse/linalg/test__lobpcg.pyi
+++ b/tests/sparse/linalg/test__lobpcg.pyi
@@ -3,7 +3,7 @@ from typing import assert_type
 import numpy as np
 import optype.numpy as onp
 
-from scipy.sparse.linalg._eigen.lobpcg.lobpcg import lobpcg
+from scipy.sparse.linalg import lobpcg
 
 a: onp.Array2D[np.float64]
 x: onp.Array2D[np.float64]


### PR DESCRIPTION
towards #1099