### PR TITLE
✅ signal: add tests for gauss_spline, spline_filter, qspline1d, qspline1d_eval, qspline2d, symiirorder1, symiirorder2

### DIFF
--- a/tests/signal/test_spline_filters.pyi
+++ b/tests/signal/test_spline_filters.pyi
@@ -1,22 +1,29 @@
 # type-tests for `signal/_spline_filters.pyi`
 
-from typing import TypeAlias, assert_type
+from typing import Any, TypeAlias, assert_type
 
 import numpy as np
 import optype.numpy as onp
 import optype.numpy.compat as npc
 
-from scipy.signal import cspline1d, cspline1d_eval, cspline2d
-from scipy.signal._spline_filters import _FloatQ
+from scipy.signal import cspline1d, cspline1d_eval, cspline2d, gauss_spline
+from scipy.signal._spline_filters import _ComplexQ, _FloatQ
 
 ###
 
 _F64_1D: TypeAlias = onp.Array1D[np.float64]
 _F64_2D: TypeAlias = onp.Array2D[np.float64]
 _FQ_1D: TypeAlias = onp.Array1D[_FloatQ]
+_FQ_2D: TypeAlias = onp.Array2D[_FloatQ]
+_FQ_3D: TypeAlias = onp.Array3D[_FloatQ]
+_FQ_ND: TypeAlias = onp.ArrayND[_FloatQ, tuple[int] | tuple[Any, ...]]
 _F80_1D: TypeAlias = onp.Array1D[npc.floating80]
 _C128_1D: TypeAlias = onp.Array1D[np.complex128]
 _C128_2D: TypeAlias = onp.Array2D[np.complex128]
+_CQ_1D: TypeAlias = onp.Array1D[_ComplexQ]
+_CQ_2D: TypeAlias = onp.Array2D[_ComplexQ]
+_CQ_3D: TypeAlias = onp.Array3D[_ComplexQ]
+_CQ_ND: TypeAlias = onp.ArrayND[_ComplexQ]
 _C160_1D: TypeAlias = onp.Array1D[npc.complexfloating160]
 
 ###
@@ -29,6 +36,15 @@ _c160_1d: _C160_1D
 
 _f64_2d: _F64_2D
 _c128_2d: _C128_2D
+_n: onp.ToFloat
+_py_f_1d: list[float]
+_py_f_2d: list[list[float]]
+_py_f_3d: list[list[list[float]]]
+_py_c_1d: list[complex]
+_py_c_2d: list[list[complex]]
+_py_c_3d: list[list[list[complex]]]
+_f_nd_like: onp.ToFloatND
+_c_nd_like: onp.ToJustComplexND
 
 ###
 
@@ -55,3 +71,21 @@ assert_type(cspline2d(_f64_1d), _F64_1D)
 assert_type(cspline2d(_f64_2d), _F64_1D)
 assert_type(cspline2d(_c128_1d), _C128_1D)
 assert_type(cspline2d(_c128_2d), _C128_1D)
+
+# gauss_spline
+
+assert_type(gauss_spline(_i64_1d, _n), _F64_1D)
+assert_type(gauss_spline(_f64_1d, _n), _F64_1D)
+assert_type(gauss_spline(_f80_1d, _n), _F80_1D)
+assert_type(gauss_spline(_f64_2d, _n), _F64_2D)
+assert_type(gauss_spline(_c128_1d, _n), _C128_1D)
+assert_type(gauss_spline(_c128_2d, _n), _C128_2D)
+assert_type(gauss_spline(_c160_1d, _n), _C160_1D)
+assert_type(gauss_spline(_py_f_1d, _n), _FQ_1D)
+assert_type(gauss_spline(_py_f_2d, _n), _FQ_2D)
+assert_type(gauss_spline(_py_f_3d, _n), _FQ_3D)
+assert_type(gauss_spline(_f_nd_like, _n), _FQ_ND)
+assert_type(gauss_spline(_py_c_1d, _n), _CQ_1D)
+assert_type(gauss_spline(_py_c_2d, _n), _CQ_2D)
+assert_type(gauss_spline(_py_c_3d, _n), _CQ_3D)
+assert_type(gauss_spline(_c_nd_like, _n), _CQ_ND)

--- a/tests/signal/test_spline_filters.pyi
+++ b/tests/signal/test_spline_filters.pyi
@@ -18,7 +18,6 @@ from scipy.signal import (
     symiirorder1,
     symiirorder2,
 )
-from scipy.signal._spline_filters import _ComplexQ, _FloatQ
 
 ###
 
@@ -26,19 +25,19 @@ _F64_1D: TypeAlias = onp.Array1D[np.float64]
 _F64_2D: TypeAlias = onp.Array2D[np.float64]
 _F32_1D: TypeAlias = onp.Array1D[np.float32]
 _F32_2D: TypeAlias = onp.Array2D[np.float32]
-_FQ_1D: TypeAlias = onp.Array1D[_FloatQ]
-_FQ_2D: TypeAlias = onp.Array2D[_FloatQ]
-_FQ_3D: TypeAlias = onp.Array3D[_FloatQ]
-_FQ_ND: TypeAlias = onp.ArrayND[_FloatQ, tuple[int] | tuple[Any, ...]]
+_FQ_1D: TypeAlias = onp.Array1D[np.float64 | np.longdouble]
+_FQ_2D: TypeAlias = onp.Array2D[np.float64 | np.longdouble]
+_FQ_3D: TypeAlias = onp.Array3D[np.float64 | np.longdouble]
+_FQ_ND: TypeAlias = onp.ArrayND[np.float64 | np.longdouble, tuple[int] | tuple[Any, ...]]
 _F80_1D: TypeAlias = onp.Array1D[npc.floating80]
 _C64_1D: TypeAlias = onp.Array1D[np.complex64]
 _C64_2D: TypeAlias = onp.Array2D[np.complex64]
 _C128_1D: TypeAlias = onp.Array1D[np.complex128]
 _C128_2D: TypeAlias = onp.Array2D[np.complex128]
-_CQ_1D: TypeAlias = onp.Array1D[_ComplexQ]
-_CQ_2D: TypeAlias = onp.Array2D[_ComplexQ]
-_CQ_3D: TypeAlias = onp.Array3D[_ComplexQ]
-_CQ_ND: TypeAlias = onp.ArrayND[_ComplexQ]
+_CQ_1D: TypeAlias = onp.Array1D[np.complex128 | np.clongdouble]
+_CQ_2D: TypeAlias = onp.Array2D[np.complex128 | np.clongdouble]
+_CQ_3D: TypeAlias = onp.Array3D[np.complex128 | np.clongdouble]
+_CQ_ND: TypeAlias = onp.ArrayND[np.complex128 | np.clongdouble]
 _C160_1D: TypeAlias = onp.Array1D[npc.complexfloating160]
 
 ###

--- a/tests/signal/test_spline_filters.pyi
+++ b/tests/signal/test_spline_filters.pyi
@@ -11,7 +11,12 @@ from scipy.signal import (
     cspline1d_eval,
     cspline2d,
     gauss_spline,
+    qspline1d,
+    qspline1d_eval,
+    qspline2d,
     spline_filter,
+    symiirorder1,
+    symiirorder2,
 )
 from scipy.signal._spline_filters import _ComplexQ, _FloatQ
 
@@ -19,12 +24,15 @@ from scipy.signal._spline_filters import _ComplexQ, _FloatQ
 
 _F64_1D: TypeAlias = onp.Array1D[np.float64]
 _F64_2D: TypeAlias = onp.Array2D[np.float64]
+_F32_1D: TypeAlias = onp.Array1D[np.float32]
 _F32_2D: TypeAlias = onp.Array2D[np.float32]
 _FQ_1D: TypeAlias = onp.Array1D[_FloatQ]
 _FQ_2D: TypeAlias = onp.Array2D[_FloatQ]
 _FQ_3D: TypeAlias = onp.Array3D[_FloatQ]
 _FQ_ND: TypeAlias = onp.ArrayND[_FloatQ, tuple[int] | tuple[Any, ...]]
 _F80_1D: TypeAlias = onp.Array1D[npc.floating80]
+_C64_1D: TypeAlias = onp.Array1D[np.complex64]
+_C64_2D: TypeAlias = onp.Array2D[np.complex64]
 _C128_1D: TypeAlias = onp.Array1D[np.complex128]
 _C128_2D: TypeAlias = onp.Array2D[np.complex128]
 _CQ_1D: TypeAlias = onp.Array1D[_ComplexQ]
@@ -38,6 +46,8 @@ _C160_1D: TypeAlias = onp.Array1D[npc.complexfloating160]
 _i64_1d: onp.Array1D[np.int64]
 _f32_1d: onp.Array1D[np.float32]
 _f32_2d: onp.Array2D[np.float32]
+_c64_1d: _C64_1D
+_c64_2d: _C64_2D
 _f64_1d: _F64_1D
 _f80_1d: _F80_1D
 _c128_1d: _C128_1D
@@ -46,6 +56,7 @@ _c160_1d: _C160_1D
 _f64_2d: _F64_2D
 _c128_2d: _C128_2D
 _n: onp.ToFloat
+_c: onp.ToComplex
 _py_f_1d: list[float]
 _py_f_2d: list[list[float]]
 _py_f_3d: list[list[list[float]]]
@@ -105,3 +116,48 @@ assert_type(spline_filter(_f32_1d, _n), _F32_2D)
 assert_type(spline_filter(_f32_2d, _n), _F32_2D)
 assert_type(spline_filter(_f64_1d, _n), _F64_2D)
 assert_type(spline_filter(_f64_2d, _n), _F64_2D)
+
+# qspline1d
+
+assert_type(qspline1d(_i64_1d, _n), _FQ_1D)
+assert_type(qspline1d(_f64_1d, _n), _F64_1D)
+assert_type(qspline1d(_f80_1d, _n), _F80_1D)
+assert_type(qspline1d(_c128_1d, _n), _C128_1D)
+assert_type(qspline1d(_c160_1d, _n), _C160_1D)
+assert_type(qspline1d(_py_f_1d, _n), _FQ_1D)
+assert_type(qspline1d(_py_c_1d, _n), _CQ_1D)
+assert_type(qspline1d(_f_nd_like, _n), _FQ_1D)
+assert_type(qspline1d(_c_nd_like, _n), _CQ_1D)
+assert_type(qspline1d(_f32_2d, _n), _FQ_1D)
+assert_type(qspline1d(_c64_2d, _n), _CQ_1D)
+
+# qspline1d_eval
+
+assert_type(qspline1d_eval(_f64_1d, _i64_1d), _F64_1D)
+assert_type(qspline1d_eval(_f64_1d, _f64_1d), _F64_1D)
+assert_type(qspline1d_eval(_f80_1d, _f64_1d), _F80_1D)
+assert_type(qspline1d_eval(_c128_1d, _f64_1d), _C128_1D)
+assert_type(qspline1d_eval(_c160_1d, _f64_1d), _C160_1D)
+
+# qspline2d
+
+assert_type(qspline2d(_i64_1d, _n), _F64_1D)
+assert_type(qspline2d(_f64_1d, _n), _F64_1D)
+assert_type(qspline2d(_f64_2d, _n), _F64_1D)
+assert_type(qspline2d(_c128_1d, _n), _C128_1D)
+assert_type(qspline2d(_c128_2d, _n), _C128_1D)
+assert_type(qspline2d(_py_f_2d, _n), _F64_1D)
+assert_type(qspline2d(_py_c_2d, _n), _C128_1D)
+
+# symiirorder1
+
+assert_type(symiirorder1(_f32_1d, _c, _c, _n), _F32_1D)
+assert_type(symiirorder1(_f64_1d, _c, _c, _n), _F64_1D)
+assert_type(symiirorder1(_c64_2d, _c, _c, _n), _C64_2D)
+assert_type(symiirorder1(_c128_1d, _c, _c, _n), _C128_1D)
+
+# symiirorder2
+
+assert_type(symiirorder2(_f32_2d, _n, _n, _n), _F32_2D)
+assert_type(symiirorder2(_f64_1d, _n, _n, _n), _F64_1D)
+assert_type(symiirorder2(_f64_2d, _n, _n, _n), _F64_2D)

--- a/tests/signal/test_spline_filters.pyi
+++ b/tests/signal/test_spline_filters.pyi
@@ -6,13 +6,20 @@ import numpy as np
 import optype.numpy as onp
 import optype.numpy.compat as npc
 
-from scipy.signal import cspline1d, cspline1d_eval, cspline2d, gauss_spline
+from scipy.signal import (
+    cspline1d,
+    cspline1d_eval,
+    cspline2d,
+    gauss_spline,
+    spline_filter,
+)
 from scipy.signal._spline_filters import _ComplexQ, _FloatQ
 
 ###
 
 _F64_1D: TypeAlias = onp.Array1D[np.float64]
 _F64_2D: TypeAlias = onp.Array2D[np.float64]
+_F32_2D: TypeAlias = onp.Array2D[np.float32]
 _FQ_1D: TypeAlias = onp.Array1D[_FloatQ]
 _FQ_2D: TypeAlias = onp.Array2D[_FloatQ]
 _FQ_3D: TypeAlias = onp.Array3D[_FloatQ]
@@ -29,6 +36,8 @@ _C160_1D: TypeAlias = onp.Array1D[npc.complexfloating160]
 ###
 
 _i64_1d: onp.Array1D[np.int64]
+_f32_1d: onp.Array1D[np.float32]
+_f32_2d: onp.Array2D[np.float32]
 _f64_1d: _F64_1D
 _f80_1d: _F80_1D
 _c128_1d: _C128_1D
@@ -89,3 +98,10 @@ assert_type(gauss_spline(_py_c_1d, _n), _CQ_1D)
 assert_type(gauss_spline(_py_c_2d, _n), _CQ_2D)
 assert_type(gauss_spline(_py_c_3d, _n), _CQ_3D)
 assert_type(gauss_spline(_c_nd_like, _n), _CQ_ND)
+
+# spline_filter
+
+assert_type(spline_filter(_f32_1d, _n), _F32_2D)
+assert_type(spline_filter(_f32_2d, _n), _F32_2D)
+assert_type(spline_filter(_f64_1d, _n), _F64_2D)
+assert_type(spline_filter(_f64_2d, _n), _F64_2D)


### PR DESCRIPTION
Towards https://github.com/scipy/scipy-stubs/issues/1099

Covers: 

- `gauss_spline `
- `spline_filter`
- `qspline1d`
- `qspline1d_eval`
- `qspline2d`
- `symiirorder1`
- `symiirorder2`