### PR TITLE
🐛 `stats`: Add missing 1D diagonal support for `matrix_normal` rowcov/colcov

### DIFF
--- a/scipy-stubs/stats/_multivariate.pyi
+++ b/scipy-stubs/stats/_multivariate.pyi
@@ -234,8 +234,8 @@ class matrix_normal_gen(multi_rv_generic):
         self,
         /,
         mean: onp.ToFloat2D | None = None,
-        rowcov: onp.ToFloat2D | onp.ToFloat = 1,
-        colcov: onp.ToFloat2D | onp.ToFloat = 1,
+        rowcov: onp.ToFloat | onp.ToFloat1D | onp.ToFloat2D = 1,
+        colcov: onp.ToFloat | onp.ToFloat1D | onp.ToFloat2D = 1,
         seed: onp.random.ToRNG | None = None,
     ) -> matrix_normal_frozen: ...
 
@@ -245,16 +245,16 @@ class matrix_normal_gen(multi_rv_generic):
         /,
         X: onp.ToFloatND,
         mean: onp.ToFloat2D | None = None,
-        rowcov: onp.ToFloat2D | onp.ToFloat = 1,
-        colcov: onp.ToFloat2D | onp.ToFloat = 1,
+        rowcov: onp.ToFloat | onp.ToFloat1D | onp.ToFloat2D = 1,
+        colcov: onp.ToFloat | onp.ToFloat1D | onp.ToFloat2D = 1,
     ) -> _ScalarOrArray_f8: ...
     def pdf(
         self,
         /,
         X: onp.ToFloatND,
         mean: onp.ToFloat2D | None = None,
-        rowcov: onp.ToFloat2D | onp.ToFloat = 1,
-        colcov: onp.ToFloat2D | onp.ToFloat = 1,
+        rowcov: onp.ToFloat | onp.ToFloat1D | onp.ToFloat2D = 1,
+        colcov: onp.ToFloat | onp.ToFloat1D | onp.ToFloat2D = 1,
     ) -> _ScalarOrArray_f8: ...
 
     # If `size > 1` the output is 3-D, otherwise 2-D.
@@ -263,8 +263,8 @@ class matrix_normal_gen(multi_rv_generic):
         self,
         /,
         mean: onp.ToFloat2D | None = None,
-        rowcov: onp.ToFloat2D | onp.ToFloat = 1,
-        colcov: onp.ToFloat2D | onp.ToFloat = 1,
+        rowcov: onp.ToFloat | onp.ToFloat1D | onp.ToFloat2D = 1,
+        colcov: onp.ToFloat | onp.ToFloat1D | onp.ToFloat2D = 1,
         size: Literal[1] = 1,
         random_state: onp.random.ToRNG | None = None,
     ) -> onp.Array2D[np.float64]: ...
@@ -273,8 +273,8 @@ class matrix_normal_gen(multi_rv_generic):
         self,
         /,
         mean: onp.ToFloat2D | None,
-        rowcov: onp.ToFloat2D | onp.ToFloat,
-        colcov: onp.ToFloat2D | onp.ToFloat,
+        rowcov: onp.ToFloat | onp.ToFloat1D | onp.ToFloat2D,
+        colcov: onp.ToFloat | onp.ToFloat1D | onp.ToFloat2D,
         size: int,
         random_state: onp.random.ToRNG | None = None,
     ) -> _Array2ND[np.float64]: ...
@@ -283,15 +283,20 @@ class matrix_normal_gen(multi_rv_generic):
         self,
         /,
         mean: onp.ToFloat2D | None = None,
-        rowcov: onp.ToFloat2D | onp.ToFloat = 1,
-        colcov: onp.ToFloat2D | onp.ToFloat = 1,
+        rowcov: onp.ToFloat | onp.ToFloat1D | onp.ToFloat2D = 1,
+        colcov: onp.ToFloat | onp.ToFloat1D | onp.ToFloat2D = 1,
         *,
         size: int,
         random_state: onp.random.ToRNG | None = None,
     ) -> _Array2ND[np.float64]: ...
 
     #
-    def entropy(self, /, rowcov: _AnyCov = 1, colcov: _AnyCov = 1) -> np.float64: ...
+    def entropy(
+        self,
+        /,
+        rowcov: onp.ToFloat | onp.ToFloat1D | onp.ToFloat2D = 1,
+        colcov: onp.ToFloat | onp.ToFloat1D | onp.ToFloat2D = 1,
+    ) -> np.float64: ...
 
 class matrix_normal_frozen(multi_rv_frozen[matrix_normal_gen]):
     # pyrefly: ignore [bad-override]
@@ -304,8 +309,8 @@ class matrix_normal_frozen(multi_rv_frozen[matrix_normal_gen]):
         self,
         /,
         mean: onp.ToFloat2D | None = None,
-        rowcov: onp.ToFloat2D | onp.ToFloat = 1,
-        colcov: onp.ToFloat2D | onp.ToFloat = 1,
+        rowcov: onp.ToFloat | onp.ToFloat1D | onp.ToFloat2D = 1,
+        colcov: onp.ToFloat | onp.ToFloat1D | onp.ToFloat2D = 1,
         seed: onp.random.ToRNG | None = None,
     ) -> None: ...
     def logpdf(self, /, X: onp.ToFloatND) -> _ScalarOrArray_f8: ...

--- a/scipy-stubs/stats/_multivariate.pyi
+++ b/scipy-stubs/stats/_multivariate.pyi
@@ -292,10 +292,7 @@ class matrix_normal_gen(multi_rv_generic):
 
     #
     def entropy(
-        self,
-        /,
-        rowcov: onp.ToFloat | onp.ToFloat1D | onp.ToFloat2D = 1,
-        colcov: onp.ToFloat | onp.ToFloat1D | onp.ToFloat2D = 1,
+        self, /, rowcov: onp.ToFloat | onp.ToFloat1D | onp.ToFloat2D = 1, colcov: onp.ToFloat | onp.ToFloat1D | onp.ToFloat2D = 1
     ) -> np.float64: ...
 
 class matrix_normal_frozen(multi_rv_frozen[matrix_normal_gen]):


### PR DESCRIPTION
follow up from #406 

> hii [@jorenham](https://github.com/jorenham) 😁 quick question on `matrix_normal_frozen ` as per docs state that `rowcov `and `colcov` accept a 1D array interpreted as diagonal entries, in addition to scalars and 2-D arrays. But as per my understanding we're missing 1D here, these are the diff , please correct me if I'm missing, or we should add. Thanks!
> 
> ```
> -        mean: onp.ToFloat2D | None = None,
> -        rowcov: onp.ToFloat2D | onp.ToFloat = 1,
> -        colcov: onp.ToFloat2D | onp.ToFloat = 1,
> +        mean: onp.Array[tuple[_M, _N], npc.floating] | None = None,
> +        rowcov: onp.ToFloat | onp.Array[tuple[_M, _M], npc.floating] = 1,
> +        colcov: onp.ToFloat | onp.Array[tuple[_N, _N], npc.floating] = 1,
> ```
