### PR TITLE
🗑️ `io`: deprecate `spmatrix` parameter default

### DIFF
--- a/scipy-stubs/io/_harwell_boeing/hb.pyi
+++ b/scipy-stubs/io/_harwell_boeing/hb.pyi
@@ -1,7 +1,8 @@
 from typing import IO, Any, Final, Literal, LiteralString, Protocol, Self, overload, type_check_only
+from typing_extensions import deprecated
 
 import numpy as np
-import optype.numpy as onp
+import optype as op
 import optype.numpy.compat as npc
 import optype.typing as opt
 
@@ -11,6 +12,8 @@ from scipy.sparse import csc_array, csc_matrix, sparray, spmatrix
 __all__ = ["hb_read", "hb_write"]
 
 ###
+
+type _NoValueType = op.JustObject
 
 type _ValueType = Literal["real", "complex", "pattern", "integer"]
 type _Structure = Literal["symmetric", "unsymmetric", "hermitian", "skewsymmetric", "rectangular"]
@@ -123,9 +126,12 @@ def _write_data(m: sparray | spmatrix, fid: IO[str], header: HBInfo) -> None: ..
 
 #
 @overload
-def hb_read(path_or_open_file: FileLike[str], *, spmatrix: onp.ToTrue = True) -> csc_matrix[Any]: ...
+@deprecated("The default value for `spmatrix` is changing to False in v1.20.")
+def hb_read(path_or_open_file: FileLike[str], *, spmatrix: _NoValueType = ...) -> csc_matrix[Any]: ...
 @overload
-def hb_read(path_or_open_file: FileLike[str], *, spmatrix: onp.ToFalse) -> csc_array[Any]: ...
+def hb_read(path_or_open_file: FileLike[str], *, spmatrix: Literal[True]) -> csc_matrix[Any]: ...
+@overload
+def hb_read(path_or_open_file: FileLike[str], *, spmatrix: Literal[False]) -> csc_array[Any]: ...
 
 #
 def hb_write(path_or_open_file: FileLike[str], m: sparray | spmatrix, hb_info: HBInfo | None = None) -> None: ...

--- a/scipy-stubs/io/_mmio.pyi
+++ b/scipy-stubs/io/_mmio.pyi
@@ -1,5 +1,7 @@
 from typing import Any, ClassVar, Literal, TypedDict, Unpack, overload, type_check_only
+from typing_extensions import deprecated
 
+import optype as op
 import optype.numpy as onp
 
 from ._fast_matrix_market import mminfo, mmread, mmwrite
@@ -14,6 +16,8 @@ type _Format = Literal["coordinate", "array"]
 type _Field = Literal["real", "complex", "pattern", "integer"]
 type _Symmetry = Literal["general", "symmetric", "skew-symmetric", "hermitian"]
 type _Info = tuple[int, int, int, _Format, _Field, _Symmetry]
+
+type _NoValueType = op.JustObject
 
 @type_check_only
 class _MMFileKwargs(TypedDict, total=False):
@@ -68,7 +72,10 @@ class MMFile:
 
     # dtype is either intp, uint64, float64, or complex128, depending on the field
     @overload
-    def read(self, /, source: FileLike[bytes], *, spmatrix: Literal[True] = True) -> onp.Array2D[Any] | coo_matrix[Any]: ...
+    @deprecated("The default value for `spmatrix` is changing to False in v1.20.")
+    def read(self, /, source: FileLike[bytes], *, spmatrix: _NoValueType = ...) -> onp.Array2D[Any] | coo_matrix[Any]: ...
+    @overload
+    def read(self, /, source: FileLike[bytes], *, spmatrix: Literal[True]) -> onp.Array2D[Any] | coo_matrix[Any]: ...
     @overload
     def read(
         self, /, source: FileLike[bytes], *, spmatrix: Literal[False]

--- a/scipy-stubs/io/matlab/_mio.pyi
+++ b/scipy-stubs/io/matlab/_mio.pyi
@@ -1,10 +1,12 @@
 from collections.abc import Mapping
-from typing import Any, Literal, TypedDict, Unpack, type_check_only
+from typing import Any, Literal, TypedDict, Unpack, overload, type_check_only
+from typing_extensions import deprecated
 
 import optype as op
 
 from ._miobase import MatFileReader
 from scipy.io._typing import ByteOrder, FileName
+from scipy.sparse import coo_array, coo_matrix, csc_array, csc_matrix
 
 __all__ = ["loadmat", "savemat", "whosmat"]
 
@@ -50,14 +52,34 @@ def mat_reader_factory(
 ) -> tuple[MatFileReader, bool]: ...
 
 #
+@overload
+@deprecated("The default value for `spmatrix` is changing to False in v1.20.")
 def loadmat(
     file_name: FileName,
     mdict: Mapping[str, object] | None = None,
     appendmat: bool = True,
     *,
-    spmatrix: bool | _NoValueType = ...,
+    spmatrix: _NoValueType = ...,
     **kwargs: Unpack[_ReaderKwargs],
-) -> dict[str, Any]: ...
+) -> dict[str, csc_matrix[Any] | coo_matrix[Any]]: ...
+@overload
+def loadmat(
+    file_name: FileName,
+    mdict: Mapping[str, object] | None = None,
+    appendmat: bool = True,
+    *,
+    spmatrix: Literal[True],
+    **kwargs: Unpack[_ReaderKwargs],
+) -> dict[str, csc_matrix[Any] | coo_matrix[Any]]: ...
+@overload
+def loadmat(
+    file_name: FileName,
+    mdict: Mapping[str, object] | None = None,
+    appendmat: bool = True,
+    *,
+    spmatrix: Literal[False],
+    **kwargs: Unpack[_ReaderKwargs],
+) -> dict[str, csc_array[Any] | coo_array[Any, tuple[int, int]]]: ...
 
 #
 def savemat(

--- a/tests/io/test_harwell_boeing.pyi
+++ b/tests/io/test_harwell_boeing.pyi
@@ -13,7 +13,7 @@ _csc_array: csc_array[npc.floating]
 ###
 
 # hb_read
-assert_type(hb_read("file.hb"), csc_matrix)
+assert_type(hb_read("file.hb"), csc_matrix)  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]
 assert_type(hb_read("file.hb", spmatrix=True), csc_matrix)
 assert_type(hb_read("file.hb", spmatrix=False), csc_array)
 

--- a/tests/io/test_matlab.pyi
+++ b/tests/io/test_matlab.pyi
@@ -1,23 +1,25 @@
 from typing import Any, Literal, assert_type
 
 from scipy.io import loadmat, savemat, whosmat
+from scipy.sparse import coo_array, coo_matrix, csc_array, csc_matrix
 
 ###
 
 # loadmat
-assert_type(loadmat("file.mat"), dict[str, Any])
-assert_type(loadmat("file.mat", mdict={}), dict[str, Any])
-assert_type(loadmat("file.mat", appendmat=False), dict[str, Any])
-assert_type(loadmat("file.mat", spmatrix=False), dict[str, Any])
-assert_type(loadmat("file.mat", byte_order="native"), dict[str, Any])
-assert_type(loadmat("file.mat", mat_dtype=True), dict[str, Any])
-assert_type(loadmat("file.mat", squeeze_me=False), dict[str, Any])
-assert_type(loadmat("file.mat", chars_as_strings=False), dict[str, Any])
-assert_type(loadmat("file.mat", matlab_compatible=True), dict[str, Any])
-assert_type(loadmat("file.mat", struct_as_record=True), dict[str, Any])
-assert_type(loadmat("file.mat", verify_compressed_data_integrity=True), dict[str, Any])
-assert_type(loadmat("file.mat", simplify_cells=True), dict[str, Any])
-assert_type(loadmat("file.mat", variable_names=("a", "b")), dict[str, Any])
+assert_type(loadmat("file.mat"), dict[str, csc_matrix | coo_matrix])  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]
+assert_type(loadmat("file.mat", mdict={}), dict[str, csc_matrix | coo_matrix])  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]
+assert_type(loadmat("file.mat", appendmat=False), dict[str, csc_matrix | coo_matrix])  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]
+assert_type(loadmat("file.mat", spmatrix=True), dict[str, csc_matrix | coo_matrix])
+assert_type(loadmat("file.mat", spmatrix=False), dict[str, csc_array | coo_array[Any, tuple[int, int]]])
+assert_type(loadmat("file.mat", byte_order="native"), dict[str, csc_matrix | coo_matrix])  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]
+assert_type(loadmat("file.mat", mat_dtype=True), dict[str, csc_matrix | coo_matrix])  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]
+assert_type(loadmat("file.mat", squeeze_me=False), dict[str, csc_matrix | coo_matrix])  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]
+assert_type(loadmat("file.mat", chars_as_strings=False), dict[str, csc_matrix | coo_matrix])  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]
+assert_type(loadmat("file.mat", matlab_compatible=True), dict[str, csc_matrix | coo_matrix])  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]
+assert_type(loadmat("file.mat", struct_as_record=True), dict[str, csc_matrix | coo_matrix])  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]
+assert_type(loadmat("file.mat", verify_compressed_data_integrity=True), dict[str, csc_matrix | coo_matrix])  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]
+assert_type(loadmat("file.mat", simplify_cells=True), dict[str, csc_matrix | coo_matrix])  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]
+assert_type(loadmat("file.mat", variable_names=("a", "b")), dict[str, csc_matrix | coo_matrix])  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]
 
 # savemat
 assert_type(savemat("file.mat", {"": ""}), None)


### PR DESCRIPTION
From the 1.18.0rc1 relnotes (https://github.com/scipy/scipy/releases/tag/v1.18.0rc1):

> Setting `spmatrix=True` for the `scipy.io` readers `mmio`, `FFM`, `hb`,
and `matlab/_mio` is now deprecated, including when set as the default
value.

towards #1614