### PR TITLE
🐛 `optimize`: generalize `newton` overloads to ND arrays

### DIFF
--- a/scipy-stubs/optimize/_zeros_py.pyi
+++ b/scipy-stubs/optimize/_zeros_py.pyi
@@ -20,10 +20,9 @@ _T = TypeVar("_T")
 _KT = TypeVar("_KT", bound=_FlagKey)
 _RT = TypeVar("_RT", bound=_Floating)
 _RT_co = TypeVar("_RT_co", bound=_Floating, default=_Float, covariant=True)
-_ToFloatT = TypeVar("_ToFloatT", bound=onp.ToFloat | onp.ToFloatND, default=onp.ToFloat)
-
+_ShapeT = TypeVar("_ShapeT", bound=tuple[int, ...])
 _Fun0D: TypeAlias = Callable[Concatenate[float, ...], onp.ToFloat] | Callable[Concatenate[np.float64, ...], onp.ToFloat]
-_Fun1D: TypeAlias = Callable[Concatenate[onp.Array1D[np.float64], ...], _ToFloatT]
+_FunND: TypeAlias = Callable[Concatenate[onp.Array[_ShapeT, np.float64], ...], onp.Array[_ShapeT, np.float64]]
 
 _State: TypeAlias = tuple[_FlagKey, _Float]
 _Bracket: TypeAlias = tuple[_Float, _Float]
@@ -136,33 +135,33 @@ def newton(
 ) -> tuple[_Float, RootResults[_Float]]: ...
 @overload
 def newton(
-    func: _Fun1D,
-    x0: onp.ToFloat1D,
-    fprime: _Fun1D[onp.ToFloat1D] | None = None,
+    func: _FunND[_ShapeT],
+    x0: onp.Array[_ShapeT, np.float64],
+    fprime: _FunND[_ShapeT] | None = None,
     args: tuple[object, ...] = (),
     tol: onp.ToFloat = 1.48e-08,
     maxiter: onp.ToJustInt = 50,
-    fprime2: _Fun1D[onp.ToFloat2D] | None = None,
-    x1: onp.ToFloat1D | None = None,
+    fprime2: _FunND[_ShapeT] | None = None,
+    x1: onp.Array[_ShapeT, np.float64] | None = None,
     rtol: onp.ToFloat = 0.0,
     full_output: onp.ToFalse = False,
     disp: bool = True,
-) -> onp.Array1D[np.float64]: ...
+) -> onp.Array[_ShapeT, np.float64]: ...
 @overload
 def newton(
-    func: _Fun1D,
-    x0: onp.ToFloat1D,
-    fprime: _Fun1D[onp.ToFloat1D] | None = None,
+    func: _FunND[_ShapeT],
+    x0: onp.Array[_ShapeT, np.float64],
+    fprime: _FunND[_ShapeT] | None = None,
     args: tuple[object, ...] = (),
     tol: onp.ToFloat = 1.48e-08,
     maxiter: onp.ToJustInt = 50,
-    fprime2: _Fun1D[onp.ToFloat2D] | None = None,
-    x1: onp.ToFloat1D | None = None,
+    fprime2: _FunND[_ShapeT] | None = None,
+    x1: onp.Array[_ShapeT, np.float64] | None = None,
     rtol: onp.ToFloat = 0.0,
     *,
     full_output: onp.ToTrue,
     disp: bool = True,
-) -> tuple[onp.Array1D[np.float64], onp.Array1D[np.bool_], onp.Array1D[np.bool_]]: ...
+) -> tuple[onp.Array[_ShapeT, np.float64], onp.Array[_ShapeT, np.bool_], onp.Array[_ShapeT, np.bool_]]: ...
 
 #
 @overload

--- a/tests/optimize/test_zeros_py.pyi
+++ b/tests/optimize/test_zeros_py.pyi
@@ -9,11 +9,13 @@ _Float: TypeAlias = float | np.float64
 _RR: TypeAlias = RootResults[float | np.float64]
 
 def f(x: float) -> float: ...
-def g(x: onp.Array1D[np.float64]) -> float: ...
+def g(x: onp.Array1D[np.float64]) -> onp.Array1D[np.float64]: ...
+def g2(x: onp.Array2D[np.float64]) -> onp.Array2D[np.float64]: ...
 def h(x: float) -> tuple[float, float]: ...
 def k(x: float) -> tuple[float, float, float]: ...
 
 arr_1d: onp.Array1D[np.float64]
+arr_2d: onp.Array2D[np.float64]
 
 # bisect
 assert_type(bisect(f, 0.0, 1.0), float)
@@ -40,6 +42,8 @@ assert_type(newton(f, 0.5), _Float)
 assert_type(newton(f, 0.5, full_output=True), tuple[_Float, RootResults[_Float]])
 assert_type(newton(g, arr_1d), onp.Array1D[np.float64])
 assert_type(newton(g, arr_1d, full_output=True), tuple[onp.Array1D[np.float64], onp.Array1D[np.bool_], onp.Array1D[np.bool_]])
+assert_type(newton(g2, arr_2d), onp.Array2D[np.float64])
+assert_type(newton(g2, arr_2d, full_output=True), tuple[onp.Array2D[np.float64], onp.Array2D[np.bool_], onp.Array2D[np.bool_]])
 
 # root_scalar
 assert_type(root_scalar(f, bracket=(0.0, 1.0)), RootResults[float])


### PR DESCRIPTION
- Fixes https://github.com/scipy/scipy-stubs/issues/1518

- Update `optimize.newton` to preserve ND array shapes in its array overloads instead of just 1D inputs.

<details>

<summary>Python snippet with the different cases for `optimize.newton`</summary>

```python
import numpy as np
from numpy.typing import NDArray

from scipy.optimize import RootResults, newton


def scalar_func(x: float) -> float:
    return x * x - 2.0


def scalar_func_with_derivative(x: float) -> float:
    return x * x - 2.0


def scalar_derivative(x: float) -> float:
    return 2.0 * x


x0 = 1.0
scalar_root = newton(scalar_func, x0=x0)
scalar_root_full = newton(scalar_func, x0=x0, full_output=True)

print(scalar_root)
print(scalar_root_full)

def vector_func_1d(x: NDArray[np.float64]) -> NDArray[np.float64]:
    return -2.0 * x + 1.0


def vector_derivative_1d(x: NDArray[np.float64]) -> NDArray[np.float64]:
    return np.full_like(x, -2.0)


x0 = np.zeros(3, dtype=float)
vector_root_1d = newton(vector_func_1d, x0=x0)
vector_root_1d_full = newton(vector_func_1d, x0=x0, full_output=True)

print(vector_root_1d)
print(vector_root_1d_full)


def vector_func_2d(x: NDArray[np.float64]) -> NDArray[np.float64]:
    return -2.0 * x + 1.0


def vector_derivative_2d(x: NDArray[np.float64]) -> NDArray[np.float64]:
    return np.full_like(x, -2.0)


x0 = np.zeros((2, 4), dtype=float)
vector_root_2d = newton(vector_func_2d, x0=x0)
vector_root_2d_full = newton(vector_func_2d, x0=x0, full_output=True)

print(vector_root_2d)
print(vector_root_2d_full)
```

</details>