### PR TITLE
👽️ `stats.mannwhitneyu`: new `zstatistic` return attribute

### DIFF
--- a/scipy-stubs/stats/_mannwhitneyu.pyi
+++ b/scipy-stubs/stats/_mannwhitneyu.pyi
@@ -36,6 +36,8 @@ class MannwhitneyuResult(tuple[_StatisticT_co, _PValueT_co], Generic[_StatisticT
     @property
     def pvalue(self) -> _PValueT_co: ...
 
+    zstatistic: _StatisticT_co
+
     #
     def __getnewargs_ex__(self) -> tuple[tuple[_StatisticT_co, _PValueT_co], dict[str, Never]]: ...
 


### PR DESCRIPTION
From the 1.18.0rc1 relnotes (https://github.com/scipy/scipy/releases/tag/v1.18.0rc1):

> `zstatistic` has been added to the result object of
`scipy.stats.mannwhitneyu`.

towards #1614