### PR TITLE
👽️ `stats.obrientransform`: change return type to tuple

### DIFF
--- a/scipy-stubs/stats/_stats_py.pyi
+++ b/scipy-stubs/stats/_stats_py.pyi
@@ -2974,9 +2974,24 @@ def relfreq(
 ) -> RelfreqResult: ...
 
 #
+@overload
+def obrientransform(*, nan_policy: NanPolicy = "propagate") -> tuple[()]: ...
+@overload
+def obrientransform(x0: onp.ToFloatND, /, *, nan_policy: NanPolicy = "propagate") -> tuple[onp.ArrayND[np.float64]]: ...
+@overload
 def obrientransform(
-    *samples: onp.ToFloatND, nan_policy: NanPolicy = "propagate"
-) -> onp.Array2D[np.float64] | onp.Array1D[np.object_]: ...
+    x0: onp.ToFloatND, x1: onp.ToFloatND, /, *, nan_policy: NanPolicy = "propagate"
+) -> tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64]]: ...
+@overload
+def obrientransform(
+    x0: onp.ToFloatND, x1: onp.ToFloatND, x2: onp.ToFloatND, /, *, nan_policy: NanPolicy = "propagate"
+) -> tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64], onp.ArrayND[np.float64]]: ...
+@overload
+def obrientransform(
+    x0: onp.ToFloatND, x1: onp.ToFloatND, x2: onp.ToFloatND, x3: onp.ToFloatND, /, *, nan_policy: NanPolicy = "propagate"
+) -> tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64], onp.ArrayND[np.float64], onp.ArrayND[np.float64]]: ...
+@overload
+def obrientransform(*samples: onp.ToFloatND, nan_policy: NanPolicy = "propagate") -> tuple[onp.ArrayND[np.float64], ...]: ...
 
 #
 @overload  # 1d ~inexact64 | +integer, keepdims=False (default)

--- a/tests/stats/test__stats_py.pyi
+++ b/tests/stats/test__stats_py.pyi
@@ -918,7 +918,17 @@ assert_type(relfreq(_f64_1d), RelfreqResult)
 
 # obrientransform
 
-assert_type(obrientransform(_f64_1d, _f64_1d), onp.Array2D[np.float64] | onp.Array1D[np.object_])
+assert_type(obrientransform(), tuple[()])
+assert_type(obrientransform(_f64_1d), tuple[onp.ArrayND[np.float64]])
+assert_type(obrientransform(_f64_1d, _f64_1d), tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64]])
+assert_type(
+    obrientransform(_f64_1d, _f64_1d, _f64_1d), tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64], onp.ArrayND[np.float64]]
+)
+assert_type(
+    obrientransform(_f64_1d, _f64_1d, _f64_1d, _f64_1d),
+    tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64], onp.ArrayND[np.float64], onp.ArrayND[np.float64]],
+)
+assert_type(obrientransform(_f64_1d, _f64_1d, _f64_1d, _f64_1d, _f64_1d), tuple[onp.ArrayND[np.float64], ...])
 
 # sigmaclip
 


### PR DESCRIPTION
From the 1.18.0rc1 relnotes (https://github.com/scipy/scipy/releases/tag/v1.18.0rc1):

> `scipy.stats.obrientransform` now returns a tuple of arrays instead of a single `ndarray`.

towards #1614