### PR TITLE
✅ `linalg`: increase type-test coverage to 100%

### DIFF
--- a/tests/linalg/test__basic.pyi
+++ b/tests/linalg/test__basic.pyi
@@ -7,7 +7,21 @@ import optype.numpy as onp
 import optype.numpy.compat as npc
 from optype.test import assert_subtype
 
-from scipy.linalg import det, inv, lstsq, solve, solve_banded, solve_circulant, solve_toeplitz, solve_triangular
+from scipy.linalg import (
+    det,
+    inv,
+    lstsq,
+    matmul_toeplitz,
+    matrix_balance,
+    pinv,
+    pinvh,
+    solve,
+    solve_banded,
+    solve_circulant,
+    solve_toeplitz,
+    solve_triangular,
+    solveh_banded,
+)
 
 ###
 
@@ -429,10 +443,97 @@ assert_type(
 )
 
 ###
-# TODO(jorenham): pinv[h]
+# solveh_banded
+
+assert_type(solveh_banded(i8_2d, i8_1d), onp.Array1D[np.float64])
+assert_type(solveh_banded(i8_2d, i8_2d), onp.Array2D[np.float64])
+assert_type(solveh_banded(i8_2d, i8_3d), onp.ArrayND[np.float64])
+assert_type(solveh_banded(i8_3d, i8_1d), onp.ArrayND[np.float64])
+
+assert_type(solveh_banded(f32_2d, f32_1d), onp.Array1D[np.float32 | np.float64])
+assert_type(solveh_banded(f32_2d, f32_2d), onp.Array2D[np.float32 | np.float64])
+assert_type(solveh_banded(f32_2d, f32_3d), onp.ArrayND[np.float32 | np.float64])
+assert_type(solveh_banded(f32_3d, f32_1d), onp.ArrayND[np.float32 | np.float64])
+
+assert_type(solveh_banded(f64_2d, f64_1d), onp.Array1D[np.float64])
+assert_type(solveh_banded(f64_2d, f64_2d), onp.Array2D[np.float64])
+assert_type(solveh_banded(f64_2d, f64_3d), onp.ArrayND[np.float64])
+assert_type(solveh_banded(f64_3d, f64_1d), onp.ArrayND[np.float64])
+
+assert_type(solveh_banded(f80_2d, f80_1d), onp.Array1D[np.float64])
+assert_type(solveh_banded(f80_2d, f80_2d), onp.Array2D[np.float64])
+assert_type(solveh_banded(f80_2d, f80_3d), onp.ArrayND[np.float64])
+assert_type(solveh_banded(f80_3d, f80_1d), onp.ArrayND[np.float64])
+
+assert_type(solveh_banded(c64_2d, c64_1d), onp.Array1D[np.complex64 | np.complex128])
+assert_type(solveh_banded(c64_2d, c64_2d), onp.Array2D[np.complex64 | np.complex128])
+assert_type(solveh_banded(c64_2d, c64_3d), onp.ArrayND[np.complex64 | np.complex128])
+assert_type(solveh_banded(c64_3d, c64_1d), onp.ArrayND[np.complex64 | np.complex128])
+
+assert_type(solveh_banded(c128_2d, c128_1d), onp.Array1D[np.complex128])
+assert_type(solveh_banded(c128_2d, c128_2d), onp.Array2D[np.complex128])
+assert_type(solveh_banded(c128_2d, c128_3d), onp.ArrayND[np.complex128])
+assert_type(solveh_banded(c128_3d, c128_1d), onp.ArrayND[np.complex128])
+
+assert_type(solveh_banded(c160_2d, c160_1d), onp.Array1D[np.complex128])
+assert_type(solveh_banded(c160_2d, c160_2d), onp.Array2D[np.complex128])
+assert_type(solveh_banded(c160_2d, c160_3d), onp.ArrayND[np.complex128])
+assert_type(solveh_banded(c160_3d, c160_1d), onp.ArrayND[np.complex128])
+
+assert_type(solveh_banded(py_f_2d, py_f_1d), onp.Array1D[np.float64])
+assert_type(solveh_banded(py_f_2d, py_f_2d), onp.Array2D[np.float64])
+assert_type(solveh_banded(py_f_2d, py_f_3d), onp.ArrayND[np.float64])
+assert_type(solveh_banded(py_f_3d, py_f_1d), onp.ArrayND[np.float64])
+
+assert_type(solveh_banded(py_c_2d, py_c_1d), onp.Array1D[np.complex128])
+assert_type(solveh_banded(py_c_2d, py_c_2d), onp.Array2D[np.complex128])
+assert_type(solveh_banded(py_c_2d, py_c_3d), onp.ArrayND[np.complex128])
+assert_type(solveh_banded(py_c_3d, py_c_1d), onp.ArrayND[np.complex128])
 
 ###
-# TODO(jorenham): matrix_balance
+# pinv
+
+assert_type(pinv(f64_nd), onp.ArrayND[npc.floating])
+assert_type(pinv(f64_nd, return_rank=True), tuple[onp.ArrayND[npc.floating], int])
+assert_type(pinv(c128_nd), onp.ArrayND[npc.inexact])
+assert_type(pinv(c128_nd, return_rank=True), tuple[onp.ArrayND[npc.inexact], int])
 
 ###
-# TODO(jorenham): matmul_toeplitz
+# pinvh
+
+assert_type(pinvh(f64_nd), onp.ArrayND[npc.floating])
+assert_type(pinvh(f64_nd, None, None, True, True), tuple[onp.ArrayND[npc.floating], int])
+assert_type(pinvh(f64_nd, return_rank=True), tuple[onp.ArrayND[npc.floating], int])
+assert_type(pinvh(c128_nd), onp.ArrayND[npc.inexact])
+assert_type(pinvh(c128_nd, None, None, True, True), tuple[onp.ArrayND[npc.inexact], int])
+assert_type(pinvh(c128_nd, return_rank=True), tuple[onp.ArrayND[npc.inexact], int])
+
+###
+# matrix_balance
+
+assert_type(matrix_balance(f64_nd), tuple[onp.ArrayND[npc.floating], onp.ArrayND[npc.floating]])
+assert_type(
+    matrix_balance(f64_nd, True, True, True),
+    tuple[onp.ArrayND[npc.floating], tuple[onp.ArrayND[npc.floating], onp.ArrayND[npc.floating]]],
+)
+assert_type(
+    matrix_balance(f64_nd, separate=True),
+    tuple[onp.ArrayND[npc.floating], tuple[onp.ArrayND[npc.floating], onp.ArrayND[npc.floating]]],
+)
+assert_type(matrix_balance(c128_nd), tuple[onp.ArrayND[npc.inexact], onp.ArrayND[npc.inexact]])
+assert_type(
+    matrix_balance(c128_nd, True, True, True),
+    tuple[onp.ArrayND[npc.inexact], tuple[onp.ArrayND[npc.inexact], onp.ArrayND[npc.inexact]]],
+)
+assert_type(
+    matrix_balance(c128_nd, separate=True),
+    tuple[onp.ArrayND[npc.inexact], tuple[onp.ArrayND[npc.inexact], onp.ArrayND[npc.inexact]]],
+)
+
+###
+# matmul_toeplitz
+
+assert_type(matmul_toeplitz(f64_1d, f64_1d), onp.Array1D[npc.floating])
+assert_type(matmul_toeplitz(f64_2d, f64_2d), onp.ArrayND[npc.floating])
+assert_type(matmul_toeplitz(c128_1d, c128_1d), onp.Array1D[npc.inexact])
+assert_type(matmul_toeplitz(c128_2d, c128_2d), onp.ArrayND[npc.inexact])

--- a/tests/linalg/test__cythonized_array_utils.pyi
+++ b/tests/linalg/test__cythonized_array_utils.pyi
@@ -1,0 +1,33 @@
+# type-tests for `linalg/_cythonized_array_utils.pyi`
+
+from typing import assert_type
+
+import numpy as np
+import optype.numpy as onp
+
+from scipy.linalg import bandwidth, ishermitian, issymmetric
+
+###
+
+f64_2d: onp.Array2D[np.float64]
+c128_2d: onp.Array2D[np.complex128]
+
+###
+# bandwidth
+
+assert_type(bandwidth(f64_2d), tuple[int, int])
+assert_type(bandwidth(c128_2d), tuple[int, int])
+
+###
+# issymmetric
+
+assert_type(issymmetric(f64_2d), bool)
+assert_type(issymmetric(f64_2d, atol=1e-6), bool)
+assert_type(issymmetric(f64_2d, rtol=1e-6), bool)
+
+###
+# ishermitian
+
+assert_type(ishermitian(c128_2d), bool)
+assert_type(ishermitian(c128_2d, atol=1e-6), bool)
+assert_type(ishermitian(c128_2d, rtol=1e-6), bool)

--- a/tests/linalg/test__decomp_svd.pyi
+++ b/tests/linalg/test__decomp_svd.pyi
@@ -4,7 +4,7 @@ import numpy as np
 import numpy.typing as npt
 import optype.numpy as onp
 
-from scipy.linalg import svd
+from scipy.linalg import diagsvd, null_space, orth, subspace_angles, svd, svdvals
 
 ArrayF32: TypeAlias = onp.ArrayND[np.float32]
 ArrayF64: TypeAlias = onp.ArrayND[np.float64]
@@ -51,5 +51,46 @@ assert_type(svd(c64_nd, compute_uv=False), ArrayF32)
 assert_type(svd(c128_nd, compute_uv=False), ArrayF64)
 assert_type(svd(c160_nd, compute_uv=False), ArrayF64)
 
-####
-# TODO: test the remaining functions in `_decomp_svd.pyi`
+###
+# svdvals
+
+assert_type(svdvals(f64_nd), onp.ArrayND[np.float64 | np.float32])
+assert_type(svdvals(f32_nd), onp.ArrayND[np.float64 | np.float32])
+assert_type(svdvals(c128_nd), onp.ArrayND[np.float64 | np.float32])
+assert_type(svdvals(c64_nd), onp.ArrayND[np.float64 | np.float32])
+assert_type(svdvals(py_f_2d), onp.ArrayND[np.float64 | np.float32])
+assert_type(svdvals(py_c_2d), onp.ArrayND[np.float64 | np.float32])
+
+###
+# diagsvd
+
+assert_type(diagsvd(f64_nd, 3, 4), onp.ArrayND[np.float64])
+assert_type(diagsvd(f32_nd, 3, 4), onp.ArrayND[np.float32])
+assert_type(diagsvd([True, False], 2, 3), onp.ArrayND[np.bool_])  # type: ignore[assert-type]  # mypy bug
+assert_type(diagsvd([1, 2], 2, 3), onp.ArrayND[np.intp])  # type: ignore[assert-type]  # mypy bug
+assert_type(diagsvd([1.0, 2.0], 2, 3), onp.ArrayND[np.float64])  # type: ignore[assert-type]  # mypy bug
+
+###
+# orth
+
+assert_type(orth(f64_nd), onp.ArrayND[np.float64])
+assert_type(orth(py_f_2d), onp.ArrayND[np.float64])
+assert_type(orth(py_c_2d), onp.ArrayND[np.complex128])
+assert_type(orth(f32_nd), onp.ArrayND[np.float32])
+assert_type(orth(c64_nd), onp.ArrayND[np.complex64])
+
+###
+# null_space
+
+assert_type(null_space(f64_nd), onp.ArrayND[np.float64])
+assert_type(null_space(py_f_2d), onp.ArrayND[np.float64])
+assert_type(null_space(py_c_2d), onp.ArrayND[np.complex128])
+assert_type(null_space(f32_nd), onp.ArrayND[np.float32])
+assert_type(null_space(c64_nd), onp.ArrayND[np.complex64])
+
+###
+# subspace_angles
+
+assert_type(subspace_angles(f64_nd, f64_nd), onp.ArrayND[np.float64 | np.float32])
+assert_type(subspace_angles(c128_nd, c128_nd), onp.ArrayND[np.float64 | np.float32])
+assert_type(subspace_angles(py_f_2d, py_f_2d), onp.ArrayND[np.float64 | np.float32])

--- a/tests/linalg/test__solvers.pyi
+++ b/tests/linalg/test__solvers.pyi
@@ -10,6 +10,7 @@ from scipy.linalg import (
     solve_continuous_lyapunov,
     solve_discrete_are,
     solve_discrete_lyapunov,
+    solve_lyapunov,
     solve_sylvester,
 )
 
@@ -61,3 +62,10 @@ assert_type(solve_discrete_are(f64_nd, f64_nd, c128_nd, f64_nd), _ComplexND)
 assert_type(solve_discrete_are(f64_nd, f64_nd, f64_nd, c128_nd), _ComplexND)
 assert_type(solve_discrete_are(f64_nd, f64_nd, f64_nd, f64_nd, c128_nd), _ComplexND)
 assert_type(solve_discrete_are(f64_nd, f64_nd, f64_nd, f64_nd, s=c128_nd), _ComplexND)
+
+###
+# solve_lyapunov  (alias for solve_continuous_lyapunov)
+
+assert_type(solve_lyapunov(f64_nd, f64_nd), _FloatND)
+assert_type(solve_lyapunov(c128_nd, f64_nd), _ComplexND)
+assert_type(solve_lyapunov(f64_nd, c128_nd), _ComplexND)

--- a/tests/linalg/test_blas.pyi
+++ b/tests/linalg/test_blas.pyi
@@ -1,0 +1,28 @@
+# type-tests for `linalg/blas.pyi`
+
+from typing import Literal as L, assert_type
+
+import numpy as np
+
+from scipy.linalg import find_best_blas_type, get_blas_funcs
+from scipy.linalg.blas import _FortranFunction
+
+###
+# find_best_blas_type
+
+assert_type(
+    find_best_blas_type(),
+    (
+        tuple[L["s"], np.dtype[np.float32], bool]
+        | tuple[L["f"], np.dtype[np.float64], bool]
+        | tuple[L["c"], np.dtype[np.complex64], bool]
+        | tuple[L["z"], np.dtype[np.complex128], bool]
+    ),
+)
+
+###
+# get_blas_funcs
+
+assert_type(get_blas_funcs("gemm"), _FortranFunction)
+assert_type(get_blas_funcs(["gemm", "larf"]), list[_FortranFunction] | _FortranFunction)
+assert_type(get_blas_funcs(iter(["gemm"])), list[_FortranFunction] | _FortranFunction)

--- a/tests/linalg/test_lapack.pyi
+++ b/tests/linalg/test_lapack.pyi
@@ -1,0 +1,12 @@
+# type-tests for `linalg/lapack.pyi`
+
+from typing import assert_type
+
+from scipy.linalg import get_lapack_funcs
+from scipy.linalg.blas import _FortranFunction
+
+###
+# get_lapack_funcs
+
+assert_type(get_lapack_funcs("getrf"), list[_FortranFunction] | _FortranFunction)
+assert_type(get_lapack_funcs(["getrf", "getrs"]), list[_FortranFunction] | _FortranFunction)


### PR DESCRIPTION
towards #1099

Note that the remaining `scipy.linalg.blas` and `scipy.linalg.lapack` names are modules, and therefore false positives. I'll address this in a follow-up.