### PR TITLE
🐴 `sparse`: improve CSC and CSR array/matrix constructor compatibility with mypy

### DIFF
--- a/scipy-stubs/sparse/_csc.pyi
+++ b/scipy-stubs/sparse/_csc.pyi
@@ -1,9 +1,8 @@
 from collections.abc import Sequence
-from typing import Any, ClassVar, Generic, Literal, TypeAlias, overload, type_check_only
+from typing import Any, ClassVar, Generic, Literal, SupportsIndex, TypeAlias, overload, type_check_only
 from typing_extensions import TypeAliasType, TypeIs, TypeVar, override
 
 import numpy as np
-import optype as op
 import optype.numpy as onp
 import optype.numpy.compat as npc
 
@@ -21,8 +20,6 @@ _Scalar: TypeAlias = npc.number | np.bool_
 _ScalarT = TypeVar("_ScalarT", bound=_Scalar)
 _ScalarT_co = TypeVar("_ScalarT_co", bound=_Scalar, default=Any, covariant=True)
 
-_Seq2D: TypeAlias = Sequence[Sequence[_T]]
-
 _ToIndices: TypeAlias = onp.CanArrayND[npc.integer] | Sequence[int]
 
 _RawCSC = TypeAliasType(
@@ -37,17 +34,18 @@ _ToCSC = TypeAliasType(
         _Sparse2D[_ScalarT]
         | onp.CanArrayND[_ScalarT]
         | _RawCSC[onp.CanArrayND[_ScalarT] | Sequence[_ScalarT]]
-        | Sequence[onp.CanArrayND[_ScalarT] | Sequence[_ScalarT]]
+        | Sequence[Sequence[_ScalarT]]
+        | list[onp.ArrayND[_ScalarT]]
     ),
     type_params=(_ScalarT,),
 )
 _ToAnyCSC = TypeAliasType(
     "_ToAnyCSC", _ToShape2D | _Sparse2D[_Scalar] | onp.ToArray2D[complex, _Scalar] | _RawCSC[onp.ToComplex1D]
 )
-_ToBoolCSC: TypeAlias = _Seq2D[bool] | _RawCSC[Sequence[bool]]
-_ToIntCSC: TypeAlias = _Seq2D[op.JustInt] | _RawCSC[Sequence[op.JustInt]]
-_ToFloatCSC: TypeAlias = _Seq2D[op.JustFloat] | _RawCSC[Sequence[op.JustFloat]] | _ToShape2D
-_ToComplexCSC: TypeAlias = _Seq2D[op.JustComplex] | _RawCSC[Sequence[op.JustComplex]]
+_ToBoolCSC: TypeAlias = Sequence[Sequence[bool]] | _RawCSC[Sequence[bool]]
+_ToIntCSC: TypeAlias = Sequence[Sequence[int]] | _RawCSC[Sequence[int]]
+_ToFloatCSC: TypeAlias = Sequence[Sequence[float]] | _RawCSC[Sequence[float]] | _ToShape2D
+_ToComplexCSC: TypeAlias = Sequence[Sequence[complex]] | _RawCSC[Sequence[complex]]
 
 ###
 
@@ -60,13 +58,10 @@ class _csc_base(_cs_matrix[_ScalarT_co, tuple[int, int]], Generic[_ScalarT_co]):
     @property
     @override
     def ndim(self, /) -> Literal[2]: ...
-    @property
-    @override
-    def shape(self, /) -> tuple[int, int]: ...
 
     #
     @override
-    def transpose(  # type: ignore[override] # pyrefly: ignore [bad-override]
+    def transpose(  # type: ignore[override] # pyrefly: ignore[bad-override]
         self, /, axes: tuple[Literal[1, -1], Literal[0]] | None = None, copy: bool = False
     ) -> _csr_base[_ScalarT_co, tuple[int, int]]: ...
 
@@ -75,7 +70,7 @@ class _csc_base(_cs_matrix[_ScalarT_co, tuple[int, int]], Generic[_ScalarT_co]):
     @overload
     def count_nonzero(self, /, axis: None = None) -> np.intp: ...
     @overload
-    def count_nonzero(self, /, axis: op.CanIndex) -> onp.Array1D[np.intp]: ...
+    def count_nonzero(self, /, axis: SupportsIndex) -> onp.Array1D[np.intp]: ...
 
 class csc_array(_csc_base[_ScalarT_co], sparray[_ScalarT_co, tuple[int, int]], Generic[_ScalarT_co]):
     # NOTE: These four methods do not exist at runtime.
@@ -94,57 +89,57 @@ class csc_array(_csc_base[_ScalarT_co], sparray[_ScalarT_co, tuple[int, int]], G
     def __assoc_as_float64__(self, /) -> csc_array[np.float64]: ...
 
     # NOTE: keep in sync with `csc_matrix.__init__`
-    @overload  # matrix-like (known dtype), dtype: None
+    @overload  # matrix-like (known dtype)
     def __init__(
         self,
         /,
         arg1: _ToCSC[_ScalarT_co],
         shape: _ToShape2D | None = None,
-        dtype: onp.ToDType[_ScalarT_co] | None = None,
+        dtype: None = None,
         copy: bool = False,
         *,
         maxprint: int | None = None,
     ) -> None: ...
-    @overload  # 2-d array-like bool, dtype: bool-like | None
+    @overload  # 2-d array-like bool
     def __init__(
         self: csc_array[np.bool_],
         /,
         arg1: _ToBoolCSC,
         shape: _ToShape2D | None = None,
-        dtype: onp.AnyBoolDType | None = None,
+        dtype: None = None,
         copy: bool = False,
         *,
         maxprint: int | None = None,
     ) -> None: ...
-    @overload  # 2-d array-like ~int, dtype: int-like | None
+    @overload  # 2-d array-like ~int
     def __init__(
         self: csc_array[np.int_],
         /,
         arg1: _ToIntCSC,
         shape: _ToShape2D | None = None,
-        dtype: onp.AnyIntDType | None = None,
+        dtype: None = None,
         copy: bool = False,
         *,
         maxprint: int | None = None,
     ) -> None: ...
-    @overload  # 2-d array-like ~float, dtype: float64-like | None
+    @overload  # 2-d array-like ~float
     def __init__(
         self: csc_array[np.float64],
         /,
         arg1: _ToFloatCSC,
         shape: _ToShape2D | None = None,
-        dtype: onp.AnyFloat64DType | None = None,
+        dtype: None = None,
         copy: bool = False,
         *,
         maxprint: int | None = None,
     ) -> None: ...
-    @overload  # 2-d array-like ~complex, dtype: complex128-like | None
+    @overload  # 2-d array-like ~complex
     def __init__(
         self: csc_array[np.complex128],
         /,
         arg1: _ToComplexCSC,
         shape: _ToShape2D | None = None,
-        dtype: onp.AnyComplex128DType | None = None,
+        dtype: None = None,
         copy: bool = False,
         *,
         maxprint: int | None = None,
@@ -283,57 +278,57 @@ class csc_matrix(_csc_base[_ScalarT_co], spmatrix[_ScalarT_co], Generic[_ScalarT
     def __assoc_as_float64__(self, /) -> csc_matrix[np.float64]: ...
 
     # NOTE: keep in sync with `csc_array.__init__`
-    @overload  # matrix-like (known dtype), dtype: None
+    @overload  # matrix-like (known dtype)
     def __init__(
         self,
         /,
         arg1: _ToCSC[_ScalarT_co],
         shape: _ToShape2D | None = None,
-        dtype: onp.ToDType[_ScalarT_co] | None = None,
+        dtype: None = None,
         copy: bool = False,
         *,
         maxprint: int | None = None,
     ) -> None: ...
-    @overload  # 2-d array-like bool, dtype: bool-like | None
+    @overload  # 2-d array-like bool
     def __init__(
         self: csc_matrix[np.bool_],
         /,
         arg1: _ToBoolCSC,
         shape: _ToShape2D | None = None,
-        dtype: onp.AnyBoolDType | None = None,
+        dtype: None = None,
         copy: bool = False,
         *,
         maxprint: int | None = None,
     ) -> None: ...
-    @overload  # 2-d array-like ~int, dtype: int-like | None
+    @overload  # 2-d array-like ~int
     def __init__(
         self: csc_matrix[np.int_],
         /,
         arg1: _ToIntCSC,
         shape: _ToShape2D | None = None,
-        dtype: onp.AnyIntDType | None = None,
+        dtype: None = None,
         copy: bool = False,
         *,
         maxprint: int | None = None,
     ) -> None: ...
-    @overload  # 2-d array-like ~float, dtype: float64-like | None
+    @overload  # 2-d array-like ~float
     def __init__(
         self: csc_matrix[np.float64],
         /,
         arg1: _ToFloatCSC,
         shape: _ToShape2D | None = None,
-        dtype: onp.AnyFloat64DType | None = None,
+        dtype: None = None,
         copy: bool = False,
         *,
         maxprint: int | None = None,
     ) -> None: ...
-    @overload  # 2-d array-like ~complex, dtype: complex128-like | None
+    @overload  # 2-d array-like ~complex
     def __init__(
         self: csc_matrix[np.complex128],
         /,
         arg1: _ToComplexCSC,
         shape: _ToShape2D | None = None,
-        dtype: onp.AnyComplex128DType | None = None,
+        dtype: None = None,
         copy: bool = False,
         *,
         maxprint: int | None = None,
@@ -460,6 +455,6 @@ class csc_matrix(_csc_base[_ScalarT_co], spmatrix[_ScalarT_co], Generic[_ScalarT
     @overload
     def getnnz(self, /, axis: None = None) -> int: ...
     @overload
-    def getnnz(self, /, axis: op.CanIndex) -> onp.Array1D[np.int32]: ...
+    def getnnz(self, /, axis: SupportsIndex) -> onp.Array1D[np.int32]: ...
 
 def isspmatrix_csc(x: object) -> TypeIs[csc_matrix[Any]]: ...

--- a/scipy-stubs/sparse/_csr.pyi
+++ b/scipy-stubs/sparse/_csr.pyi
@@ -1,4 +1,3 @@
-from collections.abc import Sequence
 from typing import Any, ClassVar, Generic, Literal, Never, TypeAlias, overload, type_check_only
 from typing_extensions import TypeAliasType, TypeIs, TypeVar, override
 
@@ -24,8 +23,8 @@ _ShapeT_co = TypeVar("_ShapeT_co", bound=tuple[int] | tuple[int, int], default=t
 # workaround for the typing-spec non-conformance regarding overload behavior of mypy and pyright
 _NeitherD: TypeAlias = tuple[Never] | tuple[Never, Never]
 
-_ToMatrixPy: TypeAlias = Sequence[_T] | Sequence[Sequence[_T]]
-_ToMatrix: TypeAlias = _spbase[_ScalarT] | onp.CanArrayND[_ScalarT] | Sequence[onp.CanArrayND[_ScalarT]] | _ToMatrixPy[_ScalarT]
+_ToMatrixPy: TypeAlias = list[_T] | list[list[_T]]
+_ToMatrix: TypeAlias = _spbase[_ScalarT] | onp.CanArrayND[_ScalarT] | list[onp.ArrayND[_ScalarT]] | _ToMatrixPy[_ScalarT]
 
 _ToData = TypeAliasType(
     "_ToData",
@@ -79,46 +78,57 @@ class csr_array(_csr_base[_ScalarT_co, _ShapeT_co], sparray[_ScalarT_co, _ShapeT
     def __assoc_as_float64__(self, /) -> csr_array[np.float64, _ShapeT_co]: ...
 
     #
-    @overload  # sparse or dense (know dtype & shape), dtype: None
+    @overload  # sparse or dense (know dtype & shape)
     def __init__(
         self,
         /,
         arg1: _spbase[_ScalarT_co, _ShapeT_co] | onp.CanArrayND[_ScalarT_co, _ShapeT_co],
-        shape: _ShapeT_co | None = None,
-        dtype: onp.ToDType[_ScalarT_co] | None = None,
+        shape: None = None,
+        dtype: None = None,
         copy: bool = False,
         *,
         maxprint: int | None = None,
     ) -> None: ...
-    @overload  # 1-d array-like (know dtype), dtype: None
+    @overload  # 1-d array-like (know dtype)
     def __init__(
         self: csr_array[_ScalarT, tuple[int]],
         /,
-        arg1: Sequence[_ScalarT],
+        arg1: list[_ScalarT],
         shape: _ToShape1D | None = None,
-        dtype: onp.ToDType[_ScalarT] | None = None,
+        dtype: None = None,
         copy: bool = False,
         *,
         maxprint: int | None = None,
     ) -> None: ...
-    @overload  # 2-d array-like (know dtype), dtype: None
+    @overload  # 2-d array-like (know dtype)
     def __init__(
         self: csr_array[_ScalarT, tuple[int, int]],
         /,
-        arg1: onp.ToArray2D[_ScalarT, _ScalarT] | _ToData[onp.ToArray1D[_ScalarT, _ScalarT]],
+        arg1: onp.ToArray2D[_ScalarT, _ScalarT],
         shape: _ToShape2D | None = None,
-        dtype: onp.ToDType[_ScalarT] | None = None,
+        dtype: None = None,
         copy: bool = False,
         *,
         maxprint: int | None = None,
     ) -> None: ...
-    @overload  # matrix-like (known dtype), dtype: None
+    @overload  # 2-d array-like (know dtype)
+    def __init__(
+        self: csr_array[_ScalarT, tuple[int, int]],
+        /,
+        arg1: _ToData[onp.ToArray1D[_ScalarT, _ScalarT]],
+        shape: _ToShape2D | None = None,
+        dtype: None = None,
+        copy: bool = False,
+        *,
+        maxprint: int | None = None,
+    ) -> None: ...
+    @overload  # matrix-like (known dtype)
     def __init__(
         self: csr_array[_ScalarT, tuple[Any, ...]],
         /,
         arg1: _ToMatrix[_ScalarT],
         shape: _ToShape1D | _ToShape2D | None = None,
-        dtype: onp.ToDType[_ScalarT] | None = None,
+        dtype: None = None,
         copy: bool = False,
         *,
         maxprint: int | None = None,
@@ -292,7 +302,7 @@ class csr_array(_csr_base[_ScalarT_co, _ShapeT_co], sparray[_ScalarT_co, _ShapeT
     def __init__(
         self: csr_array[np.bool_, tuple[int, int]],
         /,
-        arg1: onp.ToJustBoolStrict2D | _ToData[Sequence[bool]],
+        arg1: onp.ToJustBoolStrict2D | _ToData[list[bool]],
         shape: _ToShape2D | None = None,
         dtype: onp.AnyBoolDType | None = None,
         copy: bool = False,
@@ -449,18 +459,29 @@ class csr_matrix(_csr_base[_ScalarT_co], spmatrix[_ScalarT_co], Generic[_ScalarT
     def __assoc_as_float64__(self, /) -> csr_matrix[np.float64]: ...
 
     # NOTE: keep in sync with `csc_matrix.__init__`
-    @overload  # matrix-like (known dtype), dtype: None
+    @overload  # matrix-like (known dtype)
     def __init__(
         self: csr_matrix[_ScalarT],  # this self annotation works around a mypy bug
         /,
-        arg1: _ToMatrix[_ScalarT] | _ToData[onp.ToArray1D[_ScalarT, _ScalarT]],
+        arg1: _ToMatrix[_ScalarT],
         shape: _ToShape2D | None = None,
         dtype: onp.ToDType[_ScalarT] | None = None,
         copy: bool = False,
         *,
         maxprint: int | None = None,
     ) -> None: ...
-    @overload  # 2-d shape-like, dtype: None
+    @overload  # matrix-like (known dtype)
+    def __init__(
+        self: csr_matrix[_ScalarT],  # this self annotation works around a mypy bug
+        /,
+        arg1: _ToData[onp.ToArray1D[_ScalarT, _ScalarT]],
+        shape: _ToShape2D | None = None,
+        dtype: onp.ToDType[_ScalarT] | None = None,
+        copy: bool = False,
+        *,
+        maxprint: int | None = None,
+    ) -> None: ...
+    @overload  # 2-d shape-like
     def __init__(
         self: csr_matrix[np.float64],
         /,
@@ -475,7 +496,7 @@ class csr_matrix(_csr_base[_ScalarT_co], spmatrix[_ScalarT_co], Generic[_ScalarT
     def __init__(
         self: csr_matrix[np.bool_],
         /,
-        arg1: onp.ToJustBoolStrict2D | _ToData[Sequence[bool]],
+        arg1: onp.ToJustBoolStrict2D | _ToData[list[bool]],
         shape: _ToShape2D | None = None,
         dtype: onp.AnyBoolDType | None = None,
         copy: bool = False,

--- a/tests/sparse/test_csc.pyi
+++ b/tests/sparse/test_csc.pyi
@@ -11,19 +11,12 @@ dtype: np.dtype[ScalarType]
 
 shape2: tuple[int, int]
 
-ind1: np.ndarray[tuple[int], np.dtype[np.intp]]
-data1: np.ndarray[tuple[int], np.dtype[ScalarType]]
-data2: np.ndarray[tuple[int, int], np.dtype[ScalarType]]
+ind1: onp.Array1D[np.intp]
+data1: onp.Array1D[ScalarType]
+data2: onp.Array2D[ScalarType]
 
-csc_spec2: tuple[
-    np.ndarray[tuple[int], np.dtype[ScalarType]],
-    tuple[np.ndarray[tuple[int], np.dtype[np.intp]], np.ndarray[tuple[int], np.dtype[np.intp]]],
-]
-csc_spec3: tuple[
-    np.ndarray[tuple[int], np.dtype[ScalarType]],
-    np.ndarray[tuple[int], np.dtype[np.intp]],
-    np.ndarray[tuple[int], np.dtype[np.intp]],
-]
+csc_spec2: tuple[onp.Array1D[ScalarType], tuple[onp.Array1D[np.intp], onp.Array1D[np.intp]]]
+csc_spec3: tuple[onp.Array1D[ScalarType], onp.Array1D[np.intp], onp.Array1D[np.intp]]
 
 ###
 # CSC matrix constructor
@@ -60,10 +53,9 @@ assert_type(csc_matrix(csc_spec2, dtype=float), csc_matrix[np.float64])
 assert_type(csc_matrix(csc_spec2, dtype=complex), csc_matrix[np.complex128])
 
 # csc_matrix((data, indices, indptr), [shape=(M, N)])
-# NOTE: mypy incorrectly infers `csc_array[Any]` here, but it is correct in pyright.
-assert_type(csc_matrix(csc_spec3), csc_matrix[ScalarType])  # type: ignore[assert-type]
-assert_type(csc_matrix(csc_spec3, shape2), csc_matrix[ScalarType])  # type: ignore[assert-type]
-assert_type(csc_matrix(csc_spec3, shape=shape2), csc_matrix[ScalarType])  # type: ignore[assert-type]
+assert_type(csc_matrix(csc_spec3), csc_matrix[ScalarType])
+assert_type(csc_matrix(csc_spec3, shape2), csc_matrix[ScalarType])
+assert_type(csc_matrix(csc_spec3, shape=shape2), csc_matrix[ScalarType])
 
 assert_type(csc_matrix(csc_spec3, dtype=dtype), csc_matrix[ScalarType])
 assert_type(csc_matrix(csc_spec3, dtype=bool), csc_matrix[np.bool_])
@@ -106,10 +98,9 @@ assert_type(csc_array(csc_spec2, dtype=float), csc_array[np.float64])
 assert_type(csc_array(csc_spec2, dtype=complex), csc_array[np.complex128])
 
 # csc_array((data, indices, indptr), [shape=(M, N)])
-# NOTE: mypy incorrectly infers `csc_array[Any]` here, but it is correct in pyright and pyrefly.
-assert_type(csc_array(csc_spec3), csc_array[ScalarType])  # type: ignore[assert-type]
-assert_type(csc_array(csc_spec3, shape2), csc_array[ScalarType])  # type: ignore[assert-type]
-assert_type(csc_array(csc_spec3, shape=shape2), csc_array[ScalarType])  # type: ignore[assert-type]
+assert_type(csc_array(csc_spec3), csc_array[ScalarType])
+assert_type(csc_array(csc_spec3, shape2), csc_array[ScalarType])
+assert_type(csc_array(csc_spec3, shape=shape2), csc_array[ScalarType])
 
 assert_type(csc_array(csc_spec3, dtype=dtype), csc_array[ScalarType])
 assert_type(csc_array(csc_spec3, dtype=bool), csc_array[np.bool_])

--- a/tests/sparse/test_csr.pyi
+++ b/tests/sparse/test_csr.pyi
@@ -1,6 +1,7 @@
-from typing import Any, Literal, TypeAlias, assert_type
+from typing import Literal, TypeAlias, assert_type
 
 import numpy as np
+import optype.numpy as onp
 
 from ._types import ScalarType, csr_arr, csr_mat, csr_vec
 from scipy.sparse import coo_array, csc_array, csc_matrix, csr_array, csr_matrix, isspmatrix
@@ -17,8 +18,8 @@ seq_seq_int: list[list[int]]
 seq_seq_float: list[list[float]]
 seq_seq_complex: list[list[complex]]
 
-arr_f32_nd: np.ndarray[tuple[Any, ...], np.dtype[np.float32]]
-arr_f32_1d: np.ndarray[tuple[int], np.dtype[np.float32]]
+arr_f32_nd: onp.ArrayND[np.float32]
+arr_f32_1d: onp.Array1D[np.float32]
 
 ###
 # NOTE: Keep these tests in sync with the `dok` tests.
@@ -105,13 +106,13 @@ assert_type(csr_matrix((seq_int, (seq_int, seq_int))), csr_matrix[np.int64])
 assert_type(csr_matrix((seq_float, (seq_int, seq_int))), csr_matrix[np.float64])
 assert_type(csr_matrix((seq_complex, (seq_int, seq_int))), csr_matrix[np.complex128])
 # pyrefly: ignore [no-matching-overload]
-csr_matrix((seq_seq_bool, (seq_int, seq_int)))  # type: ignore[arg-type] # pyright: ignore[reportArgumentType, reportCallIssue]
+csr_matrix((seq_seq_bool, (seq_int, seq_int)))  # type: ignore[type-var] # pyright: ignore[reportArgumentType, reportCallIssue]
 # pyrefly: ignore [no-matching-overload]
-csr_matrix((seq_seq_int, (seq_int, seq_int)))  # type: ignore[arg-type] # pyright: ignore[reportArgumentType, reportCallIssue]
+csr_matrix((seq_seq_int, (seq_int, seq_int)))  # type: ignore[type-var] # pyright: ignore[reportArgumentType, reportCallIssue]
 # pyrefly: ignore [no-matching-overload]
-csr_matrix((seq_seq_float, (seq_int, seq_int)))  # type: ignore[arg-type] # pyright: ignore[reportArgumentType, reportCallIssue]
+csr_matrix((seq_seq_float, (seq_int, seq_int)))  # type: ignore[type-var] # pyright: ignore[reportArgumentType, reportCallIssue]
 # pyrefly: ignore [no-matching-overload]
-csr_matrix((seq_seq_complex, (seq_int, seq_int)))  # type: ignore[arg-type] # pyright: ignore[reportArgumentType, reportCallIssue]
+csr_matrix((seq_seq_complex, (seq_int, seq_int)))  # type: ignore[type-var] # pyright: ignore[reportArgumentType, reportCallIssue]
 
 ###
 # CSR-specific tests


### PR DESCRIPTION
This improves constructing `csc_array`, `csr_array`, `csc_matrix`, and `csc_array` instances from value/index tuples on mypy. With (based)pyright this was alreayd working fine, but in certain situations mypy would reject such calls, or infer an incorrect type. By reducing the overlap between `__init__` overloads, this no longer happens, and mypy and pyright will behave in the same (intended) manner.