### PR TITLE
✅ `signal`: test remaining waveform functions

### DIFF
--- a/scipy-stubs/signal/_waveforms.pyi
+++ b/scipy-stubs/signal/_waveforms.pyi
@@ -24,8 +24,7 @@ _ChirpMethod: TypeAlias = Literal["linear", "quadratic", "logarithmic", "hyperbo
 def sawtooth(t: _ToFloat0ND, width: _ToFloat0ND = 1) -> _FloatND: ...
 def square(t: _ToFloat0ND, duty: _ToFloat0ND = 0.5) -> _FloatND: ...
 
-# TODO(@jorenham): refine return types based on input types
-# https://github.com/scipy/scipy-stubs/issues/756
+#
 @overload  # t: +f64 0d, complex: False
 def chirp(
     t: onp.ToFloat64,

--- a/tests/signal/test_waveforms.pyi
+++ b/tests/signal/test_waveforms.pyi
@@ -1,91 +1,119 @@
-from typing import Literal, TypeAlias, assert_type
+from typing import assert_type
 
 import numpy as np
 import optype.numpy as onp
 
-from scipy.signal import gausspulse
+from scipy.signal import chirp, gausspulse, sawtooth, square, sweep_poly, unit_impulse
 
-_Array_f8: TypeAlias = onp.ArrayND[np.float64]
-_Scalar_f8: TypeAlias = np.float64
-_Falsy: TypeAlias = Literal[0, False]
-_Truthy: TypeAlias = Literal[1, True]
+###
 
-_time_scalar: onp.ToFloat
-_time_array: onp.ToFloatND
-_time_cutoff: Literal["cutoff"]
-_float: onp.ToFloat
-_truthy: _Truthy
-_falsy: _Falsy
+_f64_1d: onp.Array1D[np.float64]
+_c64_1d: onp.Array1D[np.complex64]
+_c128_0d: np.complex128
+_c128_1d: onp.Array1D[np.complex128]
 
-# test gausspulse function overloads
-# `time` as an array
-assert_type(gausspulse(_time_array), _Array_f8)
-# Full positional arguments
-assert_type(gausspulse(_time_array, _float, _float, _float, _float, _falsy, _falsy), _Array_f8)
-assert_type(gausspulse(_time_array, _float, _float, _float, _float, _truthy, _falsy), tuple[_Array_f8, _Array_f8])
-assert_type(gausspulse(_time_array, _float, _float, _float, _float, _falsy, _truthy), tuple[_Array_f8, _Array_f8])
-assert_type(gausspulse(_time_array, _float, _float, _float, _float, _truthy, _truthy), tuple[_Array_f8, _Array_f8, _Array_f8])
-# Full keyword arguments
-assert_type(gausspulse(t=_time_array), _Array_f8)
-assert_type(gausspulse(t=_time_array, retquad=_falsy, retenv=_falsy), _Array_f8)
-assert_type(gausspulse(t=_time_array, retquad=_truthy, retenv=_falsy), tuple[_Array_f8, _Array_f8])
-assert_type(gausspulse(t=_time_array, retquad=_falsy, retenv=_truthy), tuple[_Array_f8, _Array_f8])
-assert_type(gausspulse(t=_time_array, retquad=_truthy, retenv=_truthy), tuple[_Array_f8, _Array_f8, _Array_f8])
+###
 
-# Mixed positional and keyword arguments
-assert_type(gausspulse(_time_array, _float, _float, _float, _float, retquad=_falsy, retenv=_falsy), _Array_f8)
-assert_type(gausspulse(_time_array, _float, _float, _float, _float, retquad=_truthy, retenv=_falsy), tuple[_Array_f8, _Array_f8])
-assert_type(gausspulse(_time_array, _float, _float, _float, _float, retquad=_falsy, retenv=_truthy), tuple[_Array_f8, _Array_f8])
+# sawtooth
+
+assert_type(sawtooth(1.0), onp.ArrayND[np.float64])
+assert_type(sawtooth(_f64_1d), onp.ArrayND[np.float64])
+assert_type(sawtooth(_f64_1d, 0.5), onp.ArrayND[np.float64])
+
+# square
+
+assert_type(square(1.0), onp.ArrayND[np.float64])
+assert_type(square(_f64_1d), onp.ArrayND[np.float64])
+assert_type(square(_f64_1d, 0.5), onp.ArrayND[np.float64])
+
+# chirp
+
+assert_type(chirp(1.0, 0.0, 1.0, 1.0), np.float64)
+assert_type(chirp(1.0, 0.0, 1.0, 1.0, complex=False), np.float64)
+assert_type(chirp(_f64_1d, 0.0, 1.0, 1.0), onp.ArrayND[np.float64])
+assert_type(chirp(_f64_1d, 0.0, 1.0, 1.0, complex=False), onp.ArrayND[np.float64])
+assert_type(chirp(1.0, 0.0, 1.0, 1.0, complex=True), np.complex128)
+assert_type(chirp(_f64_1d, 0.0, 1.0, 1.0, complex=True), onp.ArrayND[np.complex128])
+assert_type(chirp(_c128_0d, 0.0, 1.0, 1.0), np.complex128)
+assert_type(chirp(_c128_1d, 0.0, 1.0, 1.0), onp.ArrayND[np.complex128])
+assert_type(chirp(_c64_1d, 0.0, 1.0, 1.0), onp.ArrayND[np.complex128])
+
+# sweep_poly
+
+assert_type(sweep_poly(1.0, _f64_1d), onp.ArrayND[np.float64])
+assert_type(sweep_poly(_f64_1d, _f64_1d), onp.ArrayND[np.float64])
+assert_type(sweep_poly(_f64_1d, np.poly1d([1.0, 0.0])), onp.ArrayND[np.float64])
+
+# unit_impulse
+
+assert_type(unit_impulse(10), onp.ArrayND[np.float64])
+assert_type(unit_impulse((3, 3)), onp.ArrayND[np.float64])
+assert_type(unit_impulse(10, 3), onp.ArrayND[np.float64])
+assert_type(unit_impulse(10, "mid"), onp.ArrayND[np.float64])
+assert_type(unit_impulse(10, 3, np.dtype(np.int32)), onp.ArrayND[np.int32])
+assert_type(unit_impulse(10, 3, np.dtype(np.complex128)), onp.ArrayND[np.complex128])
+
+# gausspulse
+
+assert_type(gausspulse(_f64_1d), onp.ArrayND[np.float64])
+assert_type(gausspulse(_f64_1d, 1.0, 1.0, 1.0, 1.0, False, False), onp.ArrayND[np.float64])
+assert_type(gausspulse(_f64_1d, 1.0, 1.0, 1.0, 1.0, True, False), tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64]])
+assert_type(gausspulse(_f64_1d, 1.0, 1.0, 1.0, 1.0, False, True), tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64]])
 assert_type(
-    gausspulse(_time_array, _float, _float, _float, _float, retquad=_truthy, retenv=_truthy),
-    tuple[_Array_f8, _Array_f8, _Array_f8],
+    gausspulse(_f64_1d, 1.0, 1.0, 1.0, 1.0, True, True),
+    tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64], onp.ArrayND[np.float64]],
+)
+assert_type(gausspulse(t=_f64_1d), onp.ArrayND[np.float64])
+assert_type(gausspulse(t=_f64_1d, retquad=False, retenv=False), onp.ArrayND[np.float64])
+assert_type(gausspulse(t=_f64_1d, retquad=True, retenv=False), tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64]])
+assert_type(gausspulse(t=_f64_1d, retquad=False, retenv=True), tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64]])
+assert_type(
+    gausspulse(t=_f64_1d, retquad=True, retenv=True),
+    tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64], onp.ArrayND[np.float64]],
 )
 
-# `time` as a scalar
-assert_type(gausspulse(_time_scalar), _Scalar_f8)
-# Full positional arguments
-assert_type(gausspulse(_time_scalar, _float, _float, _float, _float, _falsy, _falsy), _Scalar_f8)
-assert_type(gausspulse(_time_scalar, _float, _float, _float, _float, _truthy, _falsy), tuple[_Scalar_f8, _Scalar_f8])
-assert_type(gausspulse(_time_scalar, _float, _float, _float, _float, _falsy, _truthy), tuple[_Scalar_f8, _Scalar_f8])
-assert_type(gausspulse(_time_scalar, _float, _float, _float, _float, _truthy, _truthy), tuple[_Scalar_f8, _Scalar_f8, _Scalar_f8])
-# Full keyword arguments
-assert_type(gausspulse(t=_time_scalar), _Scalar_f8)
-assert_type(gausspulse(t=_time_scalar, retquad=_falsy, retenv=_falsy), _Scalar_f8)
-assert_type(gausspulse(t=_time_scalar, retquad=_truthy, retenv=_falsy), tuple[_Scalar_f8, _Scalar_f8])
-assert_type(gausspulse(t=_time_scalar, retquad=_falsy, retenv=_truthy), tuple[_Scalar_f8, _Scalar_f8])
-assert_type(gausspulse(t=_time_scalar, retquad=_truthy, retenv=_truthy), tuple[_Scalar_f8, _Scalar_f8, _Scalar_f8])
-
-# Mixed positional and keyword arguments
-assert_type(gausspulse(_time_scalar, _float, _float, _float, _float, retquad=_falsy, retenv=_falsy), _Scalar_f8)
+assert_type(gausspulse(_f64_1d, 1.0, 1.0, 1.0, 1.0, retquad=False, retenv=False), onp.ArrayND[np.float64])
 assert_type(
-    gausspulse(_time_scalar, _float, _float, _float, _float, retquad=_truthy, retenv=_falsy),
-    tuple[_Scalar_f8, _Scalar_f8],
-)  # fmt: skip
+    gausspulse(_f64_1d, 1.0, 1.0, 1.0, 1.0, retquad=True, retenv=False), tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64]]
+)
 assert_type(
-    gausspulse(_time_scalar, _float, _float, _float, _float, retquad=_falsy, retenv=_truthy),
-    tuple[_Scalar_f8, _Scalar_f8],
-)  # fmt: skip
+    gausspulse(_f64_1d, 1.0, 1.0, 1.0, 1.0, retquad=False, retenv=True), tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64]]
+)
 assert_type(
-    gausspulse(_time_scalar, _float, _float, _float, _float, retquad=_truthy, retenv=_truthy),
-    tuple[_Scalar_f8, _Scalar_f8, _Scalar_f8],
+    gausspulse(_f64_1d, 1.0, 1.0, 1.0, 1.0, retquad=True, retenv=True),
+    tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64], onp.ArrayND[np.float64]],
 )
 
-# `time` as the literal `"cutoff"`
-assert_type(gausspulse(_time_cutoff), _Scalar_f8)
-# Full positional arguments
-assert_type(gausspulse(_time_cutoff, _float, _float, _float, _float, _falsy, _falsy), _Scalar_f8)
-assert_type(gausspulse(_time_cutoff, _float, _float, _float, _float, _truthy, _falsy), _Scalar_f8)
-assert_type(gausspulse(_time_cutoff, _float, _float, _float, _float, _falsy, _truthy), _Scalar_f8)
-assert_type(gausspulse(_time_cutoff, _float, _float, _float, _float, _truthy, _truthy), _Scalar_f8)
-# Full keyword arguments
-assert_type(gausspulse(t=_time_cutoff), _Scalar_f8)
-assert_type(gausspulse(t=_time_cutoff, retquad=_falsy, retenv=_falsy), _Scalar_f8)
-assert_type(gausspulse(t=_time_cutoff, retquad=_truthy, retenv=_falsy), _Scalar_f8)
-assert_type(gausspulse(t=_time_cutoff, retquad=_falsy, retenv=_truthy), _Scalar_f8)
-assert_type(gausspulse(t=_time_cutoff, retquad=_truthy, retenv=_truthy), _Scalar_f8)
+assert_type(gausspulse(1.0), np.float64)
+assert_type(gausspulse(1.0, 1.0, 1.0, 1.0, 1.0, False, False), np.float64)
+assert_type(gausspulse(1.0, 1.0, 1.0, 1.0, 1.0, True, False), tuple[np.float64, np.float64])
+assert_type(gausspulse(1.0, 1.0, 1.0, 1.0, 1.0, False, True), tuple[np.float64, np.float64])
+assert_type(gausspulse(1.0, 1.0, 1.0, 1.0, 1.0, True, True), tuple[np.float64, np.float64, np.float64])
+
+assert_type(gausspulse(t=1.0), np.float64)
+assert_type(gausspulse(t=1.0, retquad=False, retenv=False), np.float64)
+assert_type(gausspulse(t=1.0, retquad=True, retenv=False), tuple[np.float64, np.float64])
+assert_type(gausspulse(t=1.0, retquad=False, retenv=True), tuple[np.float64, np.float64])
+assert_type(gausspulse(t=1.0, retquad=True, retenv=True), tuple[np.float64, np.float64, np.float64])
 
 # Mixed positional and keyword arguments
-assert_type(gausspulse(_time_cutoff, _float, _float, _float, _float, retquad=_falsy, retenv=_falsy), _Scalar_f8)
-assert_type(gausspulse(_time_cutoff, _float, _float, _float, _float, retquad=_truthy, retenv=_falsy), _Scalar_f8)
-assert_type(gausspulse(_time_cutoff, _float, _float, _float, _float, retquad=_falsy, retenv=_truthy), _Scalar_f8)
-assert_type(gausspulse(_time_cutoff, _float, _float, _float, _float, retquad=_truthy, retenv=_truthy), _Scalar_f8)
+assert_type(gausspulse(1.0, 1.0, 1.0, 1.0, 1.0, retquad=False, retenv=False), np.float64)
+assert_type(gausspulse(1.0, 1.0, 1.0, 1.0, 1.0, retquad=True, retenv=False), tuple[np.float64, np.float64])
+assert_type(gausspulse(1.0, 1.0, 1.0, 1.0, 1.0, retquad=False, retenv=True), tuple[np.float64, np.float64])
+assert_type(gausspulse(1.0, 1.0, 1.0, 1.0, 1.0, retquad=True, retenv=True), tuple[np.float64, np.float64, np.float64])
+
+assert_type(gausspulse("cutoff"), np.float64)
+assert_type(gausspulse("cutoff", 1.0, 1.0, 1.0, 1.0, False, False), np.float64)
+assert_type(gausspulse("cutoff", 1.0, 1.0, 1.0, 1.0, True, False), np.float64)
+assert_type(gausspulse("cutoff", 1.0, 1.0, 1.0, 1.0, False, True), np.float64)
+assert_type(gausspulse("cutoff", 1.0, 1.0, 1.0, 1.0, True, True), np.float64)
+assert_type(gausspulse(t="cutoff"), np.float64)
+assert_type(gausspulse(t="cutoff", retquad=False, retenv=False), np.float64)
+assert_type(gausspulse(t="cutoff", retquad=True, retenv=False), np.float64)
+assert_type(gausspulse(t="cutoff", retquad=False, retenv=True), np.float64)
+assert_type(gausspulse(t="cutoff", retquad=True, retenv=True), np.float64)
+
+assert_type(gausspulse("cutoff", 1.0, 1.0, 1.0, 1.0, retquad=False, retenv=False), np.float64)
+assert_type(gausspulse("cutoff", 1.0, 1.0, 1.0, 1.0, retquad=True, retenv=False), np.float64)
+assert_type(gausspulse("cutoff", 1.0, 1.0, 1.0, 1.0, retquad=False, retenv=True), np.float64)
+assert_type(gausspulse("cutoff", 1.0, 1.0, 1.0, 1.0, retquad=True, retenv=True), np.float64)


### PR DESCRIPTION
That is, 

- `chirp`
- `sawtooth`
- `square`
- `sweep_poly`
- `unit_impulse`

towards #1099