### PR TITLE
🗑️ `spatial`: deprecate `minkowski_distance[_p]` and `distance_matrix`

### DIFF
--- a/scipy-stubs/spatial/_kdtree.pyi
+++ b/scipy-stubs/spatial/_kdtree.pyi
@@ -1,5 +1,5 @@
 from typing import Final, Generic, Self, SupportsIndex, overload, override
-from typing_extensions import TypeVar
+from typing_extensions import TypeVar, deprecated
 
 import numpy as np
 import optype.numpy as onp
@@ -106,22 +106,28 @@ class KDTree(cKDTree[_BoxSizeT_co, _BoxSizeDataT_co], Generic[_BoxSizeT_co, _Box
     ) -> tuple[float, np.intp] | tuple[onp.ArrayND[np.float64], onp.ArrayND[np.intp]]: ...
 
 @overload
+@deprecated("This function is deprecated in favor of `scipy.spatial.distance.minkowski` and will be removed in SciPy 1.20.0.")
 def minkowski_distance_p(x: onp.ToFloatND, y: onp.ToFloatND, p: float = 2.0) -> onp.ArrayND[np.float64]: ...
 @overload
+@deprecated("This function is deprecated in favor of `scipy.spatial.distance.minkowski` and will be removed in SciPy 1.20.0.")
 def minkowski_distance_p(x: onp.ToComplexND, y: onp.ToComplexND, p: float = 2.0) -> onp.ArrayND[np.float64 | np.complex128]: ...
 
 #
 @overload
+@deprecated("This function is deprecated in favor of `scipy.spatial.distance.minkowski` and will be removed in SciPy 1.20.0.")
 def minkowski_distance(x: onp.ToFloatND, y: onp.ToFloatND, p: float = 2.0) -> onp.ArrayND[np.float64]: ...
 @overload
+@deprecated("This function is deprecated in favor of `scipy.spatial.distance.minkowski` and will be removed in SciPy 1.20.0.")
 def minkowski_distance(x: onp.ToComplexND, y: onp.ToComplexND, p: float = 2.0) -> onp.ArrayND[np.float64 | np.complex128]: ...
 
 #
 @overload
+@deprecated("This function is deprecated in favor of `scipy.spatial.distance.cdist` and will be removed in SciPy 1.20.0.")
 def distance_matrix(
     x: onp.ToFloatND, y: onp.ToFloatND, p: float = 2.0, threshold: int = 1_000_000
 ) -> onp.Array2D[np.float64]: ...
 @overload
+@deprecated("This function is deprecated in favor of `scipy.spatial.distance.cdist` and will be removed in SciPy 1.20.0.")
 def distance_matrix(
     x: onp.ToComplexND, y: onp.ToComplexND, p: float = 2.0, threshold: int = 1_000_000
 ) -> onp.Array2D[np.float64 | np.complex128]: ...

--- a/tests/spatial/test__kdtree.pyi
+++ b/tests/spatial/test__kdtree.pyi
@@ -135,17 +135,17 @@ assert_type(_tree.sparse_distance_matrix(_tree, max_distance=1.0, output_type="n
 ###
 # minkowski_distance_p
 
-assert_type(minkowski_distance_p(_f64_1d, _f64_1d), onp.ArrayND[np.float64])
-assert_type(minkowski_distance_p(_c128_1d, _c128_1d), onp.ArrayND[np.float64 | np.complex128])
+assert_type(minkowski_distance_p(_f64_1d, _f64_1d), onp.ArrayND[np.float64])  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]
+assert_type(minkowski_distance_p(_c128_1d, _c128_1d), onp.ArrayND[np.float64 | np.complex128])  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]
 
 ###
 # minkowski_distance
 
-assert_type(minkowski_distance(_f64_1d, _f64_1d), onp.ArrayND[np.float64])
-assert_type(minkowski_distance(_c128_1d, _c128_1d), onp.ArrayND[np.float64 | np.complex128])
+assert_type(minkowski_distance(_f64_1d, _f64_1d), onp.ArrayND[np.float64])  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]
+assert_type(minkowski_distance(_c128_1d, _c128_1d), onp.ArrayND[np.float64 | np.complex128])  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]
 
 ###
 # distance_matrix
 
-assert_type(distance_matrix(_f64_2d, _f64_2d), onp.Array2D[np.float64])
-assert_type(distance_matrix(_c128_2d, _c128_2d), onp.Array2D[np.float64 | np.complex128])
+assert_type(distance_matrix(_f64_2d, _f64_2d), onp.Array2D[np.float64])  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]
+assert_type(distance_matrix(_c128_2d, _c128_2d), onp.Array2D[np.float64 | np.complex128])  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]


### PR DESCRIPTION
From the 1.18.0rc1 relnotes (https://github.com/scipy/scipy/releases/tag/v1.18.0rc1):

> `scipy.spatial.minkowsi_distance`, `scipy.spatial.minkowsi_distance_p`,
and `scipy.spatial.distance_matrix` have been deprecated in favor of
other superior functions.

towards #1614