### PR TITLE
🔒️ disable uv cache in release workflow

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: astral-sh/setup-uv@v8.0.0
         with:
           python-version: "3.14"
+          enable-cache: false
 
       - name: uv build
         run: uv build


### PR DESCRIPTION
this prevents a potential cache-poisoning scenario:
https://docs.zizmor.sh/audits/#cache-poisoning