### PR TITLE
✨ `spatial.transform`: improved `Slerp`

### DIFF
--- a/scipy-stubs/spatial/transform/_rotation.pyi
+++ b/scipy-stubs/spatial/transform/_rotation.pyi
@@ -388,10 +388,15 @@ class Rotation(Generic[_ShapeT_co]):
     ) -> tuple[Rotation[tuple[()]], float, onp.Array2D[np.float64]]: ...
 
 class Slerp:
-    times: Final[onp.Array1D[np.int32 | np.int64 | np.float32 | np.float64]]
-    timedelta: Final[onp.Array1D[np.int32 | np.int64 | np.float32 | np.float64]]
-    rotations: Final[Rotation]
+    times: Final[onp.Array1D[np.float64]]
+    timedelta: Final[onp.Array1D[np.float64]]
+    rotations: Final[Rotation[tuple[int]]]
     rotvecs: Final[onp.Array2D[np.float64]]
 
-    def __init__(self, /, times: onp.ToFloat1D, rotations: Rotation) -> None: ...
-    def __call__(self, /, times: onp.ToFloat1D) -> Rotation: ...
+    def __init__(self, /, times: onp.ToFloat1D, rotations: Rotation[tuple[int]]) -> None: ...
+
+    #
+    @overload
+    def __call__(self, /, times: onp.ToFloat) -> Rotation[tuple[()]]: ...
+    @overload
+    def __call__(self, /, times: onp.ToFloat1D) -> Rotation[tuple[int]]: ...

--- a/tests/spatial/test__rotation.pyi
+++ b/tests/spatial/test__rotation.pyi
@@ -215,9 +215,21 @@ assert_type(_aligned_sens[2], onp.Array2D[np.float64])
 ###
 # Slerp
 
-_slerp = Slerp(_f64_1d, _rot_nd)
-assert_type(_slerp.times, onp.Array1D[np.int32 | np.int64 | np.float32 | np.float64])
-assert_type(_slerp.timedelta, onp.Array1D[np.int32 | np.int64 | np.float32 | np.float64])
-assert_type(_slerp.rotations, Rotation)
+_slerp: Slerp
+
+# __init__
+
+assert_type(Slerp(_f64_1d, _rot_1d), Slerp)
+assert_type(Slerp(_f64_1d, _rot_nd), Slerp)
+
+# __call__
+
+assert_type(_slerp(2), Rotation[tuple[()]])
+assert_type(_slerp(_f64_1d), Rotation[tuple[int]])
+
+# properties
+
+assert_type(_slerp.times, onp.Array1D[np.float64])
+assert_type(_slerp.timedelta, onp.Array1D[np.float64])
+assert_type(_slerp.rotations, Rotation[tuple[int]])
 assert_type(_slerp.rotvecs, onp.Array2D[np.float64])
-assert_type(_slerp(_f64_1d), Rotation)


### PR DESCRIPTION
This improves the attribute types and `__call__` signature of `scipy.spatial.transform.Slerp` by making the returned `Rotation` shape-type input-dependent.