### PR TITLE
👷 mypy_primer: run mypy with `--python-version=3.12`

### DIFF
--- a/.github/workflows/mypy_primer.yml
+++ b/.github/workflows/mypy_primer.yml
@@ -53,13 +53,13 @@ jobs:
           uvx \
             --from="https://github.com/hauntsaninja/mypy_primer.git" \
             mypy_primer \
-            --project-selector "/(altair|arviz|colour|dedupe|freqtrade|hydpy|imagehash|jax|materialize|optuna|pandas|pandera|scikit-learn|scipy|spark|static-frame|vision|xarray)/?$" \
+            --project-selector "/(altair|arviz|colour|dedupe|freqtrade|hydpy|imagehash|jax|materialize|optuna|pandas|pandera|scikit-learn|spark|static-frame|vision|xarray)/?$" \
             --new v${MYPY_VERSION} \
             --new-prepend-path new \
             --old v${MYPY_VERSION} \
             --old-prepend-path old \
             --output concise \
-            --additional-flags="--hide-error-context" \
+            --additional-flags="--hide-error-context --python-version=3.12" \
             --debug > mypy_primer.diff || [ $? -eq 1 ]
 
           # Remove ANSI color codes before uploading

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,8 +80,8 @@ prerelease = "allow"
 [tool.uv.sources]
 # the required stubdefaulter features not released yet (>0.1.0)
 stubdefaulter = { git = "https://github.com/JelleZijlstra/stubdefaulter.git", rev = "ebe9e31" }
-# TODO(@jorenham): remove once https://github.com/JelleZijlstra/typeshed_client/pull/145 is released
-typeshed-client = { git = "https://github.com/jorenham/typeshed_client.git", rev = "gh-144" }
+# TODO(@jorenham): remove once a new >2.11 release has been published
+typeshed-client = { git = "https://github.com/JelleZijlstra/typeshed_client.git", rev = "d07fd47" }
 
 # poe
 

--- a/uv.lock
+++ b/uv.lock
@@ -1133,7 +1133,7 @@ dev = [
     { name = "sp-repo-review", extras = ["cli"], specifier = "==2026.4.4" },
     { name = "stubdefaulter", git = "https://github.com/JelleZijlstra/stubdefaulter.git?rev=ebe9e31" },
     { name = "ty", specifier = "==0.0.39" },
-    { name = "typeshed-client", git = "https://github.com/jorenham/typeshed_client.git?rev=gh-144" },
+    { name = "typeshed-client", git = "https://github.com/JelleZijlstra/typeshed_client.git?rev=d07fd47" },
 ]
 extras = [{ name = "scipy-stubs", extras = ["scipy"] }]
 lint = [
@@ -1153,7 +1153,7 @@ type = [
     { name = "scipy-stubs", extras = ["scipy"] },
     { name = "stubdefaulter", git = "https://github.com/JelleZijlstra/stubdefaulter.git?rev=ebe9e31" },
     { name = "ty", specifier = "==0.0.39" },
-    { name = "typeshed-client", git = "https://github.com/jorenham/typeshed_client.git?rev=gh-144" },
+    { name = "typeshed-client", git = "https://github.com/JelleZijlstra/typeshed_client.git?rev=d07fd47" },
 ]
 
 [[package]]
@@ -1276,7 +1276,7 @@ wheels = [
 [[package]]
 name = "typeshed-client"
 version = "2.11.0"
-source = { git = "https://github.com/jorenham/typeshed_client.git?rev=gh-144#6f3d6615ccf6838ef905b6f30aa71a1d231be078" }
+source = { git = "https://github.com/JelleZijlstra/typeshed_client.git?rev=d07fd47#d07fd47fe9db0172913ed1f38d4b52e8a103f97f" }
 dependencies = [
     { name = "importlib-resources" },
     { name = "typing-extensions" },


### PR DESCRIPTION
This avoids false positive Pandas errors, because Pandas has hard-configured mypy to use `python=3.11`, which we no longer support.

See for example https://github.com/scipy/scipy-stubs/pull/1616#issuecomment-4545031794

This also fixes CI, which I broke by deleting the `typeshed-client` PR branch that was just merged.