### PR TITLE
🔨 ignore `scipy.stats.chi2_contingency` in test coverage script

### DIFF
--- a/scripts/test_coverage.py
+++ b/scripts/test_coverage.py
@@ -10,6 +10,12 @@ from typing import Final
 
 _SCIPY: Final = "scipy"
 _IGNORED_SUFFIXES: Final = {"__class__"}
+_IGNORED_QUALNAMES: Final = {
+    # `scipy.stats.chi2_contingency` is a re-export of
+    # `scipy.stats.contingency.chi2_contingency`, which is already tested in
+    # `tests/stats/test_contingency.pyi`.
+    "scipy.stats.chi2_contingency"
+}
 
 _PACKAGES_PUBLIC: Final = (
     "cluster",
@@ -225,6 +231,8 @@ def _parse_scipy_imports(tree: ast.AST) -> dict[str, str]:
 
 def _should_ignore(qualname: str) -> bool:
     """Check if a qualified name should be ignored (private or bare package)."""
+    if qualname in _IGNORED_QUALNAMES:
+        return True  # explicitly ignored public re-exports
     if qualname.endswith(("Warning", "Error")):
         return True  # exceptions
     parts = qualname.split(".")

--- a/scripts/test_coverage.py
+++ b/scripts/test_coverage.py
@@ -232,7 +232,7 @@ def _parse_scipy_imports(tree: ast.AST) -> dict[str, str]:
 def _should_ignore(qualname: str) -> bool:
     """Check if a qualified name should be ignored (private or bare package)."""
     if qualname in _IGNORED_QUALNAMES:
-        return True  # explicitly ignored public re-exports
+        return True
     if qualname.endswith(("Warning", "Error")):
         return True  # exceptions
     parts = qualname.split(".")

--- a/tests/stats/test_chi2_contingency.pyi
+++ b/tests/stats/test_chi2_contingency.pyi
@@ -1,0 +1,33 @@
+# type-tests for `scipy.stats.chi2_contingency` top-level export
+
+from typing import assert_type
+
+import numpy as np
+import optype.numpy as onp
+
+from scipy.stats import chi2_contingency
+from scipy.stats.contingency import Chi2ContingencyResult
+
+###
+
+_f32_2d: onp.Array2D[np.float32]
+_f64_2d: onp.Array2D[np.float64]
+_f64_3d: onp.Array3D[np.float64]
+_f64_nd: onp.ArrayND[np.float64]
+
+###
+
+assert_type(chi2_contingency(_f32_2d, correction=False), Chi2ContingencyResult[tuple[int, int]])
+assert_type(chi2_contingency(_f64_2d, correction=False), Chi2ContingencyResult[tuple[int, int]])
+assert_type(chi2_contingency(_f64_3d, correction=False), Chi2ContingencyResult[tuple[int, int, int]])
+assert_type(chi2_contingency(_f64_nd, correction=False), Chi2ContingencyResult)
+assert_type(chi2_contingency(_f64_2d), Chi2ContingencyResult[tuple[int, int]])
+assert_type(chi2_contingency(_f64_2d, lambda_="log-likelihood"), Chi2ContingencyResult[tuple[int, int]])
+
+###
+
+res = chi2_contingency(_f64_2d)
+assert_type(res.statistic, np.float64)
+assert_type(res.pvalue, np.float64)
+assert_type(res.dof, int)
+assert_type(res.expected_freq, onp.Array2D[np.float64])


### PR DESCRIPTION
Towards #1099 

`scipy.stats.chi2_contingency` is a re-export of `scipy.stats.contingency.chi2_contingency`, which is already
tested in `tests/stats/test_contingency.pyi`.