### PR TITLE
👽️ `stats.contingency.crosstab`: return `coo_array` instead of `coo_matrix`

### DIFF
--- a/scipy-stubs/stats/_crosstab.pyi
+++ b/scipy-stubs/stats/_crosstab.pyi
@@ -7,15 +7,15 @@ import optype.numpy as onp
 import optype.numpy.compat as npc
 
 from ._typing import BaseBunch
-from scipy.sparse import coo_matrix
+from scipy.sparse import coo_array
 
 ###
 
 _ScalarT_co = TypeVar("_ScalarT_co", bound=np.generic, default=Any, covariant=True)
 _CountT_co = TypeVar(
     "_CountT_co",
-    bound=onp.ArrayND[npc.integer] | coo_matrix[npc.integer],
-    default=onp.ArrayND[np.intp] | coo_matrix[np.intp],
+    bound=onp.ArrayND[npc.integer] | coo_array[npc.integer],
+    default=onp.ArrayND[np.intp] | coo_array[np.intp],
     covariant=True,
 )
 
@@ -49,7 +49,7 @@ def crosstab[ScalarT: np.generic](
     *,
     levels: onp.ToArrayND[ScalarT, ScalarT] | None = None,
     sparse: Literal[True],
-) -> CrosstabResult[ScalarT, coo_matrix[np.intp]]: ...
+) -> CrosstabResult[ScalarT, coo_array[np.intp]]: ...
 @overload  # bool
 def crosstab(  # type: ignore[overload-overlap]
     arg0: list[bool], /, *args: Sequence[bool], levels: Sequence[bool] | None = None, sparse: Literal[False] = False
@@ -57,7 +57,7 @@ def crosstab(  # type: ignore[overload-overlap]
 @overload  # bool, sparse=True
 def crosstab(  # type: ignore[overload-overlap]
     arg0: list[bool], arg1: Sequence[bool], /, *, levels: Sequence[bool] | None = None, sparse: Literal[True]
-) -> CrosstabResult[np.bool, coo_matrix[np.intp]]: ...
+) -> CrosstabResult[np.bool, coo_array[np.intp]]: ...
 @overload  # int
 def crosstab(
     arg0: list[int], /, *args: Sequence[int], levels: Sequence[int] | None = None, sparse: Literal[False] = False
@@ -65,7 +65,7 @@ def crosstab(
 @overload  # int, sparse=True
 def crosstab(
     arg0: list[int], arg1: Sequence[int], /, *, levels: Sequence[int] | None = None, sparse: Literal[True]
-) -> CrosstabResult[np.int_, coo_matrix[np.intp]]: ...
+) -> CrosstabResult[np.int_, coo_array[np.intp]]: ...
 @overload  # float
 def crosstab(
     arg0: list[float], /, *args: Sequence[float], levels: Sequence[float] | None = None, sparse: Literal[False] = False
@@ -73,7 +73,7 @@ def crosstab(
 @overload  # float, sparse=True
 def crosstab(
     arg0: list[float], arg1: Sequence[float], /, *, levels: Sequence[float] | None = None, sparse: Literal[True]
-) -> CrosstabResult[np.float64, coo_matrix[np.intp]]: ...
+) -> CrosstabResult[np.float64, coo_array[np.intp]]: ...
 @overload  # complex
 def crosstab(
     arg0: list[complex], /, *args: Sequence[complex], levels: Sequence[complex] | None = None, sparse: Literal[False] = False
@@ -81,7 +81,7 @@ def crosstab(
 @overload  # complex, sparse=True
 def crosstab(
     arg0: list[complex], arg1: Sequence[complex], /, *, levels: Sequence[complex] | None = None, sparse: Literal[True]
-) -> CrosstabResult[np.complex128, coo_matrix[np.intp]]: ...
+) -> CrosstabResult[np.complex128, coo_array[np.intp]]: ...
 @overload  # bytes
 def crosstab(
     arg0: Sequence[bytes], /, *args: Sequence[bytes], levels: Sequence[bytes] | None = None, sparse: Literal[False] = False
@@ -89,7 +89,7 @@ def crosstab(
 @overload  # bytes, sparse=True
 def crosstab(
     arg0: Sequence[bytes], arg1: Sequence[bytes], /, *, levels: Sequence[bytes] | None = None, sparse: Literal[True]
-) -> CrosstabResult[np.bytes_, coo_matrix[np.intp]]: ...
+) -> CrosstabResult[np.bytes_, coo_array[np.intp]]: ...
 @overload  # str
 def crosstab(
     arg0: Sequence[str], /, *args: Sequence[str], levels: Sequence[str] | None = None, sparse: Literal[False] = False
@@ -97,4 +97,4 @@ def crosstab(
 @overload  # str, sparse=True
 def crosstab(
     arg0: Sequence[str], arg1: Sequence[str], /, *, levels: Sequence[str] | None = None, sparse: Literal[True]
-) -> CrosstabResult[np.str_, coo_matrix[np.intp]]: ...
+) -> CrosstabResult[np.str_, coo_array[np.intp]]: ...

--- a/tests/stats/test__crosstab.pyi
+++ b/tests/stats/test__crosstab.pyi
@@ -3,7 +3,7 @@ from typing import assert_type
 import numpy as np
 import optype.numpy as onp
 
-from scipy.sparse import coo_matrix
+from scipy.sparse import coo_array
 from scipy.stats.contingency import crosstab
 
 ###
@@ -32,4 +32,4 @@ assert_type(crosstab(_list_bytes, _list_bytes).elements, _Tuple1N[onp.Array1D[np
 assert_type(crosstab(_list_str, _list_str).elements, _Tuple1N[onp.Array1D[np.str_]])
 
 assert_type(crosstab(_f64_2d, _f64_2d).count, onp.ArrayND[np.intp])
-assert_type(crosstab(_f64_2d, _f64_2d, sparse=True).count, coo_matrix[np.intp])
+assert_type(crosstab(_f64_2d, _f64_2d, sparse=True).count, coo_array[np.intp])


### PR DESCRIPTION
From the 1.18.0rc1 relnotes (https://github.com/scipy/scipy/releases/tag/v1.18.0rc1):

> The 2nd output object of `scipy.stats.contingency.crosstab` when kwarg
`sparse=True` is now a sparse array holding the counts instead of a sparse
matrix. This allows it to be nD, so can accept more than 2 sequences as
inputs, but it is a different class. Most operations work the same for
sparse arrays and matrixes with notable differences for matrix: `*` means
matmul and always-2D. For more info see [`migration_to_sparray`](https://scipy.github.io/devdocs/reference/sparse.migration_to_sparray.html).

towards #1614