### PR TITLE
👽️ `integrate`: sync with upstream

### DIFF
--- a/.mypyignore
+++ b/.mypyignore
@@ -20,8 +20,6 @@ scipy\.stats\.(_new_distributions\.)?Normal\.__new__
 ###
 # TODO: 1.18.0rc1
 
-scipy.integrate._ode.IntegratorBase.run_relax
-scipy.integrate._ode.IntegratorBase.step
 scipy.integrate._quad_vec.LRUDict.update
 scipy.integrate._tanhsinh.nsum
 scipy.integrate._tanhsinh.tanhsinh

--- a/.mypyignore
+++ b/.mypyignore
@@ -20,9 +20,6 @@ scipy\.stats\.(_new_distributions\.)?Normal\.__new__
 ###
 # TODO: 1.18.0rc1
 
-scipy.integrate._tanhsinh.nsum
-scipy.integrate._tanhsinh.tanhsinh
-
 scipy.interpolate._dfitpack
 scipy.interpolate._fitpack.bispeu
 scipy.interpolate._fitpack.bispev

--- a/.mypyignore
+++ b/.mypyignore
@@ -20,7 +20,6 @@ scipy\.stats\.(_new_distributions\.)?Normal\.__new__
 ###
 # TODO: 1.18.0rc1
 
-scipy.integrate._quad_vec.LRUDict.update
 scipy.integrate._tanhsinh.nsum
 scipy.integrate._tanhsinh.tanhsinh
 

--- a/scipy-stubs/integrate/_ode.pyi
+++ b/scipy-stubs/integrate/_ode.pyi
@@ -139,7 +139,6 @@ class IntegratorBase(Generic[_Inexact64T_co]):
     ) -> tuple[_Inexact64T_co, float]: ...
     def step(
         self,
-        /,
         f: Callable[..., _Inexact64T_co],
         jac: Callable[..., onp.ArrayND[_Inexact64T_co]],
         y0: complex,
@@ -147,10 +146,10 @@ class IntegratorBase(Generic[_Inexact64T_co]):
         t1: float,
         f_params: tuple[object, ...],
         jac_params: tuple[object, ...],
+        /,
     ) -> tuple[_Inexact64T_co, float]: ...
     def run_relax(
         self,
-        /,
         f: Callable[..., _Inexact64T_co],
         jac: Callable[..., onp.ArrayND[_Inexact64T_co]],
         y0: complex,
@@ -158,6 +157,7 @@ class IntegratorBase(Generic[_Inexact64T_co]):
         t1: float,
         f_params: tuple[object, ...],
         jac_params: tuple[object, ...],
+        /,
     ) -> tuple[_Inexact64T_co, float]: ...
 
 # undocumented

--- a/scipy-stubs/integrate/_quad_vec.pyi
+++ b/scipy-stubs/integrate/_quad_vec.pyi
@@ -53,7 +53,7 @@ class LRUDict(collections.OrderedDict[tuple[float, float], _VT], Generic[_VT]):
     def __init__(self, /, max_size: int) -> None: ...
     @override
     # pyrefly: ignore [bad-override]
-    def update(self, other: Never) -> NoReturn: ...  # type: ignore[override]  # pyright: ignore[reportIncompatibleMethodOverride]  # ty: ignore[invalid-method-override]
+    def update(self, other: Never, /, **kwargs: Never) -> NoReturn: ...  # type: ignore[override]  # pyright: ignore[reportIncompatibleMethodOverride]  # ty: ignore[invalid-method-override]
 
 # undocumented
 class SemiInfiniteFunc(_InfiniteFunc[_NDT_co], Generic[_NDT_co]):

--- a/scipy-stubs/integrate/_tanhsinh.pyi
+++ b/scipy-stubs/integrate/_tanhsinh.pyi
@@ -1,5 +1,6 @@
-from collections.abc import Callable
-from typing import Any, Concatenate, Final, Generic, Literal, TypeAlias, TypedDict, overload, type_check_only
+from _typeshed import Unused
+from collections.abc import Callable, Mapping
+from typing import Any, Concatenate, Final, Generic, Literal, TypedDict, overload, type_check_only
 from typing_extensions import TypeVar
 
 import numpy as np
@@ -10,20 +11,18 @@ from scipy._lib._util import _RichResult
 
 __all__ = ["nsum"]
 
-_ScalarT = TypeVar("_ScalarT", bound=np.generic)
-_InT = TypeVar("_InT")
-_ResultT = TypeVar("_ResultT")
+type _ArgsND = tuple[onp.ToScalar | onp.ToArrayND, ...]
+type _KwargsND = Mapping[str, onp.ToScalar | onp.ToArrayND]
+type _Callback[ResultT] = Callable[[ResultT], Unused]
+
+type _Integrand[InT, ScalarT: np.generic] = Callable[Concatenate[InT, ...], onp.ArrayND[ScalarT]]
+type _IntegrandReal = _Integrand[onp.ArrayND[np.float64], npc.floating]
+type _IntegrandComplex = _Integrand[onp.ArrayND[np.float64] | onp.ArrayND[np.complex128], npc.complexfloating]
+
 _ResultT_co = TypeVar("_ResultT_co", covariant=True)
 _SuccessT_co = TypeVar("_SuccessT_co", covariant=True)
 _StatusT_co = TypeVar("_StatusT_co", covariant=True)
 _MaxLevelT_co = TypeVar("_MaxLevelT_co", covariant=True)
-
-_ArgsND: TypeAlias = tuple[onp.ToScalar | onp.ToArrayND, ...]
-_Callback: TypeAlias = Callable[[_ResultT], object]  # return value is ignored
-
-_Integrand: TypeAlias = Callable[Concatenate[_InT, ...], onp.ArrayND[_ScalarT]]
-_IntegrandReal: TypeAlias = _Integrand[onp.ArrayND[np.float64], npc.floating]
-_IntegrandComplex: TypeAlias = _Integrand[onp.ArrayND[np.float64] | onp.ArrayND[np.complex128], npc.complexfloating]
 
 @type_check_only
 class _TanhSinhResult(
@@ -37,15 +36,15 @@ class _TanhSinhResult(
     nfev: _StatusT_co
     maxlevel: _MaxLevelT_co
 
-_TanhSinhResult0: TypeAlias = _TanhSinhResult[_ScalarT, np.bool_, np.int32, np.int64]
-_TanhSinhResultN: TypeAlias = _TanhSinhResult[
-    onp.ArrayND[_ScalarT],
+type _TanhSinhResult0[ScalarT: np.generic] = _TanhSinhResult[ScalarT, np.bool_, np.int32, np.int64]
+type _TanhSinhResultN[ScalarT: np.generic] = _TanhSinhResult[
+    onp.ArrayND[ScalarT],
     onp.ArrayND[np.bool_],
     onp.ArrayND[np.int32],
     onp.ArrayND[np.int64],
 ]  # fmt: skip
-_TanhSinhResultN_: TypeAlias = _TanhSinhResult[
-    onp.ArrayND[_ScalarT] | Any,
+type _TanhSinhResultN_[ScalarT: np.generic] = _TanhSinhResult[
+    onp.ArrayND[ScalarT] | Any,
     onp.ArrayND[np.bool_] | Any,
     onp.ArrayND[np.int32] | Any,
     onp.ArrayND[np.int64] | Any,
@@ -82,6 +81,7 @@ def tanhsinh(
     b: onp.ToFloat,
     *,
     args: tuple[onp.ToScalar, ...] = (),
+    kwargs: Mapping[str, onp.ToScalar] | None = None,
     log: bool = False,
     maxlevel: int | None = None,
     minlevel: int | None = 2,
@@ -97,6 +97,7 @@ def tanhsinh(
     b: onp.ToFloatND,
     *,
     args: _ArgsND = (),
+    kwargs: _KwargsND | None = None,
     log: bool = False,
     maxlevel: int | None = None,
     minlevel: int | None = 2,
@@ -112,6 +113,7 @@ def tanhsinh(
     b: onp.ToFloat | onp.ToFloatND,
     *,
     args: _ArgsND = (),
+    kwargs: _KwargsND | None = None,
     log: bool = False,
     maxlevel: int | None = None,
     minlevel: int | None = 2,
@@ -127,6 +129,7 @@ def tanhsinh(
     b: onp.ToFloat | onp.ToFloatND,
     *,
     args: _ArgsND = (),
+    kwargs: _KwargsND | None = None,
     log: bool = False,
     maxlevel: int | None = None,
     minlevel: int | None = 2,
@@ -142,6 +145,7 @@ def tanhsinh(
     b: onp.ToFloat,
     *,
     args: tuple[onp.ToScalar, ...] = (),
+    kwargs: Mapping[str, onp.ToScalar] | None = None,
     log: bool = False,
     maxlevel: int | None = None,
     minlevel: int | None = 2,
@@ -157,6 +161,7 @@ def tanhsinh(
     b: onp.ToFloatND,
     *,
     args: _ArgsND = (),
+    kwargs: _KwargsND | None = None,
     log: bool = False,
     maxlevel: int | None = None,
     minlevel: int | None = 2,
@@ -172,6 +177,7 @@ def tanhsinh(
     b: onp.ToFloat | onp.ToFloatND,
     *,
     args: _ArgsND = (),
+    kwargs: _KwargsND | None = None,
     log: bool = False,
     maxlevel: int | None = None,
     minlevel: int | None = 2,
@@ -187,6 +193,7 @@ def tanhsinh(
     b: onp.ToFloat | onp.ToFloatND,
     *,
     args: _ArgsND = (),
+    kwargs: _KwargsND | None = None,
     log: bool = False,
     maxlevel: int | None = None,
     minlevel: int | None = 2,
@@ -205,6 +212,7 @@ def nsum(
     *,
     step: onp.ToFloat = 1,
     args: tuple[onp.ToScalar, ...] = (),
+    kwargs: Mapping[str, onp.ToScalar] | None = None,
     log: bool = False,
     maxterms: int = 0x10_00_00,
     tolerances: _Tolerances | None = None,
@@ -217,6 +225,7 @@ def nsum(
     *,
     step: onp.ToFloat | onp.ToFloatND = 1,
     args: _ArgsND = (),
+    kwargs: _KwargsND | None = None,
     log: bool = False,
     maxterms: int = 0x10_00_00,
     tolerances: _Tolerances | None = None,
@@ -229,6 +238,7 @@ def nsum(
     *,
     step: onp.ToFloat | onp.ToFloatND = 1,
     args: _ArgsND = (),
+    kwargs: _KwargsND | None = None,
     log: bool = False,
     maxterms: int = 0x10_00_00,
     tolerances: _Tolerances | None = None,
@@ -241,6 +251,7 @@ def nsum(
     *,
     step: onp.ToFloatND,
     args: _ArgsND = (),
+    kwargs: _KwargsND | None = None,
     log: bool = False,
     maxterms: int = 0x10_00_00,
     tolerances: _Tolerances | None = None,


### PR DESCRIPTION
THe only public API changes are for `tanhsinh` and `nsum`, which gained a new `kwargs` kwarg, as described in the relnotes.

towards #1614