### PR TITLE
👽️ `sparse.linalg.minres`: support dtype complex

### DIFF
--- a/scipy-stubs/sparse/linalg/_isolve/minres.pyi
+++ b/scipy-stubs/sparse/linalg/_isolve/minres.pyi
@@ -17,6 +17,9 @@ type _ToLinearOperator[ScalarT: npc.number | np.bool] = onp.CanArrayND[ScalarT] 
 
 ###
 
+# mypy false positive (I'm guessing related to the unions in the next overload)
+# mypy: disable-error-code=overload-overlap
+
 @overload  # f64
 def minres(
     A: _ToLinearOperator[npc.floating64 | npc.integer],

--- a/scipy-stubs/sparse/linalg/_isolve/minres.pyi
+++ b/scipy-stubs/sparse/linalg/_isolve/minres.pyi
@@ -1,5 +1,6 @@
+from _typeshed import Unused
 from collections.abc import Callable
-from typing_extensions import TypeVar
+from typing import Any, overload
 
 import numpy as np
 import optype.numpy as onp
@@ -12,24 +13,77 @@ __all__ = ["minres"]
 
 ###
 
-_FloatT = TypeVar("_FloatT", bound=np.float32 | np.float64, default=np.float64)
-
-type _Ignored = object
-type _ToInt = npc.integer | np.bool
-type _ToLinearOperator[_ScalarT: npc.number | np.bool] = onp.CanArrayND[_ScalarT] | _spbase[_ScalarT] | LinearOperator[_ScalarT]
+type _ToLinearOperator[ScalarT: npc.number | np.bool] = onp.CanArrayND[ScalarT] | _spbase[ScalarT] | LinearOperator[ScalarT]
 
 ###
 
+@overload  # f64
 def minres(
-    A: _ToLinearOperator[_FloatT | _ToInt],
+    A: _ToLinearOperator[npc.floating64 | npc.integer],
     b: onp.ToFloat1D,
     x0: onp.ToFloat1D | None = None,
     *,
-    rtol: onp.ToFloat = 1e-5,
-    shift: onp.ToFloat = 0.0,
+    rtol: float = 1e-5,
+    shift: float = 0.0,
     maxiter: int | None = None,
-    M: _ToLinearOperator[_FloatT | _ToInt] | None = None,
-    callback: Callable[[onp.Array1D[_FloatT]], _Ignored] | None = None,
+    M: _ToLinearOperator[npc.floating | npc.integer] | None = None,
+    callback: Callable[[onp.Array1D[np.float64]], Unused] | None = None,
     show: bool = False,
     check: bool = False,
-) -> tuple[onp.Array1D[_FloatT], int]: ...
+) -> tuple[onp.Array1D[np.float64], int]: ...
+@overload  # f32
+def minres(
+    A: _ToLinearOperator[np.float32],
+    b: onp.ToJustFloat32_1D,
+    x0: onp.ToFloat1D | None = None,
+    *,
+    rtol: float = 1e-5,
+    shift: float = 0.0,
+    maxiter: int | None = None,
+    M: _ToLinearOperator[np.float32] | None = None,
+    callback: Callable[[onp.Array1D[np.float32]], Unused] | None = None,
+    show: bool = False,
+    check: bool = False,
+) -> tuple[onp.Array1D[np.float32], int]: ...
+@overload  # c128
+def minres(
+    A: _ToLinearOperator[np.complex128],
+    b: onp.ToComplex128_1D,
+    x0: onp.ToComplex1D | None = None,
+    *,
+    rtol: float = 1e-5,
+    shift: float = 0.0,
+    maxiter: int | None = None,
+    M: _ToLinearOperator[npc.number] | None = None,
+    callback: Callable[[onp.Array1D[np.complex128]], Unused] | None = None,
+    show: bool = False,
+    check: bool = False,
+) -> tuple[onp.Array1D[np.complex128], int]: ...
+@overload  # c64
+def minres(
+    A: _ToLinearOperator[np.complex64],
+    b: onp.ToJustFloat32_1D | onp.ToJustComplex64_1D,
+    x0: onp.ToJustFloat32_1D | onp.ToJustComplex64_1D | None = None,
+    *,
+    rtol: float = 1e-5,
+    shift: float = 0.0,
+    maxiter: int | None = None,
+    M: _ToLinearOperator[npc.inexact32] | None = None,
+    callback: Callable[[onp.Array1D[np.complex64]], Unused] | None = None,
+    show: bool = False,
+    check: bool = False,
+) -> tuple[onp.Array1D[np.complex64], int]: ...
+@overload  # fallback
+def minres(
+    A: _ToLinearOperator[npc.number],
+    b: onp.ToFloat1D,
+    x0: onp.ToFloat1D | None = None,
+    *,
+    rtol: float = 1e-5,
+    shift: float = 0.0,
+    maxiter: int | None = None,
+    M: _ToLinearOperator[npc.number] | None = None,
+    callback: Callable[[onp.Array1D[Any]], Unused] | None = None,
+    show: bool = False,
+    check: bool = False,
+) -> tuple[onp.Array1D[Any], int]: ...

--- a/tests/sparse/linalg/test__minres.pyi
+++ b/tests/sparse/linalg/test__minres.pyi
@@ -6,8 +6,23 @@ import optype.numpy as onp
 from scipy.sparse import csr_array
 from scipy.sparse.linalg import minres
 
-a: csr_array[np.float64]
-b: onp.Array1D[np.float64]
+###
 
+_csr_i64: csr_array[np.int64]
+_csr_f32: csr_array[np.float32]
+_csr_f64: csr_array[np.float64]
+_csr_c64: csr_array[np.complex64]
+_csr_c128: csr_array[np.complex128]
+
+_arr_i64_1d: onp.Array1D[np.int64]
+_arr_f32_1d: onp.Array1D[np.float32]
+_arr_f64_1d: onp.Array1D[np.float64]
+
+###
 # minres
-assert_type(minres(a, b), tuple[onp.Array1D[np.float64], int])
+
+assert_type(minres(_csr_i64, _arr_i64_1d), tuple[onp.Array1D[np.float64], int])
+assert_type(minres(_csr_f32, _arr_f32_1d), tuple[onp.Array1D[np.float32], int])
+assert_type(minres(_csr_f64, _arr_f64_1d), tuple[onp.Array1D[np.float64], int])
+assert_type(minres(_csr_c64, _arr_f32_1d), tuple[onp.Array1D[np.complex64], int])
+assert_type(minres(_csr_c128, _arr_f64_1d), tuple[onp.Array1D[np.complex128], int])


### PR DESCRIPTION
From the 1.18.0rc1 relnotes (https://github.com/scipy/scipy/releases/tag/v1.18.0rc1):

> `scipy.sparse.linalg.minres` now supports complex hermitian matrices.

towards #1614