### PR TITLE
✅ `special`: add more tests

### DIFF
--- a/scripts/test_coverage.py
+++ b/scripts/test_coverage.py
@@ -14,7 +14,9 @@ _IGNORED_QUALNAMES: Final = {
     # `scipy.stats.chi2_contingency` is a re-export of
     # `scipy.stats.contingency.chi2_contingency`, which is already tested in
     # `tests/stats/test_contingency.pyi`.
-    "scipy.stats.chi2_contingency"
+    "scipy.stats.chi2_contingency",
+    # `scipy.special.digamma` is an alias of `scipy.special.psi`.
+    "scipy.special.digamma",
 }
 
 _PACKAGES_PUBLIC: Final = (

--- a/tests/special/test_basic.pyi
+++ b/tests/special/test_basic.pyi
@@ -47,6 +47,95 @@ assert_type(sinc(1), np.float64)
 assert_type(sinc(1j), np.complex128)
 assert_type(sinc(i_arr), onp.ArrayND[np.float64])
 
+# yn_zeros
+assert_type(yn_zeros(1, 5), onp.Array1D[np.float64])
+
+# ynp_zeros
+assert_type(ynp_zeros(1, 5), onp.Array1D[np.float64])
+
+# y0_zeros
+assert_type(y0_zeros(5, False), tuple[onp.Array1D[np.complex128], onp.Array1D[np.complex128]])
+assert_type(y0_zeros(5, True), tuple[onp.Array1D[np.complex128], onp.Array1D[np.complex128]])
+
+# y1_zeros
+assert_type(y1_zeros(5, False), tuple[onp.Array1D[np.complex128], onp.Array1D[np.complex128]])
+assert_type(y1_zeros(5, True), tuple[onp.Array1D[np.complex128], onp.Array1D[np.complex128]])
+
+# y1p_zeros
+assert_type(y1p_zeros(5, False), tuple[onp.Array1D[np.complex128], onp.Array1D[np.complex128]])
+assert_type(y1p_zeros(5, True), tuple[onp.Array1D[np.complex128], onp.Array1D[np.complex128]])
+
+# erf_zeros
+assert_type(erf_zeros(5), onp.Array1D[np.complex128])
+
+# fresnelc_zeros
+assert_type(fresnelc_zeros(5), onp.Array1D[np.complex128])
+
+# fresnels_zeros
+assert_type(fresnels_zeros(5), onp.Array1D[np.complex128])
+
+# fresnel_zeros
+assert_type(fresnel_zeros(5), onp.Array1D[np.complex128])
+
+# polygamma
+assert_type(polygamma(1, 1.0), np.float64)
+assert_type(polygamma(1, f_arr), onp.ArrayND[np.float64])
+assert_type(polygamma(i_arr, 1.0), onp.ArrayND[np.float64])
+
+# bernoulli
+assert_type(bernoulli(5), onp.Array1D[np.float64])
+assert_type(bernoulli(5.0), onp.Array1D[np.float64])
+
+# euler
+assert_type(euler(5), onp.Array1D[np.float64])
+assert_type(euler(5.0), onp.Array1D[np.float64])
+
+# ai_zeros
+assert_type(
+    ai_zeros(5), tuple[onp.Array1D[np.float64], onp.Array1D[np.float64], onp.Array1D[np.float64], onp.Array1D[np.float64]]
+)
+
+# bi_zeros
+assert_type(
+    bi_zeros(5), tuple[onp.Array1D[np.float64], onp.Array1D[np.float64], onp.Array1D[np.float64], onp.Array1D[np.float64]]
+)
+
+# ber_zeros
+assert_type(ber_zeros(5), onp.Array1D[np.float64])
+
+# bei_zeros
+assert_type(bei_zeros(5), onp.Array1D[np.float64])
+
+# kei_zeros
+assert_type(kei_zeros(5), onp.Array1D[np.float64])
+
+# berp_zeros
+assert_type(berp_zeros(5), onp.Array1D[np.float64])
+
+# beip_zeros
+assert_type(beip_zeros(5), onp.Array1D[np.float64])
+
+# kerp_zeros
+assert_type(kerp_zeros(5), onp.Array1D[np.float64])
+
+# keip_zeros
+assert_type(keip_zeros(5), onp.Array1D[np.float64])
+
+# kelvin_zeros
+assert_type(
+    kelvin_zeros(5),
+    tuple[
+        onp.Array1D[np.float64],
+        onp.Array1D[np.float64],
+        onp.Array1D[np.float64],
+        onp.Array1D[np.float64],
+        onp.Array1D[np.float64],
+        onp.Array1D[np.float64],
+        onp.Array1D[np.float64],
+        onp.Array1D[np.float64],
+    ],
+)
+
 # comb
 assert_type(comb(5, 2, exact=True), int)
 assert_type(comb(5.0, 2.0), np.float32 | np.float64)
@@ -92,11 +181,6 @@ assert_type(stirling2(5, 2), np.float64)
 assert_type(stirling2(5, i_arr), onp.ArrayND[np.float64])
 assert_type(stirling2(i_arr, 2), onp.ArrayND[np.float64])
 
-# polygamma
-assert_type(polygamma(1, 1.0), np.float64)
-assert_type(polygamma(1, f_arr), onp.ArrayND[np.float64])
-assert_type(polygamma(i_arr, 1.0), onp.ArrayND[np.float64])
-
 # zeta
 assert_type(zeta(2.0), np.float64)
 assert_type(zeta(2.0, f_arr), onp.ArrayND[np.float64])
@@ -104,87 +188,3 @@ assert_type(zeta(f_arr), onp.ArrayND[np.float64])
 assert_type(zeta(2j), np.complex128)
 assert_type(zeta(2j, f_arr), onp.ArrayND[np.complex128])
 assert_type(zeta(c_arr), onp.ArrayND[np.complex128])
-
-# ai_zeros
-assert_type(
-    ai_zeros(5), tuple[onp.Array1D[np.float64], onp.Array1D[np.float64], onp.Array1D[np.float64], onp.Array1D[np.float64]]
-)
-
-# bei_zeros
-assert_type(bei_zeros(5), onp.Array1D[np.float64])
-
-# beip_zeros
-assert_type(beip_zeros(5), onp.Array1D[np.float64])
-
-# ber_zeros
-assert_type(ber_zeros(5), onp.Array1D[np.float64])
-
-# bernoulli
-assert_type(bernoulli(5), onp.Array1D[np.float64])
-assert_type(bernoulli(5.0), onp.Array1D[np.float64])
-
-# berp_zeros
-assert_type(berp_zeros(5), onp.Array1D[np.float64])
-
-# bi_zeros
-assert_type(
-    bi_zeros(5), tuple[onp.Array1D[np.float64], onp.Array1D[np.float64], onp.Array1D[np.float64], onp.Array1D[np.float64]]
-)
-
-# erf_zeros
-assert_type(erf_zeros(5), onp.Array1D[np.complex128])
-
-# euler
-assert_type(euler(5), onp.Array1D[np.float64])
-assert_type(euler(5.0), onp.Array1D[np.float64])
-
-# fresnel_zeros
-assert_type(fresnel_zeros(5), onp.Array1D[np.complex128])
-
-# fresnelc_zeros
-assert_type(fresnelc_zeros(5), onp.Array1D[np.complex128])
-
-# fresnels_zeros
-assert_type(fresnels_zeros(5), onp.Array1D[np.complex128])
-
-# kei_zeros
-assert_type(kei_zeros(5), onp.Array1D[np.float64])
-
-# keip_zeros
-assert_type(keip_zeros(5), onp.Array1D[np.float64])
-
-# kelvin_zeros
-assert_type(
-    kelvin_zeros(5),
-    tuple[
-        onp.Array1D[np.float64],
-        onp.Array1D[np.float64],
-        onp.Array1D[np.float64],
-        onp.Array1D[np.float64],
-        onp.Array1D[np.float64],
-        onp.Array1D[np.float64],
-        onp.Array1D[np.float64],
-        onp.Array1D[np.float64],
-    ],
-)
-
-# kerp_zeros
-assert_type(kerp_zeros(5), onp.Array1D[np.float64])
-
-# y0_zeros
-assert_type(y0_zeros(5, False), tuple[onp.Array1D[np.complex128], onp.Array1D[np.complex128]])
-assert_type(y0_zeros(5, True), tuple[onp.Array1D[np.complex128], onp.Array1D[np.complex128]])
-
-# y1_zeros
-assert_type(y1_zeros(5, False), tuple[onp.Array1D[np.complex128], onp.Array1D[np.complex128]])
-assert_type(y1_zeros(5, True), tuple[onp.Array1D[np.complex128], onp.Array1D[np.complex128]])
-
-# y1p_zeros
-assert_type(y1p_zeros(5, False), tuple[onp.Array1D[np.complex128], onp.Array1D[np.complex128]])
-assert_type(y1p_zeros(5, True), tuple[onp.Array1D[np.complex128], onp.Array1D[np.complex128]])
-
-# yn_zeros
-assert_type(yn_zeros(1, 5), onp.Array1D[np.float64])
-
-# ynp_zeros
-assert_type(ynp_zeros(1, 5), onp.Array1D[np.float64])

--- a/tests/special/test_basic.pyi
+++ b/tests/special/test_basic.pyi
@@ -12,7 +12,6 @@ from scipy.special import (
     berp_zeros,
     bi_zeros,
     comb,
-    digamma,
     erf_zeros,
     euler,
     factorial,
@@ -97,10 +96,6 @@ assert_type(stirling2(i_arr, 2), onp.ArrayND[np.float64])
 assert_type(polygamma(1, 1.0), np.float64)
 assert_type(polygamma(1, f_arr), onp.ArrayND[np.float64])
 assert_type(polygamma(i_arr, 1.0), onp.ArrayND[np.float64])
-
-# digamma
-assert_type(digamma(1.0), np.float64)
-assert_type(digamma(f_arr), onp.ArrayND[np.float64])
 
 # zeta
 assert_type(zeta(2.0), np.float64)

--- a/tests/special/test_basic.pyi
+++ b/tests/special/test_basic.pyi
@@ -3,7 +3,39 @@ from typing import assert_type
 import numpy as np
 import optype.numpy as onp
 
-from scipy.special import comb, factorial, factorial2, factorialk, perm, polygamma, sinc, stirling2, zeta
+from scipy.special import (
+    ai_zeros,
+    bei_zeros,
+    beip_zeros,
+    ber_zeros,
+    bernoulli,
+    berp_zeros,
+    bi_zeros,
+    comb,
+    digamma,
+    euler,
+    erf_zeros,
+    factorial,
+    factorial2,
+    factorialk,
+    fresnel_zeros,
+    fresnelc_zeros,
+    fresnels_zeros,
+    kei_zeros,
+    keip_zeros,
+    kelvin_zeros,
+    kerp_zeros,
+    perm,
+    polygamma,
+    sinc,
+    stirling2,
+    y0_zeros,
+    y1_zeros,
+    y1p_zeros,
+    yn_zeros,
+    ynp_zeros,
+    zeta,
+)
 
 f_arr: onp.ArrayND[np.float64]
 i_arr: onp.ArrayND[np.intp]
@@ -66,6 +98,10 @@ assert_type(polygamma(1, 1.0), np.float64)
 assert_type(polygamma(1, f_arr), onp.ArrayND[np.float64])
 assert_type(polygamma(i_arr, 1.0), onp.ArrayND[np.float64])
 
+# digamma
+assert_type(digamma(1.0), np.float64)
+assert_type(digamma(f_arr), onp.ArrayND[np.float64])
+
 # zeta
 assert_type(zeta(2.0), np.float64)
 assert_type(zeta(2.0, f_arr), onp.ArrayND[np.float64])
@@ -73,3 +109,99 @@ assert_type(zeta(f_arr), onp.ArrayND[np.float64])
 assert_type(zeta(2j), np.complex128)
 assert_type(zeta(2j, f_arr), onp.ArrayND[np.complex128])
 assert_type(zeta(c_arr), onp.ArrayND[np.complex128])
+
+# ai_zeros
+assert_type(
+    ai_zeros(5),
+    tuple[
+        onp.Array1D[np.float64],
+        onp.Array1D[np.float64],
+        onp.Array1D[np.float64],
+        onp.Array1D[np.float64],
+    ],
+)
+
+# bei_zeros
+assert_type(bei_zeros(5), onp.Array1D[np.float64])
+
+# beip_zeros
+assert_type(beip_zeros(5), onp.Array1D[np.float64])
+
+# ber_zeros
+assert_type(ber_zeros(5), onp.Array1D[np.float64])
+
+# bernoulli
+assert_type(bernoulli(5), onp.Array1D[np.float64])
+assert_type(bernoulli(5.0), onp.Array1D[np.float64])
+
+# berp_zeros
+assert_type(berp_zeros(5), onp.Array1D[np.float64])
+
+# bi_zeros
+assert_type(
+    bi_zeros(5),
+    tuple[
+        onp.Array1D[np.float64],
+        onp.Array1D[np.float64],
+        onp.Array1D[np.float64],
+        onp.Array1D[np.float64],
+    ],
+)
+
+# erf_zeros
+assert_type(erf_zeros(5), onp.Array1D[np.complex128])
+
+# euler
+assert_type(euler(5), onp.Array1D[np.float64])
+assert_type(euler(5.0), onp.Array1D[np.float64])
+
+# fresnel_zeros
+assert_type(fresnel_zeros(5), onp.Array1D[np.complex128])
+
+# fresnelc_zeros
+assert_type(fresnelc_zeros(5), onp.Array1D[np.complex128])
+
+# fresnels_zeros
+assert_type(fresnels_zeros(5), onp.Array1D[np.complex128])
+
+# kei_zeros
+assert_type(kei_zeros(5), onp.Array1D[np.float64])
+
+# keip_zeros
+assert_type(keip_zeros(5), onp.Array1D[np.float64])
+
+# kelvin_zeros
+assert_type(
+    kelvin_zeros(5),
+    tuple[
+        onp.Array1D[np.float64],
+        onp.Array1D[np.float64],
+        onp.Array1D[np.float64],
+        onp.Array1D[np.float64],
+        onp.Array1D[np.float64],
+        onp.Array1D[np.float64],
+        onp.Array1D[np.float64],
+        onp.Array1D[np.float64],
+    ],
+)
+
+# kerp_zeros
+assert_type(kerp_zeros(5), onp.Array1D[np.float64])
+
+# y0_zeros
+assert_type(y0_zeros(5, False), tuple[onp.Array1D[np.complex128], onp.Array1D[np.complex128]])
+assert_type(y0_zeros(5, True), tuple[onp.Array1D[np.complex128], onp.Array1D[np.complex128]])
+
+# y1_zeros
+assert_type(y1_zeros(5, False), tuple[onp.Array1D[np.complex128], onp.Array1D[np.complex128]])
+assert_type(y1_zeros(5, True), tuple[onp.Array1D[np.complex128], onp.Array1D[np.complex128]])
+
+# y1p_zeros
+assert_type(y1p_zeros(5, False), tuple[onp.Array1D[np.complex128], onp.Array1D[np.complex128]])
+assert_type(y1p_zeros(5, True), tuple[onp.Array1D[np.complex128], onp.Array1D[np.complex128]])
+
+# yn_zeros
+assert_type(yn_zeros(1, 5), onp.Array1D[np.float64])
+
+# ynp_zeros
+assert_type(ynp_zeros(1, 5), onp.Array1D[np.float64])

--- a/tests/special/test_basic.pyi
+++ b/tests/special/test_basic.pyi
@@ -13,8 +13,8 @@ from scipy.special import (
     bi_zeros,
     comb,
     digamma,
-    euler,
     erf_zeros,
+    euler,
     factorial,
     factorial2,
     factorialk,
@@ -112,13 +112,7 @@ assert_type(zeta(c_arr), onp.ArrayND[np.complex128])
 
 # ai_zeros
 assert_type(
-    ai_zeros(5),
-    tuple[
-        onp.Array1D[np.float64],
-        onp.Array1D[np.float64],
-        onp.Array1D[np.float64],
-        onp.Array1D[np.float64],
-    ],
+    ai_zeros(5), tuple[onp.Array1D[np.float64], onp.Array1D[np.float64], onp.Array1D[np.float64], onp.Array1D[np.float64]]
 )
 
 # bei_zeros
@@ -139,13 +133,7 @@ assert_type(berp_zeros(5), onp.Array1D[np.float64])
 
 # bi_zeros
 assert_type(
-    bi_zeros(5),
-    tuple[
-        onp.Array1D[np.float64],
-        onp.Array1D[np.float64],
-        onp.Array1D[np.float64],
-        onp.Array1D[np.float64],
-    ],
+    bi_zeros(5), tuple[onp.Array1D[np.float64], onp.Array1D[np.float64], onp.Array1D[np.float64], onp.Array1D[np.float64]]
 )
 
 # erf_zeros


### PR DESCRIPTION
Towards https://github.com/scipy/scipy-stubs/issues/1099

Covers: 

- `digamma`
- `ai_zeros`
- `bei_zeros`
- `beip_zeros`
- `ber_zeros`
- `bernoulli`
- `berp_zeros`
- `bi_zeros`
- `erf_zeros`
- `euler`
- `fresnel_zeros`
- `fresnelc_zeros`
- `fresnels_zeros`
- `kei_zeros`
- `keip_zeros`
- `kelvin_zeros`
- `kerp_zeros`
- `y0_zeros`
- `y1_zeros`
- `y1p_zeros`
- `yn_zeros`
- `ynp_zeros`