### PR TITLE
🐛 `optimize.root`: missing `OptimizeResult` return attributes

### DIFF
--- a/scipy-stubs/optimize/_root.pyi
+++ b/scipy-stubs/optimize/_root.pyi
@@ -138,7 +138,7 @@ def root(
     tol: onp.ToFloat | None = None,
     callback: Callable[[onp.ArrayND[np.float64], onp.ArrayND[np.float64]], None] | None = None,
     options: _RootOptions | None = None,
-) -> _OptimizeResult: ...
+) -> OptimizeResult: ...
 @overload  # `jac` truthy (positional)
 def root(
     fun: Callable[Concatenate[onp.ArrayND[np.float64], ...], tuple[onp.ToFloatND, onp.ToFloatND]],
@@ -149,7 +149,7 @@ def root(
     tol: onp.ToFloat | None = None,
     callback: Callable[[onp.ArrayND[np.float64], onp.ArrayND[np.float64]], None] | None = None,
     options: _RootOptions | None = None,
-) -> _OptimizeResult: ...
+) -> OptimizeResult: ...
 @overload  # `jac` truthy (keyword)
 def root(
     fun: Callable[Concatenate[onp.ArrayND[np.float64], ...], tuple[onp.ToFloatND, onp.ToFloatND]],
@@ -161,4 +161,4 @@ def root(
     tol: onp.ToFloat | None = None,
     callback: Callable[[onp.ArrayND[np.float64], onp.ArrayND[np.float64]], None] | None = None,
     options: _RootOptions | None = None,
-) -> _OptimizeResult: ...
+) -> OptimizeResult: ...


### PR DESCRIPTION
The wrong `OptimizeResult` was returned by `root`. This fixes it to return the specialized `OptimizeResult` which has proper type annotations for `x`, `success`, `message`, and `nfev`.
For the `x` attribute in particular there's still room for improvement though, see #1398.

uncovered through #1386