### PR TITLE
🗑️ `interpolate`: deprecate `pade`, `lagrange`, `approximate_taylor_polynomial`

### DIFF
--- a/scipy-stubs/interpolate/_interpolate.pyi
+++ b/scipy-stubs/interpolate/_interpolate.pyi
@@ -20,7 +20,7 @@ type _Extrapolate = Literal["periodic"] | bool
 type _Interp1dKind = Literal["linear", "nearest", "nearest-up", "zero", "slinear", "quadratic", "cubic", "previous", "next"]
 type _Interp1dFillValue = onp.ToFloat | onp.ToFloatND | tuple[onp.ToFloat | onp.ToFloatND, onp.ToFloat | onp.ToFloatND]
 
-type _Array2ND[_NumberT: npc.number] = onp.Array[tuple[int, int, *tuple[Any, ...]], _NumberT]
+type _Array2ND[NumberT: npc.number] = onp.Array[tuple[int, int, *tuple[Any, ...]], NumberT]
 
 ###
 
@@ -249,4 +249,7 @@ class NdPPoly(Generic[_CT_co]):
     ) -> onp.ArrayND[_CT_co]: ...
 
 #
+@deprecated(
+    "This function is deprecated and will be removed in SciPy 1.20.0. Use `scipy.interpolate.BarycentricInterpolator` instead."
+)
 def lagrange(x: onp.ToComplex1D, w: onp.ToComplex1D) -> np.poly1d: ...

--- a/scipy-stubs/interpolate/_pade.pyi
+++ b/scipy-stubs/interpolate/_pade.pyi
@@ -1,6 +1,9 @@
+from typing_extensions import deprecated
+
 import numpy as np
 import optype.numpy as onp
 
 __all__ = ["pade"]
 
+@deprecated("This function is deprecated and will be removed in SciPy 1.20.0. Use `mpmath.pade` instead.")
 def pade(an: onp.ToComplex1D, m: onp.ToJustInt, n: onp.ToJustInt | None = None) -> tuple[np.poly1d, np.poly1d]: ...

--- a/scipy-stubs/interpolate/_polyint.pyi
+++ b/scipy-stubs/interpolate/_polyint.pyi
@@ -2,7 +2,7 @@ import types
 from _typeshed import Incomplete
 from collections.abc import Callable, Sequence
 from typing import Any, ClassVar, Final, Generic, Protocol, Self, SupportsIndex, final, overload, override, type_check_only
-from typing_extensions import TypeIs, TypeVar
+from typing_extensions import TypeIs, TypeVar, deprecated
 
 import numpy as np
 import optype.numpy as onp
@@ -235,6 +235,7 @@ def krogh_interpolate(
 ) -> onp.ArrayND[np.float64 | np.complex128]: ...
 
 #
+@deprecated("This function is deprecated and will be removed in SciPy 1.20.0.")
 def approximate_taylor_polynomial(
     f: Callable[[onp.Array1D[np.float64]], onp.ToComplexND] | np.ufunc,
     x: onp.ToFloat,

--- a/tests/interpolate/test_interpolate.pyi
+++ b/tests/interpolate/test_interpolate.pyi
@@ -46,4 +46,4 @@ _interp2d_type: type[interp2d]  # pyright: ignore[reportDeprecated]
 ###
 # lagrange
 
-assert_type(lagrange(_f64_1d, _f64_1d), np.poly1d)
+assert_type(lagrange(_f64_1d, _f64_1d), np.poly1d)  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]

--- a/tests/interpolate/test_pade.pyi
+++ b/tests/interpolate/test_pade.pyi
@@ -7,6 +7,6 @@ from scipy.interpolate import pade
 coeffs: list[float]
 coeffs_c: list[complex]
 
-assert_type(pade(coeffs, 3), tuple[np.poly1d, np.poly1d])
-assert_type(pade(coeffs, 3, n=2), tuple[np.poly1d, np.poly1d])
-assert_type(pade(coeffs_c, 3), tuple[np.poly1d, np.poly1d])
+assert_type(pade(coeffs, 3), tuple[np.poly1d, np.poly1d])  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]
+assert_type(pade(coeffs, 3, n=2), tuple[np.poly1d, np.poly1d])  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]
+assert_type(pade(coeffs_c, 3), tuple[np.poly1d, np.poly1d])  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]

--- a/tests/interpolate/test_polyint.pyi
+++ b/tests/interpolate/test_polyint.pyi
@@ -78,4 +78,4 @@ assert_type(bary_c_f32.derivatives(0), np.ndarray[tuple[Any, ...], np.dtype[np.c
 ###
 # approximate_taylor_polynomial
 
-assert_type(approximate_taylor_polynomial(np.sin, 0.0, 3, 1.0), np.poly1d)
+assert_type(approximate_taylor_polynomial(np.sin, 0.0, 3, 1.0), np.poly1d)  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]


### PR DESCRIPTION
From the 1.18.0rc1 relnotes (https://github.com/scipy/scipy/releases/tag/v1.18.0rc1):

> The following functions have been deprecated because they were deemed
not practically useful: `scipy.interpolate.pade`, `scipy.interpolate.lagrange`,
and `scipy.interpolate.approximate_taylor_polynomial`.

towards #1614