### PR TITLE
📝 add LazySlide to the list of downstream projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ derwen.ai ([kglab](https://github.com/DerwenAI/kglab)) |
 [graphix](https://github.com/TeamGraphix/graphix) |
 Gurobi ([gurobi-logtools](https://github.com/Gurobi/gurobi-logtools)) |
 [JAX](https://github.com/jax-ml/jax) |
+[LazySlide](https://github.com/rendeirolab/LazySlide) |
 [LensKit](https://github.com/lenskit/lkpy) |
 [librosa](https://github.com/librosa/librosa) |
 [linearmodels](https://github.com/bashtage/linearmodels) |


### PR DESCRIPTION
https://github.com/rendeirolab/LazySlide