### PR TITLE
✅ `signal`: add tests for `get_window`, `place_poles`, `sepfir2d`

### DIFF
--- a/tests/signal/test_ltisys.pyi
+++ b/tests/signal/test_ltisys.pyi
@@ -20,9 +20,11 @@ from scipy.signal import (
     impulse,
     lsim,
     lti,
+    place_poles,
     step,
 )
 from scipy.signal._ltisys import (
+    Bunch,
     StateSpaceContinuous,
     StateSpaceDiscrete,
     TransferFunctionContinuous,
@@ -53,6 +55,7 @@ _c64_1d: _VecC64
 _c64_2d: onp.Array2D[np.complex64]
 _c128_1d: _VecC128
 _c128_2d: onp.Array2D[np.complex128]
+_i64_1d: onp.Array1D[np.int64]
 
 _lti_f32: lti[np.float32]
 _lti_f64: lti[np.float64]
@@ -274,6 +277,18 @@ assert_type(_lti_f32.freqresp(), tuple[_VecF32, _VecC64])
 assert_type(_lti_c64.freqresp(), tuple[_VecF32, _VecC64])
 assert_type(_lti_f64.freqresp(), tuple[_VecF64, _VecC128])
 assert_type(_lti_c128.freqresp(), tuple[_VecF64, _VecC128])
+
+###
+# place_poles
+
+place_poles_result = place_poles(_f64_2d, _f64_2d, _i64_1d)
+assert_type(place_poles_result, Bunch)
+assert_type(place_poles_result.gain_matrix, _MatF64)
+assert_type(place_poles_result.computed_poles, _VecF64)
+assert_type(place_poles_result.requested_poles, _VecF64)
+assert_type(place_poles_result.X, onp.Array2D[np.complex128])
+assert_type(place_poles_result.rtol, float)
+assert_type(place_poles_result.nb_iter, int)
 
 ###
 # dlsim

--- a/tests/signal/test_spline.pyi
+++ b/tests/signal/test_spline.pyi
@@ -1,0 +1,25 @@
+# type-tests for `signal/_spline.pyi`
+
+from typing import assert_type
+
+import numpy as np
+import optype.numpy as onp
+
+from scipy.signal import sepfir2d
+
+###
+
+_f32_2d: onp.Array2D[np.float32]
+_f64_2d: onp.Array2D[np.float64]
+_c64_2d: onp.Array2D[np.complex64]
+_c128_2d: onp.Array2D[np.complex128]
+_inexact_2d: onp.Array2D[np.float64 | np.complex128]
+
+###
+
+# sepfir2d
+assert_type(sepfir2d(_f32_2d, _f32_2d, _f32_2d), onp.ArrayND[np.float32 | np.float64])
+assert_type(sepfir2d(_f64_2d, _f64_2d, _f64_2d), onp.ArrayND[np.float32 | np.float64])
+assert_type(sepfir2d(_c64_2d, _c64_2d, _c64_2d), onp.ArrayND[np.complex64 | np.complex128])
+assert_type(sepfir2d(_c128_2d, _c128_2d, _c128_2d), onp.ArrayND[np.complex64 | np.complex128])
+assert_type(sepfir2d(_inexact_2d, _inexact_2d, _inexact_2d), onp.ArrayND[np.float32 | np.float64 | np.complex64 | np.complex128])

--- a/tests/signal/windows/test_windows.pyi
+++ b/tests/signal/windows/test_windows.pyi
@@ -1,8 +1,11 @@
+# type-tests for `signal/windows/_windows.pyi`
+
 from typing import Any, assert_type
 
 import numpy as np
 import optype.numpy as onp
 
+from scipy.signal import get_window as signal_get_window
 from scipy.signal.windows import (
     barthann,
     bartlett,
@@ -35,7 +38,23 @@ from scipy.signal.windows import (
 ###
 
 # get_window
+assert_type(signal_get_window("hann", 64), onp.Array1D[np.float64])
+assert_type(signal_get_window(4.0, 64), onp.Array1D[np.float64])
+assert_type(signal_get_window(("hann",), 64), onp.Array1D[np.float64])
+assert_type(signal_get_window(("kaiser", 4.0), 64), onp.Array1D[np.float64])
+assert_type(signal_get_window(("gaussian", 3.0), 64), onp.Array1D[np.float64])
+assert_type(signal_get_window(("general_gaussian", 1.5, 3.0), 64), onp.Array1D[np.float64])
+assert_type(signal_get_window(("dpss", 2, 4, True), 64), onp.Array1D[np.float64])
+assert_type(signal_get_window("hann", 64, fftbins=False), onp.Array1D[np.float64])
+assert_type(signal_get_window("hann", 64, xp=np), Any)
 assert_type(get_window("hann", 64), onp.Array1D[np.float64])
+assert_type(get_window(4.0, 64), onp.Array1D[np.float64])
+assert_type(get_window(("hann",), 64), onp.Array1D[np.float64])
+assert_type(get_window(("kaiser", 4.0), 64), onp.Array1D[np.float64])
+assert_type(get_window(("gaussian", 3.0), 64), onp.Array1D[np.float64])
+assert_type(get_window(("general_gaussian", 1.5, 3.0), 64), onp.Array1D[np.float64])
+assert_type(get_window(("dpss", 2, 4, True), 64), onp.Array1D[np.float64])
+assert_type(get_window("hann", 64, fftbins=False), onp.Array1D[np.float64])
 assert_type(get_window("hann", 64, xp=np), Any)
 
 # barthann


### PR DESCRIPTION
Towards https://github.com/scipy/scipy-stubs/issues/1099

Covers: 

- `get_window`
- `place_poles`
- `sepfir2d`