### PR TITLE
🐛 `sparse.csgraph`: add missing callable return type for `laplacian` with `form="function"`

### DIFF
--- a/scipy-stubs/sparse/csgraph/_laplacian.pyi
+++ b/scipy-stubs/sparse/csgraph/_laplacian.pyi
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from typing import Literal, TypeAlias, overload
 
 import numpy.typing as npt
@@ -7,13 +8,38 @@ import optype.numpy.compat as npc
 from scipy.sparse._base import _spbase
 from scipy.sparse.linalg import LinearOperator
 
-_LaplacianMatrix: TypeAlias = onp.Array2D[npc.number] | _spbase | LinearOperator
+_LaplacianFunction: TypeAlias = Callable[[onp.ToComplex2D], onp.Array2D[npc.number]]
+_LaplacianMatrix: TypeAlias = onp.Array2D[npc.number] | _spbase | LinearOperator | _LaplacianFunction
 _LaplacianDiag: TypeAlias = onp.Array1D[npc.number]
 _ToCSGraph: TypeAlias = onp.ToComplex2D | _spbase
 _Form: TypeAlias = Literal["array", "function", "lo"]
 
 ###
 
+@overload
+def laplacian(
+    csgraph: _ToCSGraph,
+    normed: bool = False,
+    return_diag: onp.ToFalse = False,
+    use_out_degree: bool = False,
+    *,
+    copy: bool = True,
+    form: Literal["function"],
+    dtype: npt.DTypeLike | None = None,
+    symmetrized: bool = False,
+) -> _LaplacianFunction: ...
+@overload
+def laplacian(
+    csgraph: _ToCSGraph,
+    normed: bool = False,
+    *,
+    return_diag: onp.ToTrue,
+    use_out_degree: bool = False,
+    copy: bool = True,
+    form: Literal["function"],
+    dtype: npt.DTypeLike | None = None,
+    symmetrized: bool = False,
+) -> tuple[_LaplacianFunction, _LaplacianDiag]: ...
 @overload
 def laplacian(
     csgraph: _ToCSGraph,

--- a/scipy-stubs/sparse/csgraph/_laplacian.pyi
+++ b/scipy-stubs/sparse/csgraph/_laplacian.pyi
@@ -9,10 +9,10 @@ from scipy.sparse._base import _spbase
 from scipy.sparse.linalg import LinearOperator
 
 _LaplacianFunction: TypeAlias = Callable[[onp.ToComplex2D], onp.Array2D[npc.number]]
-_LaplacianMatrix: TypeAlias = onp.Array2D[npc.number] | _spbase | LinearOperator | _LaplacianFunction
+_LaplacianMatrix: TypeAlias = onp.Array2D[npc.number] | _spbase | LinearOperator
 _LaplacianDiag: TypeAlias = onp.Array1D[npc.number]
 _ToCSGraph: TypeAlias = onp.ToComplex2D | _spbase
-_Form: TypeAlias = Literal["array", "function", "lo"]
+_Form: TypeAlias = Literal["array", "lo"]
 
 ###
 

--- a/tests/sparse/csgraph/test_laplacian.pyi
+++ b/tests/sparse/csgraph/test_laplacian.pyi
@@ -1,0 +1,19 @@
+from typing import reveal_type
+
+import numpy as np
+import numpy.typing as npt
+
+from scipy.sparse.csgraph import laplacian
+
+G: npt.NDArray[np.float64]
+v: npt.NDArray[np.float64]
+
+fn = laplacian(G, form="function")
+reveal_type(fn)  # Callable
+
+result = fn(v)
+reveal_type(result)
+
+fn2, diag = laplacian(G, form="function", return_diag=True)
+reveal_type(fn2)
+reveal_type(diag)

--- a/tests/sparse/csgraph/test_laplacian.pyi
+++ b/tests/sparse/csgraph/test_laplacian.pyi
@@ -1,19 +1,18 @@
-from typing import reveal_type
+from collections.abc import Callable
 
 import numpy as np
 import numpy.typing as npt
+import optype as op
+import optype.numpy as onp
+import optype.numpy.compat as npc
 
 from scipy.sparse.csgraph import laplacian
 
-G: npt.NDArray[np.float64]
-v: npt.NDArray[np.float64]
+_f64_nd: npt.NDArray[np.float64]
 
-fn = laplacian(G, form="function")
-reveal_type(fn)  # Callable
+fn = laplacian(_f64_nd, form="function")
+op.test.assert_subtype[Callable[[onp.ToComplex2D], onp.Array2D[npc.number]]](fn)
 
-result = fn(v)
-reveal_type(result)
-
-fn2, diag = laplacian(G, form="function", return_diag=True)
-reveal_type(fn2)
-reveal_type(diag)
+fn2, diag = laplacian(_f64_nd, form="function", return_diag=True)
+op.test.assert_subtype[Callable[[onp.ToComplex2D], onp.Array2D[npc.number]]](fn2)
+op.test.assert_subtype[onp.Array1D[npc.number]](diag)


### PR DESCRIPTION
fixes #1580 