### PR TITLE
🏷️ optimize: add vector-valued approx_fprime overload

### DIFF
--- a/scipy-stubs/optimize/_optimize.pyi
+++ b/scipy-stubs/optimize/_optimize.pyi
@@ -642,7 +642,14 @@ def show_options(solver: Solver | None, method: MethodAll | None, disp: onp.ToFa
 def show_options(solver: Solver | None = None, method: MethodAll | None = None, *, disp: onp.ToFalse) -> str: ...
 
 #
-def approx_fprime(xk: onp.ToFloat1D, f: _Fn1_1d, epsilon: onp.ToFloat | _FloatingCoND = ..., *args: object) -> _Float1D: ...
+@overload
+def approx_fprime(
+    xk: onp.ToFloat1D, f: _Fn1_1d[_Float], epsilon: onp.ToFloat | _FloatingCoND = ..., *args: object
+) -> _Float1D: ...
+@overload
+def approx_fprime(
+    xk: onp.ToFloat1D, f: _Fn1_1d[_Float1D], epsilon: onp.ToFloat | _FloatingCoND = ..., *args: object
+) -> _Float2D: ...
 
 #
 def check_grad(

--- a/tests/optimize/test__optimize.pyi
+++ b/tests/optimize/test__optimize.pyi
@@ -35,6 +35,7 @@ _x0: list[float]
 _arr_1d: _Float1D
 
 def _f(x: _Float1D, /) -> float: ...
+def _f_vec(x: _Float1D, /) -> _Float1D: ...
 def _f0d(x: float, /) -> float: ...
 def _fprime(x: _Float1D, /) -> _Float1D: ...
 
@@ -50,6 +51,7 @@ assert_type(rosen_hess_prod([1.0, 2.0, 3.0], [1.0, 0.0, 0.0]), _Float1D)
 # approx_fprime
 
 assert_type(approx_fprime([1.0, 2.0], _f, 1e-8), _Float1D)
+assert_type(approx_fprime([1.0, 2.0], _f_vec, 1e-8), _Float2D)
 
 ###
 # check_grad


### PR DESCRIPTION
## Summary

- Fixes #1525.

- Add `approx_fprime` overloads for:
  - scalar-valued callables returning a 1-D gradient
  - 1-D vector-valued callables returning a 2-D Jacobian

<details>

<summary>Python snippet showing the two behaviors with a scalar function from $R^2 \to R$ and a vector-valued function from $R^3 \to R^2$</summary>

```python
import numpy as np
import numpy.typing as npt
from scipy.optimize import approx_fprime


def scalar_func(x: npt.NDArray[np.float64], c0: float, c1: float) -> float:
    "Scalar-valued function: R^2 -> R."
    return c0 * x[0] ** 2 + c1 * x[1] ** 2


def vector_func(
    x: npt.NDArray[np.float64], c0: float, c1: float
) -> npt.NDArray[np.float64]:
    "Vector-valued function: R^2 -> R^3."
    return np.array([c0 * x[0] ** 2, c1 * x[1] ** 2, x[0] + x[1]], dtype=np.float64)


x = np.ones(2)
c0, c1 = (1, 200)
eps = np.sqrt(np.finfo(float).eps)
scalar_gradient = approx_fprime(x, scalar_func, eps, c0, c1)

epsilon = np.array([eps, np.sqrt(200) * eps], dtype=np.float64)
vector_jacobian = approx_fprime(x, vector_func, epsilon, c0, c1)

print("scalar-valued callable R^n -> R:", scalar_gradient, scalar_gradient.shape)
print("vector-valued callable R^n -> R^m:", vector_jacobian, vector_jacobian.shape)

```

</details>

### Note

This is my first PR to [scipy-stubs](https://github.com/scipy/scipy-stubs)