### PR TITLE
✅ `stats`: add test for `sampling.RatioUniforms`

### DIFF
--- a/tests/stats/test_sampling.pyi
+++ b/tests/stats/test_sampling.pyi
@@ -1,0 +1,15 @@
+# type-tests for `stats/_sampling.pyi`
+
+from typing import assert_type
+
+import numpy as np
+import optype.numpy as onp
+
+from scipy.stats.sampling import RatioUniforms
+
+def _pdf(x: onp.ToFloat) -> onp.ToFloat: ...
+
+_ru = RatioUniforms(_pdf, umax=1.0, vmin=-1.0, vmax=1.0)
+
+assert_type(_ru, RatioUniforms)
+assert_type(_ru.rvs(size=3), np.float64 | onp.ArrayND[np.float64])


### PR DESCRIPTION

toward #1099 

covers

- scipy.stats.sampling.RatioUniforms
