### PR TITLE
🗑️ `spatial`: deprecate `tsearch`

### DIFF
--- a/scipy-stubs/spatial/_qhull.pyi
+++ b/scipy-stubs/spatial/_qhull.pyi
@@ -1,5 +1,5 @@
 from typing import Never, Protocol, final, overload, type_check_only
-from typing_extensions import TypeVar
+from typing_extensions import TypeVar, deprecated
 
 import numpy as np
 import optype.numpy as onp
@@ -248,14 +248,18 @@ class HalfspaceIntersection(_QhullUser):
     ) -> None: ...
     def add_halfspaces(self, /, halfspaces: onp.ToFloat2D, restart: bool = False) -> None: ...
 
-# same as `tri.find_simplex(xi)`
 @overload
+@deprecated("`tsearch` is deprecated in favor of `Delaunay.find_simplex` and will be removed in SciPy 1.22.0.")
 def tsearch(tri: Delaunay, xi: _ToArrayStrictND) -> onp.ArrayND[np.int32]: ...
 @overload
+@deprecated("`tsearch` is deprecated in favor of `Delaunay.find_simplex` and will be removed in SciPy 1.22.0.")
 def tsearch(tri: Delaunay, xi: onp.ToFloatStrict1D) -> onp.Array0D[np.int32]: ...
 @overload
+@deprecated("`tsearch` is deprecated in favor of `Delaunay.find_simplex` and will be removed in SciPy 1.22.0.")
 def tsearch(tri: Delaunay, xi: onp.ToFloatStrict2D) -> onp.Array1D[np.int32]: ...
 @overload
+@deprecated("`tsearch` is deprecated in favor of `Delaunay.find_simplex` and will be removed in SciPy 1.22.0.")
 def tsearch(tri: Delaunay, xi: onp.ToFloatStrict3D) -> onp.Array2D[np.int32]: ...
 @overload
+@deprecated("`tsearch` is deprecated in favor of `Delaunay.find_simplex` and will be removed in SciPy 1.22.0.")
 def tsearch(tri: Delaunay, xi: onp.ToFloatND) -> onp.ArrayND[np.int32]: ...

--- a/tests/spatial/test__qhull.pyi
+++ b/tests/spatial/test__qhull.pyi
@@ -108,7 +108,7 @@ assert_type(_hsi.dual_vertices, onp.Array1D[np.int32])
 ###
 # tsearch
 
-assert_type(tsearch(_tri, _f64_1d), onp.Array0D[np.int32])
-assert_type(tsearch(_tri, _f64_2d), onp.Array1D[np.int32])
-assert_type(tsearch(_tri, _f64_3d), onp.Array2D[np.int32])
-assert_type(tsearch(_tri, _f64_nd), onp.ArrayND[np.int32])
+assert_type(tsearch(_tri, _f64_1d), onp.Array0D[np.int32])  # pyright: ignore[reportDeprecated] # pyrefly:ignore[deprecated]
+assert_type(tsearch(_tri, _f64_2d), onp.Array1D[np.int32])  # pyright: ignore[reportDeprecated] # pyrefly:ignore[deprecated]
+assert_type(tsearch(_tri, _f64_3d), onp.Array2D[np.int32])  # pyright: ignore[reportDeprecated] # pyrefly:ignore[deprecated]
+assert_type(tsearch(_tri, _f64_nd), onp.ArrayND[np.int32])  # pyright: ignore[reportDeprecated] # pyrefly:ignore[deprecated]


### PR DESCRIPTION
From the 1.18.0rc1 relnotes (https://github.com/scipy/scipy/releases/tag/v1.18.0rc1):

> `scipy.spatial.tsearch` has been deprecated because it duplicates functionality
more conveniently provided within the `Delaunay` class proper.

towards #1614