### PR TITLE
✅ `stats`: add tests for `scipy.stats.mstats.tmax`, `tmean`, and `tmin`

### DIFF
--- a/tests/stats/test_mstats.pyi
+++ b/tests/stats/test_mstats.pyi
@@ -1,0 +1,23 @@
+# type-tests for `stats/mstats.pyi`
+
+from typing import assert_type
+
+import numpy as np
+import optype.numpy as onp
+
+from scipy.stats.mstats import tmax, tmean, tmin
+
+###
+
+_py_i_1d: list[int]
+_f32_1d: onp.Array1D[np.float32]
+
+###
+
+assert_type(tmax(_py_i_1d), np.int_ | onp.MArray[np.int_])
+assert_type(tmax(_f32_1d), np.float32 | onp.MArray[np.float32])
+
+assert_type(tmean(_f32_1d), np.float32 | onp.MArray[np.float32])
+
+assert_type(tmin(_py_i_1d), np.int_ | onp.MArray[np.int_])
+assert_type(tmin(_f32_1d), np.float32 | onp.MArray[np.float32])

--- a/tests/stats/test_mstats.pyi
+++ b/tests/stats/test_mstats.pyi
@@ -1,6 +1,6 @@
 # type-tests for `stats/mstats.pyi`
 
-from typing import assert_type
+from typing import Any, assert_type
 
 import numpy as np
 import optype.numpy as onp
@@ -17,7 +17,7 @@ _f32_1d: onp.Array1D[np.float32]
 assert_type(tmax(_py_i_1d), np.int_ | onp.MArray[np.int_])
 assert_type(tmax(_f32_1d), np.float32 | onp.MArray[np.float32])
 
-assert_type(tmean(_f32_1d), np.float32 | onp.MArray[np.float32])
+assert_type(tmean(_f32_1d), np.floating[Any] | onp.MArray[np.floating[Any]])
 
 assert_type(tmin(_py_i_1d), np.int_ | onp.MArray[np.int_])
 assert_type(tmin(_f32_1d), np.float32 | onp.MArray[np.float32])

--- a/tests/stats/test_mstats.pyi
+++ b/tests/stats/test_mstats.pyi
@@ -14,10 +14,10 @@ _f32_1d: onp.Array1D[np.float32]
 
 ###
 
-assert_type(tmax(_py_i_1d), np.int_ | onp.MArray[np.int_])
-assert_type(tmax(_f32_1d), np.float32 | onp.MArray[np.float32])
-
 assert_type(tmean(_f32_1d), np.floating[Any] | onp.MArray[np.floating[Any]])
 
 assert_type(tmin(_py_i_1d), np.int_ | onp.MArray[np.int_])
 assert_type(tmin(_f32_1d), np.float32 | onp.MArray[np.float32])
+
+assert_type(tmax(_py_i_1d), np.int_ | onp.MArray[np.int_])
+assert_type(tmax(_f32_1d), np.float32 | onp.MArray[np.float32])


### PR DESCRIPTION

Towards #1099 

covers: 
- `scipy.stats.mstats.tmax`

- `scipy.stats.mstats.tmean`

- `scipy.stats.mstats.tmin`