### PR TITLE
👽️ `spatial.KDTree.sparse_distance_matrix`: sparse array return types

### DIFF
--- a/scipy-stubs/spatial/_ckdtree.pyi
+++ b/scipy-stubs/spatial/_ckdtree.pyi
@@ -4,7 +4,7 @@ from typing_extensions import TypeVar
 import numpy as np
 import optype.numpy as onp
 
-from scipy.sparse import coo_matrix, dok_matrix
+from scipy.sparse import coo_array, coo_matrix, dok_array, dok_matrix
 
 __all__ = ["cKDTree"]
 
@@ -323,8 +323,16 @@ class cKDTree(_CythonMixin, Generic[_BoxSizeT_co, _BoxSizeDataT_co]):
     ) -> dok_matrix[np.float64]: ...
     @overload
     def sparse_distance_matrix(
+        self, /, other: cKDTree, max_distance: onp.ToFloat, p: onp.ToFloat = 2.0, *, output_type: L["dok_array"]
+    ) -> dok_array[np.float64]: ...
+    @overload
+    def sparse_distance_matrix(
         self, /, other: cKDTree, max_distance: onp.ToFloat, p: onp.ToFloat = 2.0, *, output_type: L["coo_matrix"]
     ) -> coo_matrix[np.float64]: ...
+    @overload
+    def sparse_distance_matrix(
+        self, /, other: cKDTree, max_distance: onp.ToFloat, p: onp.ToFloat = 2.0, *, output_type: L["coo_array"]
+    ) -> coo_array[np.float64, tuple[int, int]]: ...
     @overload
     def sparse_distance_matrix(
         self, /, other: cKDTree, max_distance: onp.ToFloat, p: onp.ToFloat = 2.0, *, output_type: L["dict"]

--- a/tests/spatial/test__kdtree.pyi
+++ b/tests/spatial/test__kdtree.pyi
@@ -5,7 +5,7 @@ from typing import assert_type
 import numpy as np
 import optype.numpy as onp
 
-from scipy.sparse import coo_matrix, dok_matrix
+from scipy.sparse import coo_array, coo_matrix, dok_array, dok_matrix
 from scipy.spatial import KDTree, Rectangle, cKDTree, distance_matrix, minkowski_distance, minkowski_distance_p
 
 ###
@@ -60,7 +60,10 @@ assert_type(_ctree.count_neighbors(_ctree, _f64_1d, weights=(_f64_1d, _f64_1d)),
 # cKDTree.sparse_distance_matrix
 
 assert_type(_ctree.sparse_distance_matrix(_ctree, 1.0), dok_matrix[np.float64])
+assert_type(_ctree.sparse_distance_matrix(_ctree, 1.0, output_type="dok_matrix"), dok_matrix[np.float64])
+assert_type(_ctree.sparse_distance_matrix(_ctree, 1.0, output_type="dok_array"), dok_array[np.float64])
 assert_type(_ctree.sparse_distance_matrix(_ctree, 1.0, output_type="coo_matrix"), coo_matrix[np.float64])
+assert_type(_ctree.sparse_distance_matrix(_ctree, 1.0, output_type="coo_array"), coo_array[np.float64, tuple[int, int]])
 assert_type(_ctree.sparse_distance_matrix(_ctree, 1.0, output_type="dict"), dict[tuple[int, int], float])
 assert_type(_ctree.sparse_distance_matrix(_ctree, 1.0, output_type="ndarray"), onp.ArrayND[np.void])
 


### PR DESCRIPTION
From the 1.18.0rc1 relnotes (https://github.com/scipy/scipy/releases/tag/v1.18.0rc1):

> It is now possible to return sparse arrays rather than matrices from
`KDTree.sparse_distance_matrix`.

towards #1614