### PR TITLE
🤖 automatic dprint update workflow

### DIFF
--- a/.github/workflows/update_dprint.yml
+++ b/.github/workflows/update_dprint.yml
@@ -1,0 +1,67 @@
+name: update dprint plugins
+
+on:
+  schedule:
+    # every Monday at 08:00 UTC
+    - cron: "0 8 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  UV_LOCKED: 1
+
+jobs:
+  update:
+    if: github.repository == 'scipy/scipy-stubs'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - uses: astral-sh/setup-uv@v8.0.0
+
+      # this prevents dprint from printing "compiling ..." messages, which would
+      # otherwise be included in the PR body, so we can ignore errors here
+      - name: compile dprint plugins
+        run: uv run --only-group=lint dprint check
+        continue-on-error: true
+
+      - name: dprint config update
+        id: update
+        run: |
+          output=$(uv run --quiet --only-group=lint dprint config update --yes 2>&1)
+          echo "$output"
+          {
+            echo "output<<EOF"
+            echo "$output"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: create pull request
+        uses: peter-evans/create-pull-request@v8.1.0
+        with:
+          branch: github-actions-bot/dprint-config-update-${{ github.ref_name }}
+          commit-message: "update dprint plugins"
+          title: "update dprint plugins"
+          body: |
+            Automated update of [dprint][1] plugins via `dprint config update`.
+
+            ```
+            ${{ steps.update.outputs.output }}
+            ```
+
+            [1]: https://dprint.dev
+          labels: |
+            tool: dprint
+            topic: dependencies
+          delete-branch: true
+          signoff: true
+          sign-commits: true


### PR DESCRIPTION
Dependabot doesn't support dprint, so I wrote this workflow instead. I've already been using it (successfully) in optype for a while now, so it should be fine to use here as well.