### PR TITLE
✅ sparse : add tests for csgraph_traversal

### DIFF
--- a/tests/sparse/csgraph/test_shortest_path.pyi
+++ b/tests/sparse/csgraph/test_shortest_path.pyi
@@ -3,7 +3,7 @@ from typing import assert_type
 
 import numpy as np
 import optype.numpy as onp
-from tests.sparse._types import ScalarType, csr_arr
+from sparse._types import ScalarType, csr_arr
 
 import scipy.sparse as sparse
 from scipy.sparse.csgraph import bellman_ford, dijkstra, floyd_warshall, minimum_spanning_tree, shortest_path

--- a/tests/sparse/csgraph/test_shortest_path.pyi
+++ b/tests/sparse/csgraph/test_shortest_path.pyi
@@ -3,9 +3,9 @@ from typing import assert_type
 
 import numpy as np
 import optype.numpy as onp
+from tests.sparse._types import ScalarType, csr_arr
 
 import scipy.sparse as sparse
-from .._types import ScalarType, csr_arr
 from scipy.sparse.csgraph import bellman_ford, dijkstra, floyd_warshall, minimum_spanning_tree, shortest_path
 
 assert_type(bellman_ford(csr_arr), onp.Array2D[np.float64])

--- a/tests/sparse/csgraph/test_shortest_path.pyi
+++ b/tests/sparse/csgraph/test_shortest_path.pyi
@@ -5,7 +5,7 @@ import numpy as np
 import optype.numpy as onp
 
 import scipy.sparse as sparse
-from ._types import ScalarType, csr_arr
+from .._types import ScalarType, csr_arr
 from scipy.sparse.csgraph import bellman_ford, dijkstra, floyd_warshall, minimum_spanning_tree, shortest_path
 
 assert_type(bellman_ford(csr_arr), onp.Array2D[np.float64])

--- a/tests/sparse/csgraph/test_shortest_path.pyi
+++ b/tests/sparse/csgraph/test_shortest_path.pyi
@@ -1,12 +1,14 @@
 # Type tests for scipy.sparse.csgraph._shortest_path
-from typing import assert_type
+from typing import TypeAlias, assert_type
 
 import numpy as np
 import optype.numpy as onp
-from sparse._types import ScalarType, csr_arr
 
 import scipy.sparse as sparse
 from scipy.sparse.csgraph import bellman_ford, dijkstra, floyd_warshall, minimum_spanning_tree, shortest_path
+
+ScalarType: TypeAlias = np.float32
+csr_arr: sparse.csr_array[ScalarType, tuple[int, int]]
 
 assert_type(bellman_ford(csr_arr), onp.Array2D[np.float64])
 assert_type(bellman_ford(csr_arr, return_predecessors=True), tuple[onp.Array2D[np.float64], onp.Array2D[np.int32]])

--- a/tests/sparse/csgraph/test_traversal.pyi
+++ b/tests/sparse/csgraph/test_traversal.pyi
@@ -3,7 +3,7 @@ from typing import assert_type
 
 import numpy as np
 import optype.numpy as onp
-from tests.sparse._types import ScalarType, csr_arr
+from sparse._types import ScalarType, csr_arr
 
 import scipy.sparse as sparse
 from scipy.sparse.csgraph import breadth_first_order, breadth_first_tree, depth_first_order, depth_first_tree

--- a/tests/sparse/csgraph/test_traversal.pyi
+++ b/tests/sparse/csgraph/test_traversal.pyi
@@ -5,7 +5,7 @@ import numpy as np
 import optype.numpy as onp
 
 import scipy.sparse as sparse
-from ._types import ScalarType, csr_arr
+from .._types import ScalarType, csr_arr
 from scipy.sparse.csgraph import breadth_first_order, breadth_first_tree, depth_first_order, depth_first_tree
 
 assert_type(breadth_first_order(csr_arr, 0, return_predecessors=True), tuple[onp.Array1D[np.int32], onp.Array1D[np.int32]])

--- a/tests/sparse/csgraph/test_traversal.pyi
+++ b/tests/sparse/csgraph/test_traversal.pyi
@@ -1,12 +1,14 @@
 # Type tests for scipy.sparse.csgraph._traversal
-from typing import assert_type
+from typing import TypeAlias, assert_type
 
 import numpy as np
 import optype.numpy as onp
-from sparse._types import ScalarType, csr_arr
 
 import scipy.sparse as sparse
 from scipy.sparse.csgraph import breadth_first_order, breadth_first_tree, depth_first_order, depth_first_tree
+
+ScalarType: TypeAlias = np.float32
+csr_arr: sparse.csr_array[ScalarType, tuple[int, int]]
 
 assert_type(breadth_first_order(csr_arr, 0, return_predecessors=True), tuple[onp.Array1D[np.int32], onp.Array1D[np.int32]])
 

--- a/tests/sparse/csgraph/test_traversal.pyi
+++ b/tests/sparse/csgraph/test_traversal.pyi
@@ -1,4 +1,4 @@
-# Type tests for scipy.sparse.csgraph
+# Type tests for scipy.sparse.csgraph._traversal
 from typing import assert_type
 
 import numpy as np

--- a/tests/sparse/csgraph/test_traversal.pyi
+++ b/tests/sparse/csgraph/test_traversal.pyi
@@ -3,9 +3,9 @@ from typing import assert_type
 
 import numpy as np
 import optype.numpy as onp
+from tests.sparse._types import ScalarType, csr_arr
 
 import scipy.sparse as sparse
-from .._types import ScalarType, csr_arr
 from scipy.sparse.csgraph import breadth_first_order, breadth_first_tree, depth_first_order, depth_first_tree
 
 assert_type(breadth_first_order(csr_arr, 0, return_predecessors=True), tuple[onp.Array1D[np.int32], onp.Array1D[np.int32]])

--- a/tests/sparse/test_csgraph_shortest_path.pyi
+++ b/tests/sparse/test_csgraph_shortest_path.pyi
@@ -1,0 +1,28 @@
+# Type tests for scipy.sparse.csgraph._shortest_path
+from typing import assert_type
+
+import numpy as np
+import optype.numpy as onp
+
+import scipy.sparse as sparse
+from ._types import ScalarType, csr_arr
+from scipy.sparse.csgraph import bellman_ford, dijkstra, floyd_warshall, minimum_spanning_tree, shortest_path
+
+assert_type(bellman_ford(csr_arr), onp.Array2D[np.float64])
+assert_type(bellman_ford(csr_arr, return_predecessors=True), tuple[onp.Array2D[np.float64], onp.Array2D[np.int32]])
+
+assert_type(minimum_spanning_tree(csr_arr), sparse.csr_array[ScalarType, tuple[int, int]])
+
+assert_type(shortest_path(csr_arr), onp.Array2D[np.float64])
+assert_type(shortest_path(csr_arr, return_predecessors=True), tuple[onp.Array2D[np.float64], onp.Array2D[np.int32]])
+
+assert_type(floyd_warshall(csr_arr), onp.Array2D[np.float64])
+assert_type(floyd_warshall(csr_arr, return_predecessors=True), tuple[onp.Array2D[np.float64], onp.Array2D[np.int32]])
+
+assert_type(dijkstra(csr_arr), onp.Array2D[np.float64])
+assert_type(dijkstra(csr_arr, return_predecessors=True), tuple[onp.Array2D[np.float64], onp.Array2D[np.int32]])
+assert_type(dijkstra(csr_arr, min_only=True), onp.Array1D[np.float64])
+assert_type(
+    dijkstra(csr_arr, True, None, True, False, np.inf, min_only=True),
+    tuple[onp.Array1D[np.float64], onp.Array1D[np.int32], onp.Array1D[np.int32]],
+)

--- a/tests/sparse/test_csgraph_traversal.pyi
+++ b/tests/sparse/test_csgraph_traversal.pyi
@@ -1,0 +1,23 @@
+# Type tests for scipy.sparse.csgraph
+from typing import assert_type
+
+import numpy as np
+import optype.numpy as onp
+
+import scipy.sparse as sparse
+from ._types import ScalarType, csr_arr
+from scipy.sparse.csgraph import breadth_first_order, breadth_first_tree, depth_first_order, depth_first_tree
+
+assert_type(breadth_first_order(csr_arr, 0, return_predecessors=True), tuple[onp.Array1D[np.int32], onp.Array1D[np.int32]])
+
+assert_type(breadth_first_order(csr_arr, 0, True, False), onp.Array1D[np.int32])
+assert_type(breadth_first_order(csr_arr, 0), tuple[onp.Array1D[np.int32], onp.Array1D[np.int32]])
+
+assert_type(breadth_first_tree(csr_arr, 0), sparse.csr_array[ScalarType, tuple[int, int]])
+
+assert_type(depth_first_order(csr_arr, 0, return_predecessors=True), tuple[onp.Array1D[np.int32], onp.Array1D[np.int32]])
+
+assert_type(depth_first_order(csr_arr, 0, True, False), onp.Array1D[np.int32])
+assert_type(depth_first_order(csr_arr, 0), tuple[onp.Array1D[np.int32], onp.Array1D[np.int32]])
+
+assert_type(depth_first_tree(csr_arr, 0), sparse.csr_array[ScalarType, tuple[int, int]])

--- a/tests/sparse/test_csgraph_traversal.pyi
+++ b/tests/sparse/test_csgraph_traversal.pyi
@@ -6,17 +6,7 @@ import optype.numpy as onp
 
 import scipy.sparse as sparse
 from ._types import ScalarType, csr_arr
-from scipy.sparse.csgraph import (
-    bellman_ford,
-    breadth_first_order,
-    breadth_first_tree,
-    depth_first_order,
-    depth_first_tree,
-    dijkstra,
-    floyd_warshall,
-    minimum_spanning_tree,
-    shortest_path,
-)
+from scipy.sparse.csgraph import breadth_first_order, breadth_first_tree, depth_first_order, depth_first_tree
 
 assert_type(breadth_first_order(csr_arr, 0, return_predecessors=True), tuple[onp.Array1D[np.int32], onp.Array1D[np.int32]])
 
@@ -31,22 +21,3 @@ assert_type(depth_first_order(csr_arr, 0, True, False), onp.Array1D[np.int32])
 assert_type(depth_first_order(csr_arr, 0), tuple[onp.Array1D[np.int32], onp.Array1D[np.int32]])
 
 assert_type(depth_first_tree(csr_arr, 0), sparse.csr_array[ScalarType, tuple[int, int]])
-
-assert_type(bellman_ford(csr_arr), onp.Array2D[np.float64])
-assert_type(bellman_ford(csr_arr, return_predecessors=True), tuple[onp.Array2D[np.float64], onp.Array2D[np.int32]])
-
-assert_type(minimum_spanning_tree(csr_arr), sparse.csr_array[ScalarType, tuple[int, int]])
-
-assert_type(shortest_path(csr_arr), onp.Array2D[np.float64])
-assert_type(shortest_path(csr_arr, return_predecessors=True), tuple[onp.Array2D[np.float64], onp.Array2D[np.int32]])
-
-assert_type(floyd_warshall(csr_arr), onp.Array2D[np.float64])
-assert_type(floyd_warshall(csr_arr, return_predecessors=True), tuple[onp.Array2D[np.float64], onp.Array2D[np.int32]])
-
-assert_type(dijkstra(csr_arr), onp.Array2D[np.float64])
-assert_type(dijkstra(csr_arr, return_predecessors=True), tuple[onp.Array2D[np.float64], onp.Array2D[np.int32]])
-assert_type(dijkstra(csr_arr, min_only=True), onp.Array1D[np.float64])
-assert_type(
-    dijkstra(csr_arr, True, None, True, False, np.inf, min_only=True),
-    tuple[onp.Array1D[np.float64], onp.Array1D[np.int32], onp.Array1D[np.int32]],
-)

--- a/tests/sparse/test_csgraph_traversal.pyi
+++ b/tests/sparse/test_csgraph_traversal.pyi
@@ -6,7 +6,17 @@ import optype.numpy as onp
 
 import scipy.sparse as sparse
 from ._types import ScalarType, csr_arr
-from scipy.sparse.csgraph import breadth_first_order, breadth_first_tree, depth_first_order, depth_first_tree
+from scipy.sparse.csgraph import (
+    bellman_ford,
+    breadth_first_order,
+    breadth_first_tree,
+    depth_first_order,
+    depth_first_tree,
+    dijkstra,
+    floyd_warshall,
+    minimum_spanning_tree,
+    shortest_path,
+)
 
 assert_type(breadth_first_order(csr_arr, 0, return_predecessors=True), tuple[onp.Array1D[np.int32], onp.Array1D[np.int32]])
 
@@ -21,3 +31,22 @@ assert_type(depth_first_order(csr_arr, 0, True, False), onp.Array1D[np.int32])
 assert_type(depth_first_order(csr_arr, 0), tuple[onp.Array1D[np.int32], onp.Array1D[np.int32]])
 
 assert_type(depth_first_tree(csr_arr, 0), sparse.csr_array[ScalarType, tuple[int, int]])
+
+assert_type(bellman_ford(csr_arr), onp.Array2D[np.float64])
+assert_type(bellman_ford(csr_arr, return_predecessors=True), tuple[onp.Array2D[np.float64], onp.Array2D[np.int32]])
+
+assert_type(minimum_spanning_tree(csr_arr), sparse.csr_array[ScalarType, tuple[int, int]])
+
+assert_type(shortest_path(csr_arr), onp.Array2D[np.float64])
+assert_type(shortest_path(csr_arr, return_predecessors=True), tuple[onp.Array2D[np.float64], onp.Array2D[np.int32]])
+
+assert_type(floyd_warshall(csr_arr), onp.Array2D[np.float64])
+assert_type(floyd_warshall(csr_arr, return_predecessors=True), tuple[onp.Array2D[np.float64], onp.Array2D[np.int32]])
+
+assert_type(dijkstra(csr_arr), onp.Array2D[np.float64])
+assert_type(dijkstra(csr_arr, return_predecessors=True), tuple[onp.Array2D[np.float64], onp.Array2D[np.int32]])
+assert_type(dijkstra(csr_arr, min_only=True), onp.Array1D[np.float64])
+assert_type(
+    dijkstra(csr_arr, True, None, True, False, np.inf, min_only=True),
+    tuple[onp.Array1D[np.float64], onp.Array1D[np.int32], onp.Array1D[np.int32]],
+)


### PR DESCRIPTION
towards #1099 

covers test - 
- `scipy.sparse.csgraph.breadth_first_order`
- `scipy.sparse.csgraph.breadth_first_tree`
- `scipy.sparse.csgraph.depth_first_order`
- `scipy.sparse.csgraph.depth_first_tree`

- scipy.sparse.csgraph.bellman_ford
- scipy.sparse.csgraph.minimum_spanning_tree
- scipy.sparse.csgraph.shortest_path
- scipy.sparse.csgraph.floyd_warshall
- scipy.sparse.csgraph.dijkstra

please let me know if you have some suggestion about the order, or its fine to add in sequence i listed. Thanks!


