### PR TITLE
✨ `ndimage`: improved interpolation functions

### DIFF
--- a/scipy-stubs/ndimage/_interpolation.pyi
+++ b/scipy-stubs/ndimage/_interpolation.pyi
@@ -626,33 +626,69 @@ def zoom(
 #
 @overload
 def rotate(
-    input: onp.ToFloat | onp.ToFloatND,
+    input: _ArrayT,
     angle: onp.ToFloat,
-    axes: tuple[onp.ToInt, onp.ToInt] = (1, 0),
+    axes: tuple[int, int] = (1, 0),
     reshape: bool = True,
     output: None = None,
     order: _Order = 3,
     mode: _Mode = "constant",
     cval: onp.ToFloat = 0.0,
     prefilter: bool = True,
-) -> onp.ArrayND[np.float64 | np.float32]: ...
+) -> _ArrayT: ...
 @overload
 def rotate(
-    input: onp.ToComplex | onp.ToComplexND,
+    input: onp.SequenceND[int],
     angle: onp.ToFloat,
-    axes: tuple[onp.ToInt, onp.ToInt] = (1, 0),
+    axes: tuple[int, int] = (1, 0),
+    reshape: bool = True,
+    output: None = None,
+    order: _Order = 3,
+    mode: _Mode = "constant",
+    cval: onp.ToFloat = 0.0,
+    prefilter: bool = True,
+) -> onp.ArrayND[np.int_]: ...
+@overload
+def rotate(
+    input: onp.SequenceND[list[float]] | list[float],
+    angle: onp.ToFloat,
+    axes: tuple[int, int] = (1, 0),
+    reshape: bool = True,
+    output: None = None,
+    order: _Order = 3,
+    mode: _Mode = "constant",
+    cval: onp.ToFloat = 0.0,
+    prefilter: bool = True,
+) -> onp.ArrayND[np.float64]: ...
+@overload
+def rotate(
+    input: onp.SequenceND[list[complex]] | list[complex],
+    angle: onp.ToFloat,
+    axes: tuple[int, int] = (1, 0),
+    reshape: bool = True,
+    output: None = None,
+    order: _Order = 3,
+    mode: _Mode = "constant",
+    cval: onp.ToFloat = 0.0,
+    prefilter: bool = True,
+) -> onp.ArrayND[np.complex128]: ...
+@overload
+def rotate(
+    input: onp.ToComplexND,
+    angle: onp.ToFloat,
+    axes: tuple[int, int] = (1, 0),
     reshape: bool = True,
     output: None = None,
     order: _Order = 3,
     mode: _Mode = "constant",
     cval: onp.ToComplex = 0.0,
     prefilter: bool = True,
-) -> onp.ArrayND[np.complex128 | np.float64 | np.complex64 | np.float32]: ...
+) -> onp.ArrayND[Any]: ...
 @overload
 def rotate(
-    input: onp.ToScalar | onp.ToArrayND,
+    input: onp.ToComplexND,
     angle: onp.ToFloat,
-    axes: tuple[onp.ToInt, onp.ToInt] = (1, 0),
+    axes: tuple[int, int] = (1, 0),
     reshape: bool = True,
     *,
     output: _ArrayOrDType[_ScalarT],
@@ -663,9 +699,9 @@ def rotate(
 ) -> onp.ArrayND[_ScalarT]: ...
 @overload
 def rotate(
-    input: onp.ToScalar | onp.ToArrayND,
+    input: onp.ToComplexND,
     angle: onp.ToFloat,
-    axes: tuple[onp.ToInt, onp.ToInt] = (1, 0),
+    axes: tuple[int, int] = (1, 0),
     reshape: bool = True,
     *,
     output: type[int],
@@ -676,27 +712,27 @@ def rotate(
 ) -> onp.ArrayND[np.int_]: ...
 @overload
 def rotate(
-    input: onp.ToScalar | onp.ToArrayND,
+    input: onp.ToComplexND,
     angle: onp.ToFloat,
-    axes: tuple[onp.ToInt, onp.ToInt] = (1, 0),
+    axes: tuple[int, int] = (1, 0),
     reshape: bool = True,
     *,
-    output: type[float],
+    output: type[op.JustFloat],
     order: _Order = 3,
     mode: _Mode = "constant",
     cval: onp.ToComplex = 0.0,
     prefilter: bool = True,
-) -> onp.ArrayND[np.float64 | np.int_]: ...
+) -> onp.ArrayND[np.float64]: ...
 @overload
 def rotate(
-    input: onp.ToScalar | onp.ToArrayND,
+    input: onp.ToComplexND,
     angle: onp.ToFloat,
-    axes: tuple[onp.ToInt, onp.ToInt] = (1, 0),
+    axes: tuple[int, int] = (1, 0),
     reshape: bool = True,
     *,
-    output: type[complex],
+    output: type[op.JustComplex],
     order: _Order = 3,
     mode: _Mode = "constant",
     cval: onp.ToComplex = 0.0,
     prefilter: bool = True,
-) -> onp.ArrayND[np.complex128 | np.float64 | np.int_]: ...
+) -> onp.ArrayND[np.complex128]: ...

--- a/tests/ndimage/test__interpolation.pyi
+++ b/tests/ndimage/test__interpolation.pyi
@@ -136,13 +136,16 @@ assert_type(zoom(_f64_2d, 2.0, np.dtype(np.float32)), onp.ArrayND[np.float32])
 
 # rotate
 
-assert_type(rotate(_f64_2d, 45.0), onp.ArrayND[np.float64 | np.float32])
-assert_type(rotate(_py_f_2d, 45.0), onp.ArrayND[np.float64 | np.float32])
+assert_type(rotate(_i16_2d, 2.0), onp.Array2D[np.int16])
+assert_type(rotate(_f32_2d, 2.0), onp.Array2D[np.float32])
+assert_type(rotate(_f64_2d, 2.0), onp.Array2D[np.float64])
+assert_type(rotate(_c64_2d, 2.0), onp.Array2D[np.complex64])
+assert_type(rotate(_c128_2d, 2.0), onp.Array2D[np.complex128])
+assert_type(rotate(_py_i_2d, 2.0), onp.ArrayND[np.int_])
+assert_type(rotate(_py_f_2d, 2.0), onp.ArrayND[np.float64])
+assert_type(rotate(_py_c_2d, 2.0), onp.ArrayND[np.complex128])
 
-assert_type(rotate(_c128_2d, 45.0), onp.ArrayND[np.complex128 | np.float64 | np.complex64 | np.float32])
-assert_type(rotate(_py_c_2d, 45.0), onp.ArrayND[np.complex128 | np.float64 | np.complex64 | np.float32])
-
-assert_type(rotate(_f64_2d, 45.0, output=int), onp.ArrayND[np.int_])
-assert_type(rotate(_f64_2d, 45.0, output=float), onp.ArrayND[np.float64 | np.int_])
-assert_type(rotate(_f64_2d, 45.0, output=complex), onp.ArrayND[np.complex128 | np.float64 | np.int_])
-assert_type(rotate(_f64_2d, 45.0, output=np.dtype(np.float32)), onp.ArrayND[np.float32])
+assert_type(rotate(_f64_2d, 2.0, output=int), onp.ArrayND[np.int_])
+assert_type(rotate(_f64_2d, 2.0, output=float), onp.ArrayND[np.float64])
+assert_type(rotate(_f64_2d, 2.0, output=complex), onp.ArrayND[np.complex128])
+assert_type(rotate(_f64_2d, 2.0, output=np.dtype(np.float32)), onp.ArrayND[np.float32])


### PR DESCRIPTION
This improves the following public `scipy.ndimage` functions:

- `affine_transform`
- `geometric_transform`
- `map_coordinates`
- `rotate`
- `shift`
- `spline_filter`
- `spline_filter1d`
- `zoom`

closes #1304