### PR TITLE
⚰️ remove some commented out code

### DIFF
--- a/scripts/scipy_usage.py
+++ b/scripts/scipy_usage.py
@@ -175,14 +175,6 @@ def parse_scipy_usage(file_path: Path) -> tuple[set[str], set[str]]:
     calls = {name for name in visitor.calls if not is_scipy_module(name)}
     modules = {name for name in visitor.imports if is_scipy_module(name)}
 
-    # for call_name in calls:
-    #     parts = call_name.split(".")
-
-    #     for i in range(1, len(parts)):
-    #         module = ".".join(parts[: i + 1])
-    #         if is_scipy_module(module):
-    #             modules.add(module)
-
     return calls, modules
 
 

--- a/scripts/scipy_usage.py
+++ b/scripts/scipy_usage.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# ruff: noqa: PLR6301, ERA001
+# ruff: noqa: PLR6301
 
 import argparse
 import ast


### PR DESCRIPTION
To fix this, remove the commented-out code block in `scripts/scipy_usage.py` inside `parse_scipy_usage` (lines 178–185 in the snippet). This preserves existing behavior, improves readability, and resolves the CodeQL finding without changing functionality.

Best fix approach:
- Keep the active logic that computes `calls` and `modules`.
- Delete the entire commented loop block.
- Leave `return calls, modules` immediately after the `modules` assignment.

No imports, methods, or new definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._