### PR TITLE
🦖 `signal`: improve type-checker compatibility of LTI class constructors

### DIFF
--- a/scipy-stubs/signal/_ltisys.pyi
+++ b/scipy-stubs/signal/_ltisys.pyi
@@ -1,7 +1,6 @@
-# mypy: disable-error-code="explicit-override"
 import abc
 import types
-from typing import Any, ClassVar, Final, Generic, Literal, Never, Self, TypeAlias, final, overload, type_check_only
+from typing import Any, ClassVar, Final, Generic, Literal, Self, TypeAlias, final, overload, type_check_only
 from typing_extensions import TypeVar, override
 
 import numpy as np
@@ -109,7 +108,7 @@ class LinearTimeInvariant(Generic[_ZerosT_co, _PolesT_co, _DTT_co]):
     def __class_getitem__(cls, args: object | tuple[object, ...], /) -> types.GenericAlias: ...
 
     #
-    def __new__(cls, *system: Never, **kwargs: Never) -> Self: ...
+    def __new__(cls, /, *system: *tuple[()]) -> Self: ...
 
     #
     @abc.abstractmethod
@@ -133,18 +132,18 @@ class LinearTimeInvariant(Generic[_ZerosT_co, _PolesT_co, _DTT_co]):
 class lti(LinearTimeInvariant[_ZerosT_co, _PolesT_co, None], Generic[_ZerosT_co, _PolesT_co], metaclass=abc.ABCMeta):
     @override
     @overload
-    def __new__(cls, *system: *tuple[_ToFloat12D, onp.ToFloat1D]) -> TransferFunctionContinuous[_Float]: ...  # pyrefly:ignore[bad-override]
+    def __new__(cls, num: _ToFloat12D, den: onp.ToFloat1D, /) -> TransferFunctionContinuous[_Float]: ...  # pyrefly:ignore[bad-override]
     @overload
-    def __new__(cls, *system: *tuple[onp.ToFloat1D, onp.ToFloat1D, onp.ToFloat]) -> ZerosPolesGainContinuous[_Float]: ...
+    def __new__(cls, zeros: onp.ToFloat1D, poles: onp.ToFloat1D, gain: onp.ToFloat, /) -> ZerosPolesGainContinuous[_Float]: ...
     @overload
-    def __new__(cls, *system: *tuple[onp.ToComplex1D, onp.ToComplex1D, onp.ToFloat]) -> ZerosPolesGainContinuous: ...
+    def __new__(cls, zeros: onp.ToComplex1D, poles: onp.ToComplex1D, gain: onp.ToFloat, /) -> ZerosPolesGainContinuous: ...
     @overload
-    def __new__(cls, *system: *tuple[_ToFloat012D, _ToFloat012D, _ToFloat012D, _ToFloat012D]) -> StateSpaceContinuous[_Float]: ...
+    def __new__(cls, A: _ToFloat012D, B: _ToFloat012D, C: _ToFloat012D, D: _ToFloat012D, /) -> StateSpaceContinuous[_Float]: ...
     @overload
-    def __new__(cls, *system: *tuple[_ToComplex012D, _ToComplex012D, _ToComplex012D, _ToComplex012D]) -> StateSpaceContinuous: ...
+    def __new__(cls, A: _ToComplex012D, B: _ToComplex012D, C: _ToComplex012D, D: _ToComplex012D, /) -> StateSpaceContinuous: ...
 
     #
-    def __init__(self, /, *system: Never) -> None: ...
+    def __init__(self, /, *system: *tuple[()]) -> None: ...
 
     #
     @overload
@@ -227,27 +226,27 @@ class dlti(LinearTimeInvariant[_ZerosT_co, _PolesT_co, _DTT_co], Generic[_ZerosT
     @override
     @overload
     def __new__(  # pyrefly:ignore[bad-override]
-        cls, *system: *tuple[_ToFloat12D, onp.ToFloat1D], dt: _DTT_co = ...
+        cls, num: _ToFloat12D, den: onp.ToFloat1D, /, *, dt: _DTT_co = ...
     ) -> TransferFunctionDiscrete[_Float, _DTT_co]: ...
     @overload
     def __new__(
-        cls, *system: *tuple[onp.ToFloat1D, onp.ToFloat2D, onp.ToFloat1D], dt: _DTT_co = ...
+        cls, zeros: onp.ToFloat1D, poles: onp.ToFloat2D, gain: onp.ToFloat1D, /, *, dt: _DTT_co = ...
     ) -> ZerosPolesGainDiscrete[_Float, _Float, _DTT_co]: ...
     @overload
     def __new__(
-        cls, *system: *tuple[onp.ToComplex1D, onp.ToComplex1D, onp.ToFloat], dt: _DTT_co = ...
+        cls, zeros: onp.ToComplex1D, poles: onp.ToComplex1D, gain: onp.ToFloat1D, /, *, dt: _DTT_co = ...
     ) -> ZerosPolesGainDiscrete[_Inexact, _Float, _DTT_co]: ...
     @overload
     def __new__(
-        cls, *system: *tuple[_ToFloat012D, _ToFloat012D, _ToFloat012D, _ToFloat012D], dt: _DTT_co = ...
+        cls, A: _ToFloat012D, B: _ToFloat012D, C: _ToFloat012D, D: _ToFloat012D, /, *, dt: _DTT_co = ...
     ) -> StateSpaceDiscrete[_Float, _Float, _DTT_co]: ...
     @overload
     def __new__(
-        cls, *system: *tuple[_ToComplex012D, _ToComplex012D, _ToComplex012D, _ToComplex012D], dt: _DTT_co = ...
+        cls, A: _ToComplex012D, B: _ToComplex012D, C: _ToComplex012D, D: _ToComplex012D, /, *, dt: _DTT_co = ...
     ) -> StateSpaceDiscrete[_Inexact, _Float, _DTT_co]: ...
 
     #
-    def __init__(self, /, *system: Never, dt: float, **kwargs: Never) -> None: ...
+    def __init__(self, /, *system: *tuple[()], dt: _DTT_co) -> None: ...
 
     #
     def output(
@@ -269,31 +268,31 @@ class dlti(LinearTimeInvariant[_ZerosT_co, _PolesT_co, _DTT_co], Generic[_ZerosT
 class TransferFunction(LinearTimeInvariant[_PolesT_co, _PolesT_co, _DTT_co], Generic[_PolesT_co, _DTT_co], metaclass=abc.ABCMeta):
     @override
     @overload
-    def __new__(cls, *system: *tuple[lti[_PolesT, _PolesT]]) -> TransferFunctionContinuous[_PolesT]: ...  # pyrefly:ignore[bad-override]
+    def __new__(cls, system: lti[_PolesT, _PolesT], /) -> TransferFunctionContinuous[_PolesT]: ...  # pyrefly:ignore[bad-override]
     @overload
-    def __new__(cls, *system: *tuple[dlti[_PolesT, _PolesT, _DTT]]) -> TransferFunctionDiscrete[_PolesT, _DTT]: ...
+    def __new__(cls, system: dlti[_PolesT, _PolesT, _DTT], /) -> TransferFunctionDiscrete[_PolesT, _DTT]: ...
     @overload
-    def __new__(cls, *system: *tuple[_ToFloat12D, onp.ToFloat1D]) -> TransferFunctionContinuous[_Float]: ...
+    def __new__(cls, num: _ToFloat12D, den: onp.ToFloat1D, /) -> TransferFunctionContinuous[_Float]: ...
     @overload
-    def __new__(cls, *system: *tuple[_ToFloat12D, onp.ToFloat1D], dt: _DTT) -> TransferFunctionDiscrete[_Float, _DTT]: ...
+    def __new__(cls, num: _ToFloat12D, den: onp.ToFloat1D, /, *, dt: _DTT) -> TransferFunctionDiscrete[_Float, _DTT]: ...
 
     #
     @overload
     def __init__(self, system: LinearTimeInvariant[_PolesT_co, _PolesT_co, _DTT_co], /) -> None: ...
     @overload
-    def __init__(self, numerator: _ToFloat12D, denominator: onp.ToFloat1D, /) -> None: ...
+    def __init__(self, num: _ToFloat12D, den: onp.ToFloat1D, /, *, dt: _DTT_co = ...) -> None: ...
 
     #
     @property
     def num(self, /) -> _Array12D[_PolesT_co]: ...
     @num.setter
-    def num(self, /, num: _ToFloat12D) -> None: ...
+    def num(self, num: _ToFloat12D, /) -> None: ...
 
     #
     @property
     def den(self, /) -> onp.Array1D[_PolesT_co]: ...
     @den.setter
-    def den(self, /, den: onp.ToFloat1D) -> None: ...
+    def den(self, den: onp.ToFloat1D, /) -> None: ...
 
     #
     @override
@@ -331,31 +330,33 @@ class TransferFunctionDiscrete(
 class ZerosPolesGain(LinearTimeInvariant[_ZerosT_co, _PolesT_co, _DTT_co], Generic[_ZerosT_co, _PolesT_co, _DTT_co]):
     @override
     @overload
-    def __new__(cls, *system: *tuple[lti[_ZerosT_co, _PolesT_co]]) -> ZerosPolesGainContinuous[_ZerosT_co, _PolesT_co]: ...  # pyrefly:ignore[bad-override]
+    def __new__(cls, system: lti[_ZerosT_co, _PolesT_co], /) -> ZerosPolesGainContinuous[_ZerosT_co, _PolesT_co]: ...  # pyrefly:ignore[bad-override]
     @overload
     def __new__(
-        cls, *system: *tuple[dlti[_ZerosT_co, _PolesT_co, _DTT_co]]
+        cls, system: dlti[_ZerosT_co, _PolesT_co, _DTT_co], /
     ) -> ZerosPolesGainDiscrete[_ZerosT_co, _PolesT_co, _DTT_co]: ...
     @overload
-    def __new__(cls, *system: *tuple[_ToFloat12D, onp.ToFloat1D, onp.ToFloat]) -> ZerosPolesGainContinuous[_Float, _Float]: ...
+    def __new__(
+        cls, zeros: _ToFloat12D, poles: onp.ToFloat1D, gain: onp.ToFloat, /
+    ) -> ZerosPolesGainContinuous[_Float, _Float]: ...
     @overload
     def __new__(
-        cls, *system: *tuple[_ToComplex12D, onp.ToFloat1D, onp.ToFloat]
+        cls, zeros: _ToComplex12D, poles: onp.ToFloat1D, gain: onp.ToFloat, /
     ) -> ZerosPolesGainContinuous[_Inexact, _Float]: ...
     @overload
     def __new__(
-        cls, *system: *tuple[_ToFloat12D, onp.ToFloat1D, onp.ToFloat], dt: _DTT
+        cls, zeros: _ToFloat12D, poles: onp.ToFloat1D, gain: onp.ToFloat, /, *, dt: _DTT
     ) -> ZerosPolesGainDiscrete[_Float, _Float, _DTT]: ...
     @overload
     def __new__(
-        cls, *system: *tuple[_ToComplex12D, onp.ToFloat1D, onp.ToFloat], dt: _DTT
+        cls, zeros: _ToComplex12D, poles: onp.ToFloat1D, gain: onp.ToFloat, /, *, dt: _DTT
     ) -> ZerosPolesGainDiscrete[_Inexact, _Float, _DTT]: ...
 
     #
     @overload
     def __init__(self, system: LinearTimeInvariant[_ZerosT_co, _PolesT_co, _DTT_co], /) -> None: ...
     @overload
-    def __init__(self, zeros: _ToComplex12D, poles: onp.ToFloat1D, gain: onp.ToFloat, /) -> None: ...
+    def __init__(self, zeros: _ToComplex12D, poles: onp.ToFloat1D, gain: onp.ToFloat, /, *, dt: _DTT_co = ...) -> None: ...
 
     #
     @property
@@ -439,26 +440,24 @@ class StateSpace(LinearTimeInvariant[_ZerosT_co, _PolesT_co, _DTT_co], Generic[_
 
     @override
     @overload
-    def __new__(cls, *system: *tuple[lti[_ZerosT_co, _PolesT_co]]) -> StateSpaceContinuous[_ZerosT_co, _PolesT_co]: ...  # pyrefly:ignore[bad-override]
+    def __new__(cls, system: lti[_ZerosT_co, _PolesT_co], /) -> StateSpaceContinuous[_ZerosT_co, _PolesT_co]: ...  # pyrefly:ignore[bad-override]
+    @overload
+    def __new__(cls, system: dlti[_ZerosT_co, _PolesT_co, _DTT_co], /) -> StateSpaceDiscrete[_ZerosT_co, _PolesT_co, _DTT_co]: ...
     @overload
     def __new__(
-        cls, *system: *tuple[dlti[_ZerosT_co, _PolesT_co, _DTT_co]]
-    ) -> StateSpaceDiscrete[_ZerosT_co, _PolesT_co, _DTT_co]: ...
-    @overload
-    def __new__(
-        cls, *system: *tuple[_ToFloat012D, _ToFloat012D, _ToFloat012D, _ToFloat012D]
+        cls, A: _ToFloat012D, B: _ToFloat012D, C: _ToFloat012D, D: _ToFloat012D, /
     ) -> StateSpaceContinuous[_Float, _Float]: ...
     @overload
     def __new__(
-        cls, *system: *tuple[_ToComplex012D, _ToComplex012D, _ToComplex012D, _ToComplex012D]
+        cls, A: _ToComplex012D, B: _ToComplex012D, C: _ToComplex012D, D: _ToComplex012D, /
     ) -> StateSpaceContinuous[_Inexact, _Float]: ...
     @overload
     def __new__(
-        cls, *system: *tuple[_ToFloat012D, _ToFloat012D, _ToFloat012D, _ToFloat012D], dt: _DTT
+        cls, A: _ToFloat012D, B: _ToFloat012D, C: _ToFloat012D, D: _ToFloat012D, /, *, dt: _DTT
     ) -> StateSpaceDiscrete[_Float, _Float, _DTT]: ...
     @overload
     def __new__(
-        cls, *system: *tuple[_ToComplex012D, _ToComplex012D, _ToComplex012D, _ToComplex012D], dt: _DTT
+        cls, A: _ToComplex012D, B: _ToComplex012D, C: _ToComplex012D, D: _ToComplex012D, /, *, dt: _DTT
     ) -> StateSpaceDiscrete[_Inexact, _Float, _DTT]: ...
 
     #
@@ -466,11 +465,25 @@ class StateSpace(LinearTimeInvariant[_ZerosT_co, _PolesT_co, _DTT_co], Generic[_
     def __init__(self, system: StateSpace[_ZerosT_co, _PolesT_co, _DTT_co], /) -> None: ...
     @overload
     def __init__(
-        self: StateSpace[_Float, _Float], A: _ToFloat012D, B: _ToFloat012D, C: _ToFloat012D, D: _ToFloat012D, /
+        self: StateSpace[_Float, _Float],
+        A: _ToFloat012D,
+        B: _ToFloat012D,
+        C: _ToFloat012D,
+        D: _ToFloat012D,
+        /,
+        *,
+        dt: _DTT_co = ...,
     ) -> None: ...
     @overload
     def __init__(
-        self: StateSpace[_Inexact, _Float], A: _ToComplex012D, B: _ToComplex012D, C: _ToComplex012D, D: _ToComplex012D, /
+        self: StateSpace[_Inexact, _Float],
+        A: _ToComplex012D,
+        B: _ToComplex012D,
+        C: _ToComplex012D,
+        D: _ToComplex012D,
+        /,
+        *,
+        dt: _DTT_co = ...,
     ) -> None: ...
 
     #
@@ -567,7 +580,7 @@ class Bunch:
     rtol: float
     nb_iter: int
 
-    def __init__(self, /, **kwds: Never) -> None: ...
+    def __init__(self, /) -> None: ...
 
 #
 def place_poles(

--- a/tests/signal/test_ltisys.pyi
+++ b/tests/signal/test_ltisys.pyi
@@ -57,14 +57,14 @@ _c128_1d: _VecC128
 _c128_2d: onp.Array2D[np.complex128]
 _i64_1d: onp.Array1D[np.int64]
 
-_lti_f32: lti[np.float32]
-_lti_f64: lti[np.float64]
-_lti_c64: lti[np.complex64]
-_lti_c128: lti[np.complex128]
-_dlti_f32: dlti[np.float32]
-_dlti_f64: dlti[np.float64]
-_dlti_c64: dlti[np.complex64]
-_dlti_c128: dlti[np.complex128]
+_lti_f32: lti[np.float32, np.float32]
+_lti_f64: lti[np.float64, np.float64]
+_lti_c64: lti[np.complex64, np.float32]
+_lti_c128: lti[np.complex128, np.float64]
+_dlti_f32: dlti[np.float32, np.float32, float]
+_dlti_f64: dlti[np.float64, np.float64, float]
+_dlti_c64: dlti[np.complex64, np.float32, float]
+_dlti_c128: dlti[np.complex128, np.float64, float]
 _ss_cont_f32: StateSpaceContinuous[np.float32, np.float32]
 _ss_cont_f64: StateSpaceContinuous[np.float64, np.float64]
 _ss_disc_f32: StateSpaceDiscrete[np.float32, np.float32, float]
@@ -108,23 +108,49 @@ _to_ss_disc_c128: tuple[
 ]
 
 ###
-# StateSpace
-ss_f32 = StateSpace(_ss_cont_f32)  # pyrefly: ignore[bad-argument-type]
-assert_type(ss_f32, StateSpaceContinuous[np.float32, np.float32])  # type: ignore[assert-type]
-ss_disc_f64 = StateSpace(_ss_disc_f64)  # pyrefly: ignore[bad-argument-type]
-assert_type(ss_disc_f64, StateSpaceDiscrete[np.float64, np.float64, float])  # type: ignore[assert-type]  # pyrefly: ignore[assert-type]
+
+# mypy (still) doesn't support `__new__` methods that return a different type
 
 # TransferFunction
-tf_f32 = TransferFunction(_tf_cont_f32)  # pyrefly: ignore[bad-argument-type]
-assert_type(tf_f32, TransferFunctionContinuous[np.float32])  # type: ignore[assert-type]
-tf_disc_f64 = TransferFunctionDiscrete(_f64_2d, _f64_1d, dt=0.1)  # pyrefly: ignore[bad-argument-type]
-assert_type(tf_disc_f64, TransferFunctionDiscrete[np.float32 | np.float64, float])  # type: ignore[assert-type]
+assert_type(TransferFunction(_tf_cont_f32), TransferFunctionContinuous[np.float32])  # type: ignore[assert-type]
+assert_type(TransferFunction(_tf_disc_f32), TransferFunctionDiscrete[np.float32, float])  # type: ignore[assert-type]
+assert_type(TransferFunction(_f64_1d, _f64_1d), TransferFunctionContinuous[np.float32 | np.float64])  # type: ignore[assert-type]
+assert_type(TransferFunction(_f64_1d, _f64_1d, dt=0.1), TransferFunctionDiscrete[np.float32 | np.float64, float])  # type: ignore[assert-type]
 
 # ZerosPolesGain
-zpk_f32 = ZerosPolesGain(_f32_1d, _f32_1d, 1.0)  # pyrefly: ignore[bad-argument-type]
-assert_type(zpk_f32, ZerosPolesGainContinuous[np.float32 | np.float64, np.float32 | np.float64])  # type: ignore[assert-type]  # pyrefly: ignore[assert-type]
-zpk_disc_f64 = ZerosPolesGainDiscrete(_f64_1d, _f64_1d, 1.0, dt=0.1)  # pyrefly: ignore[bad-argument-type]
-assert_type(zpk_disc_f64, ZerosPolesGainDiscrete[np.float32 | np.float64, np.float32 | np.float64, float])
+assert_type(ZerosPolesGain(_zpk_cont_f32), ZerosPolesGainContinuous[np.float32, np.float32])  # type: ignore[assert-type]
+assert_type(ZerosPolesGain(_zpk_disc_f32), ZerosPolesGainDiscrete[np.float32, np.float32, float])  # type: ignore[assert-type]
+assert_type(ZerosPolesGain(_f64_1d, _f64_1d, 5), ZerosPolesGainContinuous[np.float32 | np.float64, np.float32 | np.float64])  # type: ignore[assert-type]
+assert_type(  # type: ignore[assert-type]
+    ZerosPolesGain(_c128_1d, _f64_1d, 5),
+    ZerosPolesGainContinuous[np.float32 | np.float64 | np.complex64 | np.complex128, np.float32 | np.float64],
+)
+assert_type(  # type: ignore[assert-type]
+    ZerosPolesGain(_f64_1d, _f64_1d, 5, dt=0.1), ZerosPolesGainDiscrete[np.float32 | np.float64, np.float32 | np.float64, float]
+)
+assert_type(  # type: ignore[assert-type]
+    ZerosPolesGain(_c128_1d, _f64_1d, 5, dt=0.1),
+    ZerosPolesGainDiscrete[np.float32 | np.float64 | np.complex64 | np.complex128, np.float32 | np.float64, float],
+)
+
+# StateSpace
+assert_type(StateSpace(_ss_cont_f32), StateSpaceContinuous[np.float32, np.float32])  # type: ignore[assert-type]
+assert_type(StateSpace(_ss_disc_f32), StateSpaceDiscrete[np.float32, np.float32, float])  # type: ignore[assert-type]
+assert_type(  # type: ignore[assert-type]
+    StateSpace(_f64_2d, _f64_2d, _f64_2d, _f64_2d), StateSpaceContinuous[np.float32 | np.float64, np.float32 | np.float64]
+)
+assert_type(  # type: ignore[assert-type]
+    StateSpace(_c128_2d, _c128_2d, _c128_2d, _c128_2d),
+    StateSpaceContinuous[np.float32 | np.float64 | np.complex64 | np.complex128, np.float32 | np.float64],
+)
+assert_type(  # type: ignore[assert-type]
+    StateSpace(_f64_2d, _f64_2d, _f64_2d, _f64_2d, dt=0.1),
+    StateSpaceDiscrete[np.float32 | np.float64, np.float32 | np.float64, float],
+)
+assert_type(  # type: ignore[assert-type]
+    StateSpace(_c128_2d, _c128_2d, _c128_2d, _c128_2d, dt=0.1),
+    StateSpaceDiscrete[np.float32 | np.float64 | np.complex64 | np.complex128, np.float32 | np.float64, float],
+)
 
 ###
 # lsim (same as impulse and step)
@@ -222,22 +248,22 @@ assert_type(_lti_c128.step(), tuple[_VecF64, _VecC128])
 # what's going on with mypy here...?
 
 # f32
-assert_type(bode(_lti_f32), tuple[_VecF32, _VecF32, _VecF32])  # type: ignore[assert-type]
+assert_type(bode(_lti_f32), tuple[_VecF32, _VecF32, _VecF32])
 assert_type(bode(_to_tf_cont_f32), tuple[_VecF32, _VecF32, _VecF32])
 assert_type(bode(_to_zpk_cont_f32), tuple[_VecF32, _VecF32, _VecF32])
 assert_type(bode(_to_ss_cont_f32), tuple[_VecF32, _VecF32, _VecF32])
 # c64
-assert_type(bode(_lti_c64), tuple[_VecF32, _VecF32, _VecF32])  # type: ignore[assert-type]
+assert_type(bode(_lti_c64), tuple[_VecF32, _VecF32, _VecF32])
 assert_type(bode(_to_tf_cont_c64), tuple[_VecF32, _VecF32, _VecF32])
 assert_type(bode(_to_zpk_cont_c64), tuple[_VecF32, _VecF32, _VecF32])
 assert_type(bode(_to_ss_cont_c64), tuple[_VecF32, _VecF32, _VecF32])
 # f64
-assert_type(bode(_lti_f64), tuple[_VecF64, _VecF64, _VecF64])  # type: ignore[assert-type]
+assert_type(bode(_lti_f64), tuple[_VecF64, _VecF64, _VecF64])
 assert_type(bode(_to_tf_cont_f64), tuple[_VecF64, _VecF64, _VecF64])
 assert_type(bode(_to_zpk_cont_f64), tuple[_VecF64, _VecF64, _VecF64])
 assert_type(bode(_to_ss_cont_f64), tuple[_VecF64, _VecF64, _VecF64])
 # c128
-assert_type(bode(_lti_c128), tuple[_VecF64, _VecF64, _VecF64])  # type: ignore[assert-type]
+assert_type(bode(_lti_c128), tuple[_VecF64, _VecF64, _VecF64])
 assert_type(bode(_to_tf_cont_c128), tuple[_VecF64, _VecF64, _VecF64])
 assert_type(bode(_to_zpk_cont_c128), tuple[_VecF64, _VecF64, _VecF64])
 assert_type(bode(_to_ss_cont_c128), tuple[_VecF64, _VecF64, _VecF64])


### PR DESCRIPTION
This improves mypy and pyrefly compatibility of direct construction of the following `scipy.signal` classes:

- `TransferFunction`
- `ZerosPolesGain`
- `StateSpace`

Closes #1553