### PR TITLE
✨ `io`: improved `MMFile.{read,write}` signatures

### DIFF
--- a/scipy-stubs/io/_mmio.pyi
+++ b/scipy-stubs/io/_mmio.pyi
@@ -78,7 +78,7 @@ class MMFile:
         self,
         /,
         target: FileLike[bytes],
-        a: spmatrix | sparray | onp.ToArrayND,
+        a: spmatrix | sparray | onp.ToArray2D,
         comment: str = "",
         field: _Field | None = None,
         precision: int | None = None,


### PR DESCRIPTION
`MMFile.read`  now returns gradual dtypes, and `MMFile.write` no longer accepts non-2d array-likes.