### PR TITLE
🦖 `special`: improve `softplus` compatibility with older numpy versions

### DIFF
--- a/scipy-stubs/special/_basic.pyi
+++ b/scipy-stubs/special/_basic.pyi
@@ -509,7 +509,7 @@ def softplus(
 ) -> _f8_nd: ...
 @overload
 def softplus(
-    x: onp.CanArrayND[_SCT_f, _ShapeT], *, out: None = None, dtype: onp.ToDType[_SCT_f] | None = None, **kwds: Unpack[_KwBase]
+    x: onp.ArrayND[_SCT_f, _ShapeT], *, out: None = None, dtype: onp.ToDType[_SCT_f] | None = None, **kwds: Unpack[_KwBase]
 ) -> onp.ArrayND[_SCT_f, _ShapeT]: ...
 @overload
 def softplus(


### PR DESCRIPTION
This issue was uncovered by @fbourgey in #1581. 

Disclaimer; I did not verify this at all, but I'm pretty sure this'll fix it.