### PR TITLE
👽️ `linalg.bandwidth`: sync with upstream (backwards incompatible type change)

### DIFF
--- a/.mypyignore
+++ b/.mypyignore
@@ -20,8 +20,6 @@ scipy\.stats\.(_new_distributions\.)?Normal\.__new__
 ###
 # TODO: 1.18.0rc1
 
-scipy.linalg._cythonized_array_utils.__all__
-scipy.linalg._cythonized_array_utils.bandwidth
 scipy.linalg._decomp.eigvals
 scipy.linalg._decomp_lu_cython
 scipy.linalg._matfuncs.logm
@@ -29,8 +27,6 @@ scipy.linalg._matfuncs.signm
 scipy.linalg._matfuncs.sqrtm
 scipy.linalg._matfuncs_expm
 scipy.linalg._matfuncs_schur_sqrtm
-scipy.linalg._misc.__all__
-scipy.linalg._misc.bandwidth
 scipy.linalg._testutils._FakeMatrix.shape
 scipy.linalg._testutils._FakeMatrix2.shape
 scipy.linalg.basic.get_lapack_funcs

--- a/scipy-stubs/linalg/__init__.pyi
+++ b/scipy-stubs/linalg/__init__.pyi
@@ -29,7 +29,7 @@ from ._basic import (
     solve_triangular,
     solveh_banded,
 )
-from ._cythonized_array_utils import bandwidth, ishermitian, issymmetric
+from ._cythonized_array_utils import ishermitian, issymmetric
 from ._decomp import (
     cdf2rdf,
     eig,
@@ -69,7 +69,7 @@ from ._matfuncs import (
     tanhm,
     tanm,
 )
-from ._misc import LinAlgError, LinAlgWarning, norm
+from ._misc import LinAlgError, LinAlgWarning, bandwidth, norm
 from ._procrustes import orthogonal_procrustes
 from ._sketches import clarkson_woodruff_transform
 from ._solvers import (

--- a/scipy-stubs/linalg/_cythonized_array_utils.pyi
+++ b/scipy-stubs/linalg/_cythonized_array_utils.pyi
@@ -4,11 +4,10 @@ import numpy as np
 import optype.numpy as onp
 import optype.numpy.compat as npc
 
-__all__ = ["bandwidth", "ishermitian", "issymmetric"]
+__all__ = ["ishermitian", "issymmetric"]
 
 # see `scipy/linalg/_cythonized_array_utils.pxd`
 _Numeric: TypeAlias = npc.integer | np.float32 | np.float64 | npc.floating80 | np.complex64 | np.complex128
 
-def bandwidth(a: onp.ArrayND[_Numeric]) -> tuple[int, int]: ...
 def issymmetric(a: onp.ArrayND[_Numeric], atol: float | None = None, rtol: float | None = None) -> bool: ...
 def ishermitian(a: onp.ArrayND[_Numeric], atol: float | None = None, rtol: float | None = None) -> bool: ...

--- a/scipy-stubs/linalg/_misc.pyi
+++ b/scipy-stubs/linalg/_misc.pyi
@@ -1,11 +1,11 @@
-from typing import Any, Literal, SupportsIndex, TypeAlias, TypeVar, overload
+from typing import Any, Literal, Never, SupportsIndex, TypeAlias, TypeVar, overload
 
 import numpy as np
 import optype.numpy as onp
 import optype.numpy.compat as npc
 from numpy.linalg import LinAlgError
 
-__all__ = ["LinAlgError", "LinAlgWarning", "norm"]
+__all__ = ["LinAlgError", "LinAlgWarning", "bandwidth", "norm"]
 
 _Inf: TypeAlias = float
 _Order: TypeAlias = Literal["fro", "nuc", 0, 1, -1, 2, -2] | _Inf
@@ -172,3 +172,13 @@ def norm(
 
 #
 def _datacopied(arr: onp.ArrayND[Any], original: onp.CanArrayND[Any]) -> bool: ...  # undocumented
+
+#
+@overload  # pyright workaround
+def bandwidth(a: onp.ArrayND[npc.number, tuple[Never, Never, Never, Never]]) -> tuple[np.int64 | Any, np.int64 | Any]: ...
+@overload
+def bandwidth(a: onp.ToComplexStrict2D) -> tuple[np.int64, np.int64]: ...
+@overload
+def bandwidth(a: onp.ToComplexStrict3D) -> tuple[onp.Array1D[np.int64], onp.Array1D[np.int64]]: ...
+@overload
+def bandwidth(a: onp.ToComplexND) -> tuple[onp.ArrayND[np.int64] | Any, onp.ArrayND[np.int64] | Any]: ...

--- a/tests/linalg/test__cythonized_array_utils.pyi
+++ b/tests/linalg/test__cythonized_array_utils.pyi
@@ -5,18 +5,12 @@ from typing import assert_type
 import numpy as np
 import optype.numpy as onp
 
-from scipy.linalg import bandwidth, ishermitian, issymmetric
+from scipy.linalg import ishermitian, issymmetric
 
 ###
 
 f64_2d: onp.Array2D[np.float64]
 c128_2d: onp.Array2D[np.complex128]
-
-###
-# bandwidth
-
-assert_type(bandwidth(f64_2d), tuple[int, int])
-assert_type(bandwidth(c128_2d), tuple[int, int])
 
 ###
 # issymmetric

--- a/tests/linalg/test__misc.pyi
+++ b/tests/linalg/test__misc.pyi
@@ -5,7 +5,7 @@ from typing import assert_type
 import numpy as np
 import optype.numpy as onp
 
-from scipy.linalg import norm
+from scipy.linalg import bandwidth, norm
 
 ###
 
@@ -16,6 +16,12 @@ py_c: complex
 f32: np.float32
 f80: np.float128
 
+f64_2d: onp.Array2D[np.float64]
+c128_2d: onp.Array2D[np.complex128]
+
+f64_3d: onp.Array3D[np.float64]
+c128_3d: onp.Array3D[np.complex128]
+
 f64_nd: onp.ArrayND[np.float64]
 f32_nd: onp.ArrayND[np.float32]
 f80_nd: onp.ArrayND[np.float128]
@@ -24,6 +30,14 @@ c128_nd: onp.ArrayND[np.complex128]
 
 py_f_1d: list[float]
 py_f_2d: list[list[float]]
+
+###
+# bandwidth
+
+assert_type(bandwidth(f64_2d), tuple[np.int64, np.int64])
+assert_type(bandwidth(f64_3d), tuple[onp.Array1D[np.int64], onp.Array1D[np.int64]])
+assert_type(bandwidth(c128_2d), tuple[np.int64, np.int64])
+assert_type(bandwidth(c128_3d), tuple[onp.Array1D[np.int64], onp.Array1D[np.int64]])
 
 ###
 # norm


### PR DESCRIPTION
Several upstream changes for `scipy.linalg.bandwith`:

- The implementation moved from `_cythonized_array_utils` to `linalg._misc` 
  - No problems here
- Batching for >2-d input
  - Not mentioned in the [rc1 relnotes](https://github.com/scipy/scipy/releases/tag/v1.18.0rc1)
- For 2-D input, the return type changed from `(int, int)` to `(np.int64, np.int64)`
  - Also not mentioned in the [rc1 relnotes](https://github.com/scipy/scipy/releases/tag/v1.18.0rc1).
  - From a typing perspective, this is a **backwards-incompatible breaking change**, because even though `np.int64` and `int` are mostly ducktype-compatible, they are incompatible nominal types. This is likely to lead to new typing errors, because  `a: int = np.int64(1)` is invalid, and so is `b: np.int64 = 1`. So "swapping" `int` for `int64` or vice-versa won't be accepted by type-checkers [^1]. 

I think it would be best to revert the `int`/`np.int64` return type change. The new batching support is probably also worth mentioning.

Towards #1614

[^1]: For `float`/`np.float64` this wouldn't have been an issue, because unlike `int`/`np.int64`, `np.float64` subclasses `builtins.float`. So `x: float = np.float64(0.78)` is accepted by all type-checkers.

---

**Update**: I did a quick github code search ([repro](https://github.com/search?q=%2Flinalg%5C.bandwidth%5C%28%2F+language%3APython++NOT+is%3Aarchived+NOT+is%3Afork&type=code)), and literally the first hit is an example of where this will cause typing errors: https://github.com/NatLabRockies/batmods-lite/blob/7fdb441d678df459a87834b32e6dedc3dc4cee12/src/bmlite/_core/_idasolver.py#L111