### PR TITLE
✨ `linalg.interpolative`: improved shape-typing and dtypes

### DIFF
--- a/scipy-stubs/linalg/interpolative.pyi
+++ b/scipy-stubs/linalg/interpolative.pyi
@@ -27,7 +27,7 @@ _ArrayT = TypeVar("_ArrayT", bound=np.ndarray[Any, Any])
 _ShapeT = TypeVar("_ShapeT", bound=tuple[int, ...])
 
 _IndexArray: TypeAlias = onp.Array1D[npc.integer] | Sequence[int]
-_LinOp: TypeAlias = onp.Array2D[_NumberT] | LinearOperator[_NumberT]
+_ToLinOp: TypeAlias = onp.Array2D[_NumberT] | LinearOperator[_NumberT]
 
 ###
 
@@ -43,47 +43,52 @@ def _C_contiguous_copy(A: onp.ToJustFloat64_ND) -> onp.ArrayND[np.float64]: ...
 def _C_contiguous_copy(A: onp.ToJustComplex128_ND) -> onp.ArrayND[np.complex128]: ...
 
 # undocumented
-def _is_real(A: onp.ArrayND[np.float64 | np.complex128, _ShapeT]) -> TypeIs[onp.ArrayND[np.float64, _ShapeT]]: ...
+def _is_real(A: onp.ArrayND[npc.inexact64, _ShapeT]) -> TypeIs[onp.ArrayND[np.float64, _ShapeT]]: ...
 
 #
 @overload  # f64, eps_or_k<1
 def interp_decomp(
-    A: _LinOp[np.float64], eps_or_k: Literal[0, -1, -2, -3, -4], rand: bool = True, rng: onp.random.ToRNG | None = None
+    A: _ToLinOp[npc.floating64], eps_or_k: Literal[0, -1, -2, -3, -4], rand: bool = True, rng: onp.random.ToRNG | None = None
 ) -> tuple[int, onp.Array1D[np.intp], onp.Array2D[np.float64]]: ...
 @overload  # f64, eps_or_k>=1
 def interp_decomp(
-    A: _LinOp[np.float64], eps_or_k: Literal[1, 2, 3, 4, 5], rand: bool = True, rng: onp.random.ToRNG | None = None
+    A: _ToLinOp[npc.floating64], eps_or_k: Literal[1, 2, 3, 4, 5], rand: bool = True, rng: onp.random.ToRNG | None = None
 ) -> tuple[onp.Array1D[np.intp], onp.Array2D[np.float64]]: ...
 @overload  # f64, eps_or_k unknown
 def interp_decomp(
-    A: _LinOp[np.float64], eps_or_k: float, rand: bool = True, rng: onp.random.ToRNG | None = None
+    A: _ToLinOp[npc.floating64], eps_or_k: float, rand: bool = True, rng: onp.random.ToRNG | None = None
 ) -> tuple[int, onp.Array1D[np.intp], onp.Array2D[np.float64]] | tuple[onp.Array1D[np.intp], onp.Array2D[np.float64]]: ...
 @overload  # c128, eps_or_k<1
 def interp_decomp(
-    A: _LinOp[np.complex128], eps_or_k: Literal[0, -1, -2, -3, -4], rand: bool = True, rng: onp.random.ToRNG | None = None
+    A: _ToLinOp[npc.complexfloating128],
+    eps_or_k: Literal[0, -1, -2, -3, -4],
+    rand: bool = True,
+    rng: onp.random.ToRNG | None = None,
 ) -> tuple[int, onp.Array1D[np.intp], onp.Array2D[np.complex128]]: ...
 @overload  # c128, eps_or_k>=1
 def interp_decomp(
-    A: _LinOp[np.complex128], eps_or_k: Literal[1, 2, 3, 4, 5], rand: bool = True, rng: onp.random.ToRNG | None = None
+    A: _ToLinOp[npc.complexfloating128], eps_or_k: Literal[1, 2, 3, 4, 5], rand: bool = True, rng: onp.random.ToRNG | None = None
 ) -> tuple[onp.Array1D[np.intp], onp.Array2D[np.complex128]]: ...
 @overload  # c128, eps_or_k unknown
 def interp_decomp(
-    A: _LinOp[np.complex128], eps_or_k: float, rand: bool = True, rng: onp.random.ToRNG | None = None
+    A: _ToLinOp[npc.complexfloating128], eps_or_k: float, rand: bool = True, rng: onp.random.ToRNG | None = None
 ) -> tuple[int, onp.Array1D[np.intp], onp.Array2D[np.complex128]] | tuple[onp.Array1D[np.intp], onp.Array2D[np.complex128]]: ...
 
 #
 @overload
-def reconstruct_matrix_from_id(B: onp.Array2D[np.float64], idx: _IndexArray, proj: onp.ToFloat2D) -> onp.Array2D[np.float64]: ...
+def reconstruct_matrix_from_id(
+    B: onp.Array2D[npc.floating64], idx: _IndexArray, proj: onp.ToFloat2D
+) -> onp.Array2D[np.float64]: ...
 @overload
 def reconstruct_matrix_from_id(
-    B: onp.Array2D[np.complex128], idx: _IndexArray, proj: onp.ToComplex2D
+    B: onp.Array2D[npc.complexfloating128], idx: _IndexArray, proj: onp.ToComplex2D
 ) -> onp.Array2D[np.complex128]: ...
 
 #
 @overload
-def reconstruct_interp_matrix(idx: _IndexArray, proj: onp.Array2D[np.float64]) -> onp.Array2D[np.float64]: ...
+def reconstruct_interp_matrix(idx: _IndexArray, proj: onp.Array2D[npc.floating64]) -> onp.Array2D[np.float64]: ...
 @overload
-def reconstruct_interp_matrix(idx: _IndexArray, proj: onp.Array2D[np.complex128]) -> onp.Array2D[np.complex128]: ...
+def reconstruct_interp_matrix(idx: _IndexArray, proj: onp.Array2D[npc.complexfloating128]) -> onp.Array2D[np.complex128]: ...
 
 #
 def reconstruct_skel_matrix(A: onp.Array2D[_NumberT], k: SupportsIndex, idx: _IndexArray) -> onp.Array2D[_NumberT]: ...
@@ -91,37 +96,35 @@ def reconstruct_skel_matrix(A: onp.Array2D[_NumberT], k: SupportsIndex, idx: _In
 #
 @overload
 def id_to_svd(
-    B: onp.Array2D[np.float64], idx: onp.Array1D[np.int64], proj: onp.Array2D[np.float64]
+    B: onp.Array2D[npc.floating64], idx: onp.Array1D[np.int64], proj: onp.Array2D[npc.floating64]
 ) -> tuple[onp.Array2D[np.float64], onp.Array1D[np.float64], onp.Array2D[np.float64]]: ...
 @overload
 def id_to_svd(
-    B: onp.Array2D[np.complex128], idx: onp.Array1D[np.int64], proj: onp.Array2D[np.complex128]
+    B: onp.Array2D[npc.complexfloating128], idx: onp.Array1D[np.int64], proj: onp.Array2D[npc.complexfloating128]
 ) -> tuple[onp.Array2D[np.complex128], onp.Array1D[np.float64], onp.Array2D[np.complex128]]: ...
 
 #
 @overload
 def svd(
-    A: _LinOp[np.float64], eps_or_k: float, rand: bool = True, rng: onp.random.ToRNG | None = None
+    A: _ToLinOp[npc.floating64], eps_or_k: float, rand: bool = True, rng: onp.random.ToRNG | None = None
 ) -> tuple[onp.Array2D[np.float64], onp.Array1D[np.float64], onp.Array2D[np.float64]]: ...
 @overload
 def svd(
-    A: _LinOp[np.complex128], eps_or_k: float, rand: bool = True, rng: onp.random.ToRNG | None = None
+    A: _ToLinOp[npc.complexfloating128], eps_or_k: float, rand: bool = True, rng: onp.random.ToRNG | None = None
 ) -> tuple[onp.Array2D[np.complex128], onp.Array1D[np.float64], onp.Array2D[np.complex128]]: ...
 
 #
-def estimate_spectral_norm(
-    A: _LinOp[np.float64 | np.complex128], its: int = 20, rng: onp.random.ToRNG | None = None
-) -> float: ...
+def estimate_spectral_norm(A: _ToLinOp[npc.inexact64], its: int = 20, rng: onp.random.ToRNG | None = None) -> float: ...
 
 #
 @overload
 def estimate_spectral_norm_diff(
-    A: _LinOp[np.float64], B: _LinOp[np.float64], its: int = 20, rng: onp.random.ToRNG | None = None
+    A: _ToLinOp[npc.floating64], B: _ToLinOp[npc.floating64], its: int = 20, rng: onp.random.ToRNG | None = None
 ) -> float: ...
 @overload
 def estimate_spectral_norm_diff(
-    A: _LinOp[np.complex128], B: _LinOp[np.complex128], its: int = 20, rng: onp.random.ToRNG | None = None
+    A: _ToLinOp[npc.complexfloating128], B: _ToLinOp[npc.complexfloating128], its: int = 20, rng: onp.random.ToRNG | None = None
 ) -> float: ...
 
 #
-def estimate_rank(A: onp.ArrayND[npc.number] | LinearOperator, eps: onp.ToFloat, rng: onp.random.ToRNG | None = None) -> int: ...
+def estimate_rank(A: _ToLinOp[npc.inexact64], eps: float, rng: onp.random.ToRNG | None = None) -> int: ...

--- a/tests/linalg/test_interpolative.pyi
+++ b/tests/linalg/test_interpolative.pyi
@@ -112,5 +112,7 @@ assert_type(estimate_spectral_norm_diff(_lo_c128, _c128_2d), float)
 assert_type(estimate_spectral_norm_diff(_lo_c128, _lo_c128), float)
 
 # estimate_rank
-assert_type(estimate_rank(_f64_2d, 1e-6), int)
-assert_type(estimate_rank(_lo_f64, 1e-6), int)
+assert_type(estimate_rank(_f64_2d, 1), int)
+assert_type(estimate_rank(_lo_f64, 1), int)
+assert_type(estimate_rank(_c128_2d, 1), int)
+assert_type(estimate_rank(_lo_c128, 1), int)


### PR DESCRIPTION
This improves the following public `scipy.linalg.interpolative` functions:

- `estimate_rank`
- `estimate_spectral_norm`
- `estimate_spectral_norm_diff`
- `id_to_svd`
- `interp_decomp`
- `reconstruct_interp_matrix`
- `reconstruct_matrix_from_id`
- `reconstruct_skel_matrix`
- `svd`

closes #1329