### PR TITLE
fftpack: improve return dtypes for real transforms

### DIFF
--- a/scipy-stubs/fftpack/_realtransforms.pyi
+++ b/scipy-stubs/fftpack/_realtransforms.pyi
@@ -1,4 +1,4 @@
-from typing import Literal, SupportsIndex, TypeAlias, overload
+from typing import Any, Literal, SupportsIndex, TypeAlias, TypeVar, overload
 
 import numpy as np
 import optype.numpy as onp
@@ -9,14 +9,63 @@ from scipy.fft._typing import DCTType
 
 __all__ = ["dct", "dctn", "dst", "dstn", "idct", "idctn", "idst", "idstn"]
 
+_DTypeT = TypeVar("_DTypeT", bound=np.dtype[np.float32 | np.float64 | npc.floating80 | npc.complexfloating])
+_ShapeT = TypeVar("_ShapeT", bound=tuple[int, ...])
+
 _NormKind: TypeAlias = Literal["ortho"] | None
 
-_ArrayReal: TypeAlias = onp.ArrayND[np.float32 | np.float64 | np.longdouble]  # no float16
-_ArrayComplex: TypeAlias = onp.ArrayND[npc.complexfloating]
+# workaround for a strange bug in pyright's overlapping overload detection with `numpy<2.1`
+_WorkaroundForPyright: TypeAlias = tuple[int] | tuple[Any, ...]
+
+_FloatND: TypeAlias = onp.ArrayND[np.float32 | np.float64 | np.longdouble, _WorkaroundForPyright]
 
 ###
 
-#
+@overload
+def dctn(
+    x: onp.CanArrayND[npc.integer, _ShapeT],
+    type: DCTType = 2,
+    shape: AnyShape | None = None,
+    axes: AnyShape | None = None,
+    norm: _NormKind = None,
+    overwrite_x: bool = False,
+) -> onp.Array[_ShapeT, np.float64]: ...
+@overload
+def dctn(
+    x: onp.CanArrayND[np.float16, _ShapeT],
+    type: DCTType = 2,
+    shape: AnyShape | None = None,
+    axes: AnyShape | None = None,
+    norm: _NormKind = None,
+    overwrite_x: bool = False,
+) -> onp.Array[_ShapeT, np.float32]: ...
+@overload
+def dctn(
+    x: onp.CanArray[_ShapeT, _DTypeT],
+    type: DCTType = 2,
+    shape: AnyShape | None = None,
+    axes: AnyShape | None = None,
+    norm: _NormKind = None,
+    overwrite_x: bool = False,
+) -> np.ndarray[_ShapeT, _DTypeT]: ...
+@overload
+def dctn(
+    x: onp.SequenceND[float],
+    type: DCTType = 2,
+    shape: AnyShape | None = None,
+    axes: AnyShape | None = None,
+    norm: _NormKind = None,
+    overwrite_x: bool = False,
+) -> onp.ArrayND[np.float64]: ...
+@overload
+def dctn(
+    x: onp.SequenceND[list[complex]] | list[complex],
+    type: DCTType = 2,
+    shape: AnyShape | None = None,
+    axes: AnyShape | None = None,
+    norm: _NormKind = None,
+    overwrite_x: bool = False,
+) -> onp.ArrayND[np.complex128]: ...
 @overload
 def dctn(
     x: onp.ToFloatND,
@@ -25,18 +74,54 @@ def dctn(
     axes: AnyShape | None = None,
     norm: _NormKind = None,
     overwrite_x: bool = False,
-) -> _ArrayReal: ...
+) -> _FloatND: ...
+
+#
 @overload
-def dctn(
-    x: onp.ToComplexND,
+def idctn(
+    x: onp.CanArrayND[npc.integer, _ShapeT],
     type: DCTType = 2,
     shape: AnyShape | None = None,
     axes: AnyShape | None = None,
     norm: _NormKind = None,
     overwrite_x: bool = False,
-) -> _ArrayReal | _ArrayComplex: ...
-
-#
+) -> onp.Array[_ShapeT, np.float64]: ...
+@overload
+def idctn(
+    x: onp.CanArrayND[np.float16, _ShapeT],
+    type: DCTType = 2,
+    shape: AnyShape | None = None,
+    axes: AnyShape | None = None,
+    norm: _NormKind = None,
+    overwrite_x: bool = False,
+) -> onp.Array[_ShapeT, np.float32]: ...
+@overload
+def idctn(
+    x: onp.CanArray[_ShapeT, _DTypeT],
+    type: DCTType = 2,
+    shape: AnyShape | None = None,
+    axes: AnyShape | None = None,
+    norm: _NormKind = None,
+    overwrite_x: bool = False,
+) -> np.ndarray[_ShapeT, _DTypeT]: ...
+@overload
+def idctn(
+    x: onp.SequenceND[float],
+    type: DCTType = 2,
+    shape: AnyShape | None = None,
+    axes: AnyShape | None = None,
+    norm: _NormKind = None,
+    overwrite_x: bool = False,
+) -> onp.ArrayND[np.float64]: ...
+@overload
+def idctn(
+    x: onp.SequenceND[list[complex]] | list[complex],
+    type: DCTType = 2,
+    shape: AnyShape | None = None,
+    axes: AnyShape | None = None,
+    norm: _NormKind = None,
+    overwrite_x: bool = False,
+) -> onp.ArrayND[np.complex128]: ...
 @overload
 def idctn(
     x: onp.ToFloatND,
@@ -45,18 +130,54 @@ def idctn(
     axes: AnyShape | None = None,
     norm: _NormKind = None,
     overwrite_x: bool = False,
-) -> _ArrayReal: ...
+) -> _FloatND: ...
+
+#
 @overload
-def idctn(
-    x: onp.ToComplexND,
+def dstn(
+    x: onp.CanArrayND[npc.integer, _ShapeT],
     type: DCTType = 2,
     shape: AnyShape | None = None,
     axes: AnyShape | None = None,
     norm: _NormKind = None,
     overwrite_x: bool = False,
-) -> _ArrayReal | _ArrayComplex: ...
-
-#
+) -> onp.Array[_ShapeT, np.float64]: ...
+@overload
+def dstn(
+    x: onp.CanArrayND[np.float16, _ShapeT],
+    type: DCTType = 2,
+    shape: AnyShape | None = None,
+    axes: AnyShape | None = None,
+    norm: _NormKind = None,
+    overwrite_x: bool = False,
+) -> onp.Array[_ShapeT, np.float32]: ...
+@overload
+def dstn(
+    x: onp.CanArray[_ShapeT, _DTypeT],
+    type: DCTType = 2,
+    shape: AnyShape | None = None,
+    axes: AnyShape | None = None,
+    norm: _NormKind = None,
+    overwrite_x: bool = False,
+) -> np.ndarray[_ShapeT, _DTypeT]: ...
+@overload
+def dstn(
+    x: onp.SequenceND[float],
+    type: DCTType = 2,
+    shape: AnyShape | None = None,
+    axes: AnyShape | None = None,
+    norm: _NormKind = None,
+    overwrite_x: bool = False,
+) -> onp.ArrayND[np.float64]: ...
+@overload
+def dstn(
+    x: onp.SequenceND[list[complex]] | list[complex],
+    type: DCTType = 2,
+    shape: AnyShape | None = None,
+    axes: AnyShape | None = None,
+    norm: _NormKind = None,
+    overwrite_x: bool = False,
+) -> onp.ArrayND[np.complex128]: ...
 @overload
 def dstn(
     x: onp.ToFloatND,
@@ -65,18 +186,54 @@ def dstn(
     axes: AnyShape | None = None,
     norm: _NormKind = None,
     overwrite_x: bool = False,
-) -> _ArrayReal: ...
+) -> _FloatND: ...
+
+#
 @overload
-def dstn(
-    x: onp.ToComplexND,
+def idstn(
+    x: onp.CanArrayND[npc.integer, _ShapeT],
     type: DCTType = 2,
     shape: AnyShape | None = None,
     axes: AnyShape | None = None,
     norm: _NormKind = None,
     overwrite_x: bool = False,
-) -> _ArrayReal | _ArrayComplex: ...
-
-#
+) -> onp.Array[_ShapeT, np.float64]: ...
+@overload
+def idstn(
+    x: onp.CanArrayND[np.float16, _ShapeT],
+    type: DCTType = 2,
+    shape: AnyShape | None = None,
+    axes: AnyShape | None = None,
+    norm: _NormKind = None,
+    overwrite_x: bool = False,
+) -> onp.Array[_ShapeT, np.float32]: ...
+@overload
+def idstn(
+    x: onp.CanArray[_ShapeT, _DTypeT],
+    type: DCTType = 2,
+    shape: AnyShape | None = None,
+    axes: AnyShape | None = None,
+    norm: _NormKind = None,
+    overwrite_x: bool = False,
+) -> np.ndarray[_ShapeT, _DTypeT]: ...
+@overload
+def idstn(
+    x: onp.SequenceND[float],
+    type: DCTType = 2,
+    shape: AnyShape | None = None,
+    axes: AnyShape | None = None,
+    norm: _NormKind = None,
+    overwrite_x: bool = False,
+) -> onp.ArrayND[np.float64]: ...
+@overload
+def idstn(
+    x: onp.SequenceND[list[complex]] | list[complex],
+    type: DCTType = 2,
+    shape: AnyShape | None = None,
+    axes: AnyShape | None = None,
+    norm: _NormKind = None,
+    overwrite_x: bool = False,
+) -> onp.ArrayND[np.complex128]: ...
 @overload
 def idstn(
     x: onp.ToFloatND,
@@ -85,18 +242,54 @@ def idstn(
     axes: AnyShape | None = None,
     norm: _NormKind = None,
     overwrite_x: bool = False,
-) -> _ArrayReal: ...
-@overload
-def idstn(
-    x: onp.ToComplexND,
-    type: DCTType = 2,
-    shape: AnyShape | None = None,
-    axes: AnyShape | None = None,
-    norm: _NormKind = None,
-    overwrite_x: bool = False,
-) -> _ArrayReal | _ArrayComplex: ...
+) -> _FloatND: ...
 
 #
+@overload
+def dct(
+    x: onp.CanArrayND[npc.integer, _ShapeT],
+    type: DCTType = 2,
+    n: onp.ToInt | None = None,
+    axis: SupportsIndex = -1,
+    norm: _NormKind = None,
+    overwrite_x: bool = False,
+) -> onp.Array[_ShapeT, np.float64]: ...
+@overload
+def dct(
+    x: onp.CanArrayND[np.float16, _ShapeT],
+    type: DCTType = 2,
+    n: onp.ToInt | None = None,
+    axis: SupportsIndex = -1,
+    norm: _NormKind = None,
+    overwrite_x: bool = False,
+) -> onp.Array[_ShapeT, np.float32]: ...
+@overload
+def dct(
+    x: onp.CanArray[_ShapeT, _DTypeT],
+    type: DCTType = 2,
+    n: onp.ToInt | None = None,
+    axis: SupportsIndex = -1,
+    norm: _NormKind = None,
+    overwrite_x: bool = False,
+) -> np.ndarray[_ShapeT, _DTypeT]: ...
+@overload
+def dct(
+    x: onp.SequenceND[float],
+    type: DCTType = 2,
+    n: onp.ToInt | None = None,
+    axis: SupportsIndex = -1,
+    norm: _NormKind = None,
+    overwrite_x: bool = False,
+) -> onp.ArrayND[np.float64]: ...
+@overload
+def dct(
+    x: onp.SequenceND[list[complex]] | list[complex],
+    type: DCTType = 2,
+    n: onp.ToInt | None = None,
+    axis: SupportsIndex = -1,
+    norm: _NormKind = None,
+    overwrite_x: bool = False,
+) -> onp.ArrayND[np.complex128]: ...
 @overload
 def dct(
     x: onp.ToFloatND,
@@ -105,18 +298,54 @@ def dct(
     axis: SupportsIndex = -1,
     norm: _NormKind = None,
     overwrite_x: bool = False,
-) -> _ArrayReal: ...
+) -> _FloatND: ...
+
+#
 @overload
-def dct(
-    x: onp.ToComplexND,
+def idct(
+    x: onp.CanArrayND[npc.integer, _ShapeT],
     type: DCTType = 2,
     n: onp.ToInt | None = None,
     axis: SupportsIndex = -1,
     norm: _NormKind = None,
     overwrite_x: bool = False,
-) -> _ArrayReal | _ArrayComplex: ...
-
-#
+) -> onp.Array[_ShapeT, np.float64]: ...
+@overload
+def idct(
+    x: onp.CanArrayND[np.float16, _ShapeT],
+    type: DCTType = 2,
+    n: onp.ToInt | None = None,
+    axis: SupportsIndex = -1,
+    norm: _NormKind = None,
+    overwrite_x: bool = False,
+) -> onp.Array[_ShapeT, np.float32]: ...
+@overload
+def idct(
+    x: onp.CanArray[_ShapeT, _DTypeT],
+    type: DCTType = 2,
+    n: onp.ToInt | None = None,
+    axis: SupportsIndex = -1,
+    norm: _NormKind = None,
+    overwrite_x: bool = False,
+) -> np.ndarray[_ShapeT, _DTypeT]: ...
+@overload
+def idct(
+    x: onp.SequenceND[float],
+    type: DCTType = 2,
+    n: onp.ToInt | None = None,
+    axis: SupportsIndex = -1,
+    norm: _NormKind = None,
+    overwrite_x: bool = False,
+) -> onp.ArrayND[np.float64]: ...
+@overload
+def idct(
+    x: onp.SequenceND[list[complex]] | list[complex],
+    type: DCTType = 2,
+    n: onp.ToInt | None = None,
+    axis: SupportsIndex = -1,
+    norm: _NormKind = None,
+    overwrite_x: bool = False,
+) -> onp.ArrayND[np.complex128]: ...
 @overload
 def idct(
     x: onp.ToFloatND,
@@ -125,18 +354,54 @@ def idct(
     axis: SupportsIndex = -1,
     norm: _NormKind = None,
     overwrite_x: bool = False,
-) -> _ArrayReal: ...
+) -> _FloatND: ...
+
+#
 @overload
-def idct(
-    x: onp.ToComplexND,
+def dst(
+    x: onp.CanArrayND[npc.integer, _ShapeT],
     type: DCTType = 2,
     n: onp.ToInt | None = None,
     axis: SupportsIndex = -1,
     norm: _NormKind = None,
     overwrite_x: bool = False,
-) -> _ArrayReal | _ArrayComplex: ...
-
-#
+) -> onp.Array[_ShapeT, np.float64]: ...
+@overload
+def dst(
+    x: onp.CanArrayND[np.float16, _ShapeT],
+    type: DCTType = 2,
+    n: onp.ToInt | None = None,
+    axis: SupportsIndex = -1,
+    norm: _NormKind = None,
+    overwrite_x: bool = False,
+) -> onp.Array[_ShapeT, np.float32]: ...
+@overload
+def dst(
+    x: onp.CanArray[_ShapeT, _DTypeT],
+    type: DCTType = 2,
+    n: onp.ToInt | None = None,
+    axis: SupportsIndex = -1,
+    norm: _NormKind = None,
+    overwrite_x: bool = False,
+) -> np.ndarray[_ShapeT, _DTypeT]: ...
+@overload
+def dst(
+    x: onp.SequenceND[float],
+    type: DCTType = 2,
+    n: onp.ToInt | None = None,
+    axis: SupportsIndex = -1,
+    norm: _NormKind = None,
+    overwrite_x: bool = False,
+) -> onp.ArrayND[np.float64]: ...
+@overload
+def dst(
+    x: onp.SequenceND[list[complex]] | list[complex],
+    type: DCTType = 2,
+    n: onp.ToInt | None = None,
+    axis: SupportsIndex = -1,
+    norm: _NormKind = None,
+    overwrite_x: bool = False,
+) -> onp.ArrayND[np.complex128]: ...
 @overload
 def dst(
     x: onp.ToFloatND,
@@ -145,18 +410,54 @@ def dst(
     axis: SupportsIndex = -1,
     norm: _NormKind = None,
     overwrite_x: bool = False,
-) -> _ArrayReal: ...
+) -> _FloatND: ...
+
+#
 @overload
-def dst(
-    x: onp.ToComplexND,
+def idst(
+    x: onp.CanArrayND[npc.integer, _ShapeT],
     type: DCTType = 2,
     n: onp.ToInt | None = None,
     axis: SupportsIndex = -1,
     norm: _NormKind = None,
     overwrite_x: bool = False,
-) -> _ArrayReal | _ArrayComplex: ...
-
-#
+) -> onp.Array[_ShapeT, np.float64]: ...
+@overload
+def idst(
+    x: onp.CanArrayND[np.float16, _ShapeT],
+    type: DCTType = 2,
+    n: onp.ToInt | None = None,
+    axis: SupportsIndex = -1,
+    norm: _NormKind = None,
+    overwrite_x: bool = False,
+) -> onp.Array[_ShapeT, np.float32]: ...
+@overload
+def idst(
+    x: onp.CanArray[_ShapeT, _DTypeT],
+    type: DCTType = 2,
+    n: onp.ToInt | None = None,
+    axis: SupportsIndex = -1,
+    norm: _NormKind = None,
+    overwrite_x: bool = False,
+) -> np.ndarray[_ShapeT, _DTypeT]: ...
+@overload
+def idst(
+    x: onp.SequenceND[float],
+    type: DCTType = 2,
+    n: onp.ToInt | None = None,
+    axis: SupportsIndex = -1,
+    norm: _NormKind = None,
+    overwrite_x: bool = False,
+) -> onp.ArrayND[np.float64]: ...
+@overload
+def idst(
+    x: onp.SequenceND[list[complex]] | list[complex],
+    type: DCTType = 2,
+    n: onp.ToInt | None = None,
+    axis: SupportsIndex = -1,
+    norm: _NormKind = None,
+    overwrite_x: bool = False,
+) -> onp.ArrayND[np.complex128]: ...
 @overload
 def idst(
     x: onp.ToFloatND,
@@ -165,13 +466,4 @@ def idst(
     axis: SupportsIndex = -1,
     norm: _NormKind = None,
     overwrite_x: bool = False,
-) -> _ArrayReal: ...
-@overload
-def idst(
-    x: onp.ToComplexND,
-    type: DCTType = 2,
-    n: onp.ToInt | None = None,
-    axis: SupportsIndex = -1,
-    norm: _NormKind = None,
-    overwrite_x: bool = False,
-) -> _ArrayReal | _ArrayComplex: ...
+) -> _FloatND: ...


### PR DESCRIPTION
Improves return dtypes for scipy.fftpack real transforms (dct, idct, dst, idst, dctn, idctn, dstn, idstn) to match the overload pattern in [scipy.fft._realtransforms](https://github.com/scipy/scipy-stubs/blob/master/scipy-stubs/fft/_realtransforms.pyi).

Closes #1489