### PR TITLE
👽️ `sparse.linalg.LinearOperator`: N-d support

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,11 +262,12 @@ See the `scipy` columns below for which classes are subscriptable at runtime.
 
 #### `scipy.sparse.linalg`
 
-| generic type                | `scipy-stubs` | `scipy`  |                                                                                                      |
-| --------------------------- | ------------- | -------- | ---------------------------------------------------------------------------------------------------- |
-| `LaplacianNd[T: real]`      | `>=1.14.1.6`  | `>=1.17` | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.LaplacianNd.html)    |
-| `LinearOperator[T: scalar]` | `>=1.14.1.6`  | `>=1.17` | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.LinearOperator.html) |
-| `SuperLU[T: inexact]`       | `>=1.16.0.1`  | `>=1.17` | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.SuperLU.html)        |
+| generic type                          | `scipy-stubs` | `scipy`  |                                                                                                      |
+| ------------------------------------- | ------------- | -------- | ---------------------------------------------------------------------------------------------------- |
+| `LaplacianNd[T: real]`                | `>=1.14.1.6`  | `>=1.17` | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.LaplacianNd.html)    |
+| `LinearOperator[T: scalar]`           | `>=1.14.1.6`  | `>=1.17` | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.LinearOperator.html) |
+| `dopc[T: scalar, S: (int, int, ...)]` | `>=1.18.0.0`  | `>=1.18` | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.LinearOperator.html) |
+| `SuperLU[T: inexact]`                 | `>=1.16.0.1`  | `>=1.17` | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.SuperLU.html)        |
 
 ### `scipy.spatial.transform`
 

--- a/scipy-stubs/sparse/linalg/_interface.pyi
+++ b/scipy-stubs/sparse/linalg/_interface.pyi
@@ -282,7 +282,7 @@ class LinearOperator(Generic[_SCT_co, _ShapeT_co]):
     #
     @overload
     def __matmul__[SCT: _Scalar, ShapeT: _Shape](
-        self, /, x: LinearOperator[SCT, _Shape]
+        self, /, x: LinearOperator[SCT, ShapeT]
     ) -> _ProductLinearOperator[_SCT_co, SCT, ShapeT]: ...
     @overload
     def __matmul__(self, /, x: onp.ToFloatND) -> onp.ArrayND[_SCT_co]: ...

--- a/scipy-stubs/sparse/linalg/_interface.pyi
+++ b/scipy-stubs/sparse/linalg/_interface.pyi
@@ -5,6 +5,7 @@ from typing import Any, ClassVar, Final, Generic, Protocol, Self, SupportsIndex,
 from typing_extensions import TypeVar
 
 import numpy as np
+import numpy_typing_compat as nptc
 import optype.numpy as onp
 import optype.numpy.compat as npc
 
@@ -40,7 +41,7 @@ class _HasShapeAndMatVec(Protocol[_SCT_co, _ShapeT_co]):
 
     #
     @overload
-    def matvec(self, /, x: onp.CanArrayND[np.float64]) -> onp.CanArrayND[_SCT_co]: ...
+    def matvec(self, /, x: onp.CanArrayND[np.float64]) -> onp.ArrayND[_SCT_co]: ...
     @overload
     def matvec(self, /, x: onp.CanArrayND[np.complex128]) -> onp.ToComplexND: ...
 
@@ -52,7 +53,7 @@ class _HasShapeAndDTypeAndMatVec(Protocol[_SCT_co, _ShapeT_co]):
     def shape(self, /) -> _ShapeT_co: ...
 
     #
-    def matvec(self, /, x: onp.CanArrayND[np.float64 | np.complex128]) -> onp.ToComplexND: ...
+    def matvec(self, /, x: onp.CanArrayND[np.float64] | onp.CanArrayND[np.complex128]) -> onp.ToComplexND: ...
 
 ###
 
@@ -643,7 +644,7 @@ class IdentityOperator(LinearOperator[_SCT_co, _ShapeT_co], Generic[_SCT_co, _Sh
 #
 @overload
 def aslinearoperator[InexactT: npc.inexact, ShapeT: _Shape](
-    A: onp.CanArrayND[InexactT, ShapeT],
+    A: nptc.CanArray[ShapeT, np.dtype[InexactT]],
 ) -> MatrixLinearOperator[InexactT, ShapeT]: ...
 @overload
 def aslinearoperator[InexactT: npc.inexact, ShapeT: _Shape](

--- a/scipy-stubs/sparse/linalg/_interface.pyi
+++ b/scipy-stubs/sparse/linalg/_interface.pyi
@@ -521,7 +521,7 @@ class _ScaledLinearOperator(LinearOperator[_SCT_co, _ShapeT_co], Generic[_SCT_co
 
     #
     @overload
-    def __new__(cls, A: LinearOperator[_SCT_co, _ShapeT_co], alpha: _SCT_co | complex, xp: ModuleType | None = None) -> Self: ...
+    def __new__(cls, A: LinearOperator[_SCT_co, _ShapeT_co], alpha: _SCT_co | complex, xp: ModuleType | None = None) -> Self: ...  # type:ignore[overload-overlap]
     @overload
     def __new__[ShapeT: _Shape](
         cls, A: LinearOperator[npc.floating, ShapeT], alpha: onp.ToFloat64, xp: ModuleType | None = None

--- a/scipy-stubs/sparse/linalg/_interface.pyi
+++ b/scipy-stubs/sparse/linalg/_interface.pyi
@@ -1,5 +1,5 @@
 from _typeshed import Incomplete
-from collections.abc import Callable, Iterable
+from collections.abc import Callable
 from types import GenericAlias, ModuleType
 from typing import Any, ClassVar, Final, Generic, Protocol, Self, SupportsIndex, final, overload, override, type_check_only
 from typing_extensions import TypeVar
@@ -14,82 +14,86 @@ __all__ = ["LinearOperator", "aslinearoperator"]
 
 ###
 
-type _ToShape = Iterable[SupportsIndex]
-type _Real = np.bool | npc.integer | npc.floating
-type _FunMatVec = Callable[[onp.ArrayND[Any]], onp.ToComplex1D | onp.ToComplex2D]
-type _FunMatMat = Callable[[onp.Array2D[Any]], onp.ToComplex2D]
+type _Real = npc.floating | npc.integer | np.bool
+type _Scalar = npc.number | np.bool
+
+type _Shape = tuple[int, int, *tuple[int, ...]]
+type _AnyShape = tuple[int, int, *tuple[Any, ...]]
+
+type _FunMatVec = Callable[[onp.ArrayND[Any]], onp.ToComplexND]
+type _FunMatMat = Callable[[onp.Array2D[Any]], onp.ToComplexND]
 
 _SCT_co = TypeVar("_SCT_co", bound=npc.number | np.bool, default=Any, covariant=True)
 _SCT1_co = TypeVar("_SCT1_co", bound=npc.number | np.bool, default=Any, covariant=True)
 _SCT2_co = TypeVar("_SCT2_co", bound=npc.number | np.bool, default=_SCT1_co, covariant=True)
-_FunMatVecT_co = TypeVar("_FunMatVecT_co", bound=_FunMatVec, default=_FunMatVec, covariant=True)
-_LinearOperatorT_co = TypeVar("_LinearOperatorT_co", bound=LinearOperator[Any], covariant=True)
+_ShapeT_co = TypeVar("_ShapeT_co", bound=_Shape, default=_AnyShape, covariant=True)
+_LinearOperatorT_co = TypeVar("_LinearOperatorT_co", bound=LinearOperator[Any, Any], covariant=True)
 
 @type_check_only
 class _CanAdjoint(Protocol[_LinearOperatorT_co]):
     def _adjoint(self, /) -> _LinearOperatorT_co: ...
 
 @type_check_only
-class _HasShapeAndMatVec(Protocol[_SCT_co]):
-    shape: tuple[int, int]
+class _HasShapeAndMatVec(Protocol[_SCT_co, _ShapeT_co]):
+    @property
+    def shape(self, /) -> _ShapeT_co: ...
+
+    #
     @overload
-    def matvec(self, /, x: onp.CanArray1D[np.float64]) -> onp.CanArray1D[_SCT_co]: ...
+    def matvec(self, /, x: onp.CanArrayND[np.float64]) -> onp.CanArrayND[_SCT_co]: ...
     @overload
-    def matvec(self, /, x: onp.CanArray2D[np.float64]) -> onp.CanArray2D[_SCT_co]: ...
-    @overload
-    def matvec(self, /, x: onp.CanArray1D[np.complex128]) -> onp.ToComplex1D: ...
-    @overload
-    def matvec(self, /, x: onp.CanArray2D[np.complex128]) -> onp.ToComplex2D: ...
+    def matvec(self, /, x: onp.CanArrayND[np.complex128]) -> onp.ToComplexND: ...
 
 @type_check_only
-class _HasShapeAndDTypeAndMatVec(Protocol[_SCT_co]):
-    shape: tuple[int, int]
+class _HasShapeAndDTypeAndMatVec(Protocol[_SCT_co, _ShapeT_co]):
     @property
     def dtype(self, /) -> np.dtype[_SCT_co]: ...
-    @overload
-    def matvec(self, /, x: onp.CanArray1D[np.float64] | onp.CanArray1D[np.complex128]) -> onp.ToComplex1D: ...
-    @overload
-    def matvec(self, /, x: onp.CanArray2D[np.float64] | onp.CanArray2D[np.complex128]) -> onp.ToComplex2D: ...
+    @property
+    def shape(self, /) -> _ShapeT_co: ...
+
+    #
+    def matvec(self, /, x: onp.CanArrayND[np.float64 | np.complex128]) -> onp.ToComplexND: ...
 
 ###
 
-class LinearOperator(Generic[_SCT_co]):
+class LinearOperator(Generic[_SCT_co, _ShapeT_co]):
     __array_ufunc__: ClassVar[None] = None
-    ndim: ClassVar[int] = 2
-
-    shape: Final[tuple[int, int]]
-    dtype: np.dtype[_SCT_co]
 
     @classmethod
     def __class_getitem__(cls, arg: object, /) -> GenericAlias: ...
 
+    dtype: np.dtype[_SCT_co]
+    shape: _ShapeT_co
+    ndim: Final[int]
+    _xp: Final[ModuleType]
+
     # keep in sync with `_CustomLinearOperator.__init__`
     @overload  # no dtype
-    def __new__(
+    def __new__[ShapeT: _Shape](
         cls,
-        shape: _ToShape,
+        shape: ShapeT,
         matvec: _FunMatVec,
         rmatvec: _FunMatVec | None = None,
         matmat: _FunMatMat | None = None,
         dtype: None = None,
         rmatmat: _FunMatMat | None = None,
         xp: None = None,
-    ) -> _CustomLinearOperator[np.int8 | Any]: ...
+    ) -> _CustomLinearOperator[np.int8 | Any, ShapeT]: ...
     @overload  # dtype known (positional)
-    def __new__[SCT: npc.number | np.bool](
+    def __new__[SCT: _Scalar, ShapeT: _Shape](
         cls,
-        shape: _ToShape,
+        shape: ShapeT,
         matvec: _FunMatVec,
         rmatvec: _FunMatVec | None,
         matmat: _FunMatMat | None,
         dtype: onp.ToDType[SCT],
         rmatmat: _FunMatMat | None = None,
         xp: ModuleType | None = None,
-    ) -> _CustomLinearOperator[SCT]: ...
+    ) -> _CustomLinearOperator[SCT, ShapeT]: ...
     @overload  # dtype known (keyword)
-    def __new__[SCT: npc.number | np.bool](
+    def __new__[SCT: _Scalar, ShapeT: _Shape](
         cls,
-        shape: _ToShape,
+        shape: ShapeT,
         matvec: _FunMatVec,
         rmatvec: _FunMatVec | None = None,
         matmat: _FunMatMat | None = None,
@@ -97,22 +101,22 @@ class LinearOperator(Generic[_SCT_co]):
         dtype: onp.ToDType[SCT],
         rmatmat: _FunMatMat | None = None,
         xp: ModuleType | None = None,
-    ) -> _CustomLinearOperator[SCT]: ...
+    ) -> _CustomLinearOperator[SCT, ShapeT]: ...
     @overload  # dtype-like int_ (positional)
-    def __new__(
+    def __new__[ShapeT: _Shape](
         cls,
-        shape: _ToShape,
+        shape: ShapeT,
         matvec: _FunMatVec,
         rmatvec: _FunMatVec | None,
         matmat: _FunMatMat | None,
         dtype: onp.AnyIntDType,
         rmatmat: _FunMatMat | None = None,
         xp: None = None,
-    ) -> _CustomLinearOperator[np.int_]: ...
+    ) -> _CustomLinearOperator[np.int_, ShapeT]: ...
     @overload  # dtype-like int_ (keyword)
-    def __new__(
+    def __new__[ShapeT: _Shape](
         cls,
-        shape: _ToShape,
+        shape: ShapeT,
         matvec: _FunMatVec,
         rmatvec: _FunMatVec | None = None,
         matmat: _FunMatMat | None = None,
@@ -120,22 +124,22 @@ class LinearOperator(Generic[_SCT_co]):
         dtype: onp.AnyIntDType,
         rmatmat: _FunMatMat | None = None,
         xp: None = None,
-    ) -> _CustomLinearOperator[np.int_]: ...
+    ) -> _CustomLinearOperator[np.int_, ShapeT]: ...
     @overload  # dtype-like float64 (positional)
-    def __new__(
+    def __new__[ShapeT: _Shape](
         cls,
-        shape: _ToShape,
+        shape: ShapeT,
         matvec: _FunMatVec,
         rmatvec: _FunMatVec | None,
         matmat: _FunMatMat | None,
         dtype: onp.AnyFloat64DType,
         rmatmat: _FunMatMat | None = None,
         xp: None = None,
-    ) -> _CustomLinearOperator[np.float64]: ...
+    ) -> _CustomLinearOperator[np.float64, ShapeT]: ...
     @overload  # dtype-like float64 (positional)
-    def __new__(
+    def __new__[ShapeT: _Shape](
         cls,
-        shape: _ToShape,
+        shape: ShapeT,
         matvec: _FunMatVec,
         rmatvec: _FunMatVec | None = None,
         matmat: _FunMatMat | None = None,
@@ -143,22 +147,22 @@ class LinearOperator(Generic[_SCT_co]):
         dtype: onp.AnyFloat64DType,
         rmatmat: _FunMatMat | None = None,
         xp: None = None,
-    ) -> _CustomLinearOperator[np.float64]: ...
+    ) -> _CustomLinearOperator[np.float64, ShapeT]: ...
     @overload  # dtype-like complex128 (positional)
-    def __new__(
+    def __new__[ShapeT: _Shape](
         cls,
-        shape: _ToShape,
+        shape: ShapeT,
         matvec: _FunMatVec,
         rmatvec: _FunMatVec | None,
         matmat: _FunMatMat | None,
         dtype: onp.AnyComplex128DType,
         rmatmat: _FunMatMat | None = None,
         xp: None = None,
-    ) -> _CustomLinearOperator[np.complex128]: ...
+    ) -> _CustomLinearOperator[np.complex128, ShapeT]: ...
     @overload  # dtype-like complex128 (keyword)
-    def __new__(
+    def __new__[ShapeT: _Shape](
         cls,
-        shape: _ToShape,
+        shape: ShapeT,
         matvec: _FunMatVec,
         rmatvec: _FunMatVec | None = None,
         matmat: _FunMatMat | None = None,
@@ -166,22 +170,22 @@ class LinearOperator(Generic[_SCT_co]):
         dtype: onp.AnyComplex128DType,
         rmatmat: _FunMatMat | None = None,
         xp: None = None,
-    ) -> _CustomLinearOperator[np.complex128]: ...
+    ) -> _CustomLinearOperator[np.complex128, ShapeT]: ...
     @overload  # unknown dtype
-    def __new__(
+    def __new__[ShapeT: _Shape](
         cls,
-        shape: _ToShape,
+        shape: ShapeT,
         matvec: _FunMatVec,
         rmatvec: _FunMatVec | None = None,
         matmat: _FunMatMat | None = None,
         dtype: type | str | None = None,
         rmatmat: _FunMatMat | None = None,
         xp: None = None,
-    ) -> _CustomLinearOperator[Any]: ...
+    ) -> _CustomLinearOperator[Any, ShapeT]: ...
     @overload  # xp given
-    def __new__(
+    def __new__[ShapeT: _Shape](
         cls,
-        shape: _ToShape,
+        shape: ShapeT,
         matvec: _FunMatVec,
         rmatvec: _FunMatVec | None = None,
         matmat: _FunMatMat | None = None,
@@ -189,7 +193,7 @@ class LinearOperator(Generic[_SCT_co]):
         rmatmat: _FunMatMat | None = None,
         *,
         xp: ModuleType,
-    ) -> _CustomLinearOperator[Any]: ...
+    ) -> _CustomLinearOperator[Any, ShapeT]: ...
 
     # NOTE: the `__init__` method cannot be annotated, because it will cause mypy to ignore `__new__`:
     # https://github.com/python/mypy/issues/17251
@@ -209,145 +213,121 @@ class LinearOperator(Generic[_SCT_co]):
 
     #
     @property
-    def H[LinearOperatorT: LinearOperator[Any]](self: _CanAdjoint[LinearOperatorT], /) -> LinearOperatorT: ...
+    def H[LinearOperatorT: LinearOperator[Any, Any]](self: _CanAdjoint[LinearOperatorT], /) -> LinearOperatorT: ...
     @final
-    def adjoint[LinearOperatorT: LinearOperator[Any]](self: _CanAdjoint[LinearOperatorT], /) -> LinearOperatorT: ...
-    def _adjoint(self, /) -> LinearOperator[_SCT_co]: ...
+    def adjoint[LinearOperatorT: LinearOperator[Any, Any]](self: _CanAdjoint[LinearOperatorT], /) -> LinearOperatorT: ...
+    def _adjoint(self, /) -> LinearOperator[_SCT_co, _ShapeT_co]: ...
 
     #
     @property
-    def T(self, /) -> _TransposedLinearOperator[_SCT_co]: ...
-    def transpose(self, /) -> _TransposedLinearOperator[_SCT_co]: ...
+    def T(self, /) -> _TransposedLinearOperator[_SCT_co, _ShapeT_co]: ...
+    def transpose(self, /) -> _TransposedLinearOperator[_SCT_co, _ShapeT_co]: ...
 
     #
-    @overload  # float array 1d
-    def matvec(self, /, x: onp.ToFloatStrict1D) -> onp.Array1D[_SCT_co]: ...
     @overload  # float matrix
     def matvec(self, /, x: onp.Matrix[_Real]) -> onp.Matrix[_SCT_co]: ...
     @overload  # complex matrix
     def matvec(self, /, x: onp.Matrix[np.complex128]) -> onp.Matrix[np.complex128]: ...
-    @overload  # float array 2d
-    def matvec(self, /, x: onp.ToFloatStrict2D) -> onp.Array2D[_SCT_co]: ...
-    @overload  # complex array 1d
-    def matvec(self, /, x: onp.ToJustComplex128Strict1D) -> onp.Array1D[np.complex128]: ...
-    @overload  # complex array 2d
-    def matvec(self, /, x: onp.ToJustComplex128Strict2D) -> onp.Array2D[np.complex128]: ...
     @overload  # float array
-    def matvec(self, /, x: onp.ToFloat2D) -> onp.ArrayND[_SCT_co]: ...
+    def matvec(self, /, x: onp.ToFloatND) -> onp.ArrayND[_SCT_co]: ...
     @overload  # complex array
-    def matvec(self, /, x: onp.ToJustComplex128_2D) -> onp.ArrayND[np.complex128]: ...
+    def matvec(self, /, x: onp.ToJustComplex128_ND) -> onp.ArrayND[np.complex128]: ...
     @overload  # unknown array
-    def matvec(self, /, x: onp.ToComplex2D) -> onp.ArrayND[Any]: ...
+    def matvec(self, /, x: onp.ToComplexND) -> onp.ArrayND[Any]: ...
     rmatvec = matvec
 
     #
     @overload
-    def matmat(self, /, X: onp.ToFloat2D) -> onp.Array2D[_SCT_co]: ...
+    def matmat(self, /, X: onp.ToFloatND) -> onp.ArrayND[_SCT_co]: ...
     @overload
-    def matmat(self, /, X: onp.ToJustComplex128_2D) -> onp.Array2D[np.complex128]: ...
+    def matmat(self, /, X: onp.ToJustComplex128_ND) -> onp.ArrayND[np.complex128]: ...
     @overload
-    def matmat(self, /, X: onp.ToComplex2D) -> onp.Array2D[Any]: ...
+    def matmat(self, /, X: onp.ToComplexND) -> onp.ArrayND[Any]: ...
     rmatmat = matmat
 
     #
     @overload
-    def dot[SCT: npc.number | np.bool](self, /, x: LinearOperator[SCT]) -> _ProductLinearOperator[_SCT_co, SCT]: ...
+    def dot[SCT: _Scalar, ShapeT: _Shape](
+        self, /, x: LinearOperator[SCT, ShapeT]
+    ) -> _ProductLinearOperator[_SCT_co, SCT, ShapeT]: ...
     @overload
-    def dot(self, /, x: onp.ToFloat) -> _ScaledLinearOperator[_SCT_co]: ...
+    def dot(self, /, x: onp.ToFloat) -> _ScaledLinearOperator[_SCT_co, _ShapeT_co]: ...
     @overload
-    def dot(self, /, x: onp.ToJustComplex128) -> _ScaledLinearOperator[np.complex128]: ...
-    @overload
-    def dot(self, /, x: onp.ToFloatStrict1D) -> onp.Array1D[_SCT_co]: ...
-    @overload
-    def dot(self, /, x: onp.ToJustComplex128Strict1D) -> onp.Array1D[np.complex128]: ...
-    @overload
-    def dot(self, /, x: onp.ToFloatStrict2D) -> onp.Array2D[_SCT_co]: ...
-    @overload
-    def dot(self, /, x: onp.ToJustComplex128Strict2D) -> onp.Array2D[np.complex128]: ...
+    def dot(self, /, x: onp.ToJustComplex128) -> _ScaledLinearOperator[np.complex128, _ShapeT_co]: ...
     @overload
     def dot(self, /, x: onp.ToFloatND) -> onp.ArrayND[_SCT_co]: ...
+    @overload
+    def dot(self, /, x: onp.ToJustComplex128_ND) -> onp.ArrayND[np.complex128]: ...
     @overload
     def dot(self, /, x: onp.ToComplexND) -> onp.ArrayND[Any]: ...
     __mul__ = dot
 
     # keep in sync with `dot`
     @overload
-    def rdot[SCT: npc.number | np.bool](self, /, x: LinearOperator[SCT]) -> _ProductLinearOperator[_SCT_co, SCT]: ...
+    def rdot[SCT: _Scalar, ShapeT: _Shape](
+        self, /, x: LinearOperator[SCT, ShapeT]
+    ) -> _ProductLinearOperator[_SCT_co, SCT, ShapeT]: ...
     @overload
-    def rdot(self, /, x: onp.ToFloat) -> _ScaledLinearOperator[_SCT_co]: ...
+    def rdot(self, /, x: onp.ToFloat) -> _ScaledLinearOperator[_SCT_co, _ShapeT_co]: ...
     @overload
-    def rdot(self, /, x: onp.ToJustComplex128) -> _ScaledLinearOperator[np.complex128]: ...
-    @overload
-    def rdot(self, /, x: onp.ToFloatStrict1D) -> onp.Array1D[_SCT_co]: ...
-    @overload
-    def rdot(self, /, x: onp.ToJustComplex128Strict1D) -> onp.Array1D[np.complex128]: ...
-    @overload
-    def rdot(self, /, x: onp.ToFloatStrict2D) -> onp.Array2D[_SCT_co]: ...
-    @overload
-    def rdot(self, /, x: onp.ToJustComplex128Strict2D) -> onp.Array2D[np.complex128]: ...
+    def rdot(self, /, x: onp.ToJustComplex128) -> _ScaledLinearOperator[np.complex128, _ShapeT_co]: ...
     @overload
     def rdot(self, /, x: onp.ToFloatND) -> onp.ArrayND[_SCT_co]: ...
+    @overload
+    def rdot(self, /, x: onp.ToJustComplex128_ND) -> onp.ArrayND[np.complex128]: ...
     @overload
     def rdot(self, /, x: onp.ToComplexND) -> onp.ArrayND[Any]: ...
     __rmul__ = rdot
 
     #
     @overload
-    def __matmul__[SCT: npc.number | np.bool](self, /, x: LinearOperator[SCT]) -> _ProductLinearOperator[_SCT_co, SCT]: ...
-    @overload
-    def __matmul__(self, /, x: onp.ToFloatStrict1D) -> onp.Array1D[_SCT_co]: ...
-    @overload
-    def __matmul__(self, /, x: onp.ToJustComplex128Strict1D) -> onp.Array1D[np.complex128]: ...
-    @overload
-    def __matmul__(self, /, x: onp.ToFloatStrict2D) -> onp.Array2D[_SCT_co]: ...
-    @overload
-    def __matmul__(self, /, x: onp.ToJustComplex128Strict2D) -> onp.Array2D[np.complex128]: ...
+    def __matmul__[SCT: _Scalar, ShapeT: _Shape](
+        self, /, x: LinearOperator[SCT, _Shape]
+    ) -> _ProductLinearOperator[_SCT_co, SCT, ShapeT]: ...
     @overload
     def __matmul__(self, /, x: onp.ToFloatND) -> onp.ArrayND[_SCT_co]: ...
+    @overload
+    def __matmul__(self, /, x: onp.ToJustComplex128_ND) -> onp.ArrayND[np.complex128]: ...
     @overload
     def __matmul__(self, /, x: onp.ToComplexND) -> onp.ArrayND[Any]: ...
     __call__ = __matmul__
 
-    #
+    # TODO(@jorenham): shape-typing
     @overload
-    def __rmatmul__[SCT: npc.number | np.bool](self, /, x: LinearOperator[SCT]) -> _ProductLinearOperator[_SCT_co, SCT]: ...
-    @overload
-    def __rmatmul__(self, /, x: onp.ToFloatStrict1D) -> onp.Array1D[_SCT_co]: ...
-    @overload
-    def __rmatmul__(self, /, x: onp.ToJustComplex128Strict1D) -> onp.Array1D[np.complex128]: ...
-    @overload
-    def __rmatmul__(self, /, x: onp.ToFloatStrict2D) -> onp.Array2D[_SCT_co]: ...
-    @overload
-    def __rmatmul__(self, /, x: onp.ToJustComplex128Strict2D) -> onp.Array2D[np.complex128]: ...
+    def __rmatmul__[SCT: _Scalar, ShapeT: _Shape](
+        self, /, x: LinearOperator[SCT, ShapeT]
+    ) -> _ProductLinearOperator[_SCT_co, SCT, ShapeT]: ...
     @overload
     def __rmatmul__(self, /, x: onp.ToFloatND) -> onp.ArrayND[_SCT_co]: ...
+    @overload
+    def __rmatmul__(self, /, x: onp.ToJustComplex128_ND) -> onp.ArrayND[np.complex128]: ...
     @overload
     def __rmatmul__(self, /, x: onp.ToComplexND) -> onp.ArrayND[Any]: ...
 
     #
     @overload
-    def __truediv__(self, other: onp.ToFloat, /) -> _ScaledLinearOperator[_SCT_co]: ...
+    def __truediv__(self, other: onp.ToFloat, /) -> _ScaledLinearOperator[_SCT_co, _ShapeT_co]: ...
     @overload
-    def __truediv__(self, other: onp.ToJustComplex128, /) -> _ScaledLinearOperator[np.complex128]: ...
+    def __truediv__(self, other: onp.ToJustComplex128, /) -> _ScaledLinearOperator[np.complex128, _ShapeT_co]: ...
     @overload
-    def __truediv__(self, other: onp.ToComplex, /) -> _ScaledLinearOperator[Any]: ...
+    def __truediv__(self, other: onp.ToComplex, /) -> _ScaledLinearOperator[Any, _ShapeT_co]: ...
 
     #
-    def __neg__(self, /) -> _ScaledLinearOperator[_SCT_co]: ...
-    def __add__[SCT: npc.number | np.bool](self, x: LinearOperator[SCT], /) -> _SumLinearOperator[_SCT_co, SCT]: ...
+    def __neg__(self, /) -> _ScaledLinearOperator[_SCT_co, _ShapeT_co]: ...
+    def __add__[SCT: _Scalar](self, x: LinearOperator[SCT], /) -> _SumLinearOperator[_SCT_co, SCT, _ShapeT_co]: ...
     __sub__ = __add__
-    def __pow__(self, p: onp.ToInt, /) -> _PowerLinearOperator[_SCT_co]: ...
+    def __pow__(self, p: onp.ToInt, /) -> _PowerLinearOperator[_SCT_co, _ShapeT_co]: ...
 
 @final
-class _CustomLinearOperator(LinearOperator[_SCT_co], Generic[_SCT_co, _FunMatVecT_co]):
+class _CustomLinearOperator(LinearOperator[_SCT_co, _ShapeT_co], Generic[_SCT_co, _ShapeT_co]):
     args: tuple[()]
 
     #
     @overload  # no dtype
-    def __init__(
-        self: _CustomLinearOperator[np.int8 | Any],
+    def __init__[ShapeT: _Shape](
+        self: _CustomLinearOperator[np.int8 | Any, ShapeT],
         /,
-        shape: _ToShape,
+        shape: ShapeT,
         matvec: _FunMatVec,
         rmatvec: _FunMatVec | None = None,
         matmat: _FunMatMat | None = None,
@@ -359,7 +339,7 @@ class _CustomLinearOperator(LinearOperator[_SCT_co], Generic[_SCT_co, _FunMatVec
     def __init__(
         self,
         /,
-        shape: _ToShape,
+        shape: _ShapeT_co,
         matvec: _FunMatVec,
         rmatvec: _FunMatVec | None,
         matmat: _FunMatMat | None,
@@ -371,7 +351,7 @@ class _CustomLinearOperator(LinearOperator[_SCT_co], Generic[_SCT_co, _FunMatVec
     def __init__(
         self,
         /,
-        shape: _ToShape,
+        shape: _ShapeT_co,
         matvec: _FunMatVec,
         rmatvec: _FunMatVec | None = None,
         matmat: _FunMatMat | None = None,
@@ -381,10 +361,10 @@ class _CustomLinearOperator(LinearOperator[_SCT_co], Generic[_SCT_co, _FunMatVec
         xp: None = None,
     ) -> None: ...
     @overload  # dtype-like int_ (positional)
-    def __init__(
-        self: _CustomLinearOperator[np.int_],
+    def __init__[ShapeT: _Shape](
+        self: _CustomLinearOperator[np.int_, ShapeT],
         /,
-        shape: _ToShape,
+        shape: ShapeT,
         matvec: _FunMatVec,
         rmatvec: _FunMatVec | None,
         matmat: _FunMatMat | None,
@@ -393,10 +373,10 @@ class _CustomLinearOperator(LinearOperator[_SCT_co], Generic[_SCT_co, _FunMatVec
         xp: None = None,
     ) -> None: ...
     @overload  # dtype-like int_ (keyword)
-    def __init__(
-        self: _CustomLinearOperator[np.int_],
+    def __init__[ShapeT: _Shape](
+        self: _CustomLinearOperator[np.int_, ShapeT],
         /,
-        shape: _ToShape,
+        shape: ShapeT,
         matvec: _FunMatVec,
         rmatvec: _FunMatVec | None = None,
         matmat: _FunMatMat | None = None,
@@ -406,10 +386,10 @@ class _CustomLinearOperator(LinearOperator[_SCT_co], Generic[_SCT_co, _FunMatVec
         xp: None = None,
     ) -> None: ...
     @overload  # dtype-like float64 (positional)
-    def __init__(
-        self: _CustomLinearOperator[np.float64],
+    def __init__[ShapeT: _Shape](
+        self: _CustomLinearOperator[np.float64, ShapeT],
         /,
-        shape: _ToShape,
+        shape: ShapeT,
         matvec: _FunMatVec,
         rmatvec: _FunMatVec | None,
         matmat: _FunMatMat | None,
@@ -418,10 +398,10 @@ class _CustomLinearOperator(LinearOperator[_SCT_co], Generic[_SCT_co, _FunMatVec
         xp: None = None,
     ) -> None: ...
     @overload  # dtype-like float64 (keyword)
-    def __init__(
-        self: _CustomLinearOperator[np.float64],
+    def __init__[ShapeT: _Shape](
+        self: _CustomLinearOperator[np.float64, ShapeT],
         /,
-        shape: _ToShape,
+        shape: ShapeT,
         matvec: _FunMatVec,
         rmatvec: _FunMatVec | None = None,
         matmat: _FunMatMat | None = None,
@@ -431,10 +411,10 @@ class _CustomLinearOperator(LinearOperator[_SCT_co], Generic[_SCT_co, _FunMatVec
         xp: None = None,
     ) -> None: ...
     @overload  # dtype-like complex128 (positional)
-    def __init__(
-        self: _CustomLinearOperator[np.complex128],
+    def __init__[ShapeT: _Shape](
+        self: _CustomLinearOperator[np.complex128, ShapeT],
         /,
-        shape: _ToShape,
+        shape: ShapeT,
         matvec: _FunMatVec,
         rmatvec: _FunMatVec | None,
         matmat: _FunMatMat | None,
@@ -443,10 +423,10 @@ class _CustomLinearOperator(LinearOperator[_SCT_co], Generic[_SCT_co, _FunMatVec
         xp: None = None,
     ) -> None: ...
     @overload  # dtype-like complex128 (keyword)
-    def __init__(
-        self: _CustomLinearOperator[np.complex128],
+    def __init__[ShapeT: _Shape](
+        self: _CustomLinearOperator[np.complex128, ShapeT],
         /,
-        shape: _ToShape,
+        shape: ShapeT,
         matvec: _FunMatVec,
         rmatvec: _FunMatVec | None = None,
         matmat: _FunMatMat | None = None,
@@ -456,10 +436,10 @@ class _CustomLinearOperator(LinearOperator[_SCT_co], Generic[_SCT_co, _FunMatVec
         xp: None = None,
     ) -> None: ...
     @overload  # unknown dtype
-    def __init__(
-        self: _CustomLinearOperator[Any],
+    def __init__[ShapeT: _Shape](
+        self: _CustomLinearOperator[Any, ShapeT],
         /,
-        shape: _ToShape,
+        shape: ShapeT,
         matvec: _FunMatVec,
         rmatvec: _FunMatVec | None = None,
         matmat: _FunMatMat | None = None,
@@ -468,10 +448,10 @@ class _CustomLinearOperator(LinearOperator[_SCT_co], Generic[_SCT_co, _FunMatVec
         xp: None = None,
     ) -> None: ...
     @overload  # xp given
-    def __init__(
-        self: _CustomLinearOperator[Any],
+    def __init__[ShapeT: _Shape](
+        self: _CustomLinearOperator[Any, ShapeT],
         /,
-        shape: _ToShape,
+        shape: ShapeT,
         matvec: _FunMatVec,
         rmatvec: _FunMatVec | None = None,
         matmat: _FunMatMat | None = None,
@@ -486,85 +466,91 @@ class _CustomLinearOperator(LinearOperator[_SCT_co], Generic[_SCT_co, _FunMatVec
     def _adjoint(self, /) -> Self: ...
 
 @type_check_only
-class _UnaryLinearOperator(LinearOperator[_SCT_co], Generic[_SCT_co]):
-    A: LinearOperator[_SCT_co]
-    args: tuple[LinearOperator[_SCT_co]]
+class _UnaryLinearOperator(LinearOperator[_SCT_co, _ShapeT_co], Generic[_SCT_co, _ShapeT_co]):
+    A: LinearOperator[_SCT_co, _ShapeT_co]
+    args: tuple[LinearOperator[_SCT_co, _ShapeT_co]]
+
+    #
+    def __new__(cls, A: LinearOperator[_SCT_co, _ShapeT_co], xp: ModuleType | None = None) -> Self: ...
+    def __init__(self, /, A: LinearOperator[_SCT_co, _ShapeT_co], xp: ModuleType | None = None) -> None: ...
 
     #
     @override
-    def __new__(cls, A: LinearOperator[_SCT_co], xp: ModuleType | None = None) -> Self: ...  # pyrefly:ignore[bad-override]
-    @override
-    def __init__(self, /, A: LinearOperator[_SCT_co], xp: ModuleType | None = None) -> None: ...  # pyrefly:ignore[bad-override]
-
-    #
-    @override
-    def _adjoint(self, /) -> _AdjointLinearOperator[_SCT_co]: ...
+    def _adjoint(self, /) -> _AdjointLinearOperator[_SCT_co, _ShapeT_co]: ...
 
 @final
-class _AdjointLinearOperator(_UnaryLinearOperator[_SCT_co], Generic[_SCT_co]): ...
+class _AdjointLinearOperator(_UnaryLinearOperator[_SCT_co, _ShapeT_co], Generic[_SCT_co, _ShapeT_co]): ...
 
 @final
-class _TransposedLinearOperator(_UnaryLinearOperator[_SCT_co], Generic[_SCT_co]): ...
+class _TransposedLinearOperator(_UnaryLinearOperator[_SCT_co, _ShapeT_co], Generic[_SCT_co, _ShapeT_co]): ...
 
 @final
-class _SumLinearOperator(LinearOperator[_SCT1_co | _SCT2_co], Generic[_SCT1_co, _SCT2_co]):
-    args: tuple[LinearOperator[_SCT1_co], LinearOperator[_SCT2_co]]
+class _SumLinearOperator(LinearOperator[_SCT1_co | _SCT2_co, _ShapeT_co], Generic[_SCT1_co, _SCT2_co, _ShapeT_co]):
+    args: tuple[LinearOperator[_SCT1_co, _ShapeT_co], LinearOperator[_SCT2_co, _ShapeT_co]]
 
-    @override
-    def __new__(cls, A: LinearOperator[_SCT1_co], B: LinearOperator[_SCT2_co], xp: ModuleType | None = None) -> Self: ...  # pyrefly:ignore[bad-override]
-    @override
-    def __init__(self, /, A: LinearOperator[_SCT1_co], B: LinearOperator[_SCT2_co], xp: ModuleType | None = None) -> None: ...  # pyrefly:ignore[bad-override]
+    def __new__(
+        cls, A: LinearOperator[_SCT1_co, _ShapeT_co], B: LinearOperator[_SCT2_co, _ShapeT_co], xp: ModuleType | None = None
+    ) -> Self: ...
+    def __init__(
+        self, /, A: LinearOperator[_SCT1_co, _ShapeT_co], B: LinearOperator[_SCT2_co, _ShapeT_co], xp: ModuleType | None = None
+    ) -> None: ...
 
     #
     @override
     def _adjoint(self, /) -> Self: ...
 
 @final
-class _ProductLinearOperator(LinearOperator[_SCT1_co | _SCT2_co], Generic[_SCT1_co, _SCT2_co]):
-    args: tuple[LinearOperator[_SCT1_co], LinearOperator[_SCT2_co]]
+class _ProductLinearOperator(LinearOperator[_SCT1_co | _SCT2_co, _ShapeT_co], Generic[_SCT1_co, _SCT2_co, _ShapeT_co]):
+    args: tuple[LinearOperator[_SCT1_co, _ShapeT_co], LinearOperator[_SCT2_co, _ShapeT_co]]
 
     #
-    @override
-    def __new__(cls, A: LinearOperator[_SCT1_co], B: LinearOperator[_SCT2_co], xp: ModuleType | None = None) -> Self: ...  # pyrefly:ignore[bad-override]
-    @override
-    def __init__(self, /, A: LinearOperator[_SCT1_co], B: LinearOperator[_SCT2_co], xp: ModuleType | None = None) -> None: ...  # pyrefly:ignore[bad-override]
+    def __new__(
+        cls, A: LinearOperator[_SCT1_co, _ShapeT_co], B: LinearOperator[_SCT2_co, _ShapeT_co], xp: ModuleType | None = None
+    ) -> Self: ...
+    def __init__(
+        self, /, A: LinearOperator[_SCT1_co, _ShapeT_co], B: LinearOperator[_SCT2_co, _ShapeT_co], xp: ModuleType | None = None
+    ) -> None: ...
 
     #
     @override
     def _adjoint(self, /) -> Self: ...
 
 @final
-class _ScaledLinearOperator(LinearOperator[_SCT_co], Generic[_SCT_co]):
-    args: tuple[LinearOperator[_SCT_co], _SCT_co | complex]
+class _ScaledLinearOperator(LinearOperator[_SCT_co, _ShapeT_co], Generic[_SCT_co, _ShapeT_co]):
+    args: tuple[LinearOperator[_SCT_co, _ShapeT_co], _SCT_co | complex]
 
     #
-    @override
     @overload
-    def __new__(cls, A: LinearOperator[_SCT_co], alpha: _SCT_co | complex, xp: ModuleType | None = None) -> Self: ...  # type:ignore[overload-overlap]  # pyrefly:ignore[bad-override]
+    def __new__(cls, A: LinearOperator[_SCT_co, _ShapeT_co], alpha: _SCT_co | complex, xp: ModuleType | None = None) -> Self: ...
     @overload
-    def __new__(
-        cls, A: LinearOperator[npc.floating], alpha: onp.ToFloat64, xp: ModuleType | None = None
-    ) -> _ScaledLinearOperator[np.float64]: ...
+    def __new__[ShapeT: _Shape](
+        cls, A: LinearOperator[npc.floating, ShapeT], alpha: onp.ToFloat64, xp: ModuleType | None = None
+    ) -> _ScaledLinearOperator[np.float64, ShapeT]: ...
     @overload
-    def __new__(
-        cls, A: LinearOperator[npc.complexfloating], alpha: onp.ToComplex128, xp: ModuleType | None = None
-    ) -> _ScaledLinearOperator[np.complex128]: ...
+    def __new__[ShapeT: _Shape](
+        cls, A: LinearOperator[npc.complexfloating, ShapeT], alpha: onp.ToComplex128, xp: ModuleType | None = None
+    ) -> _ScaledLinearOperator[np.complex128, ShapeT]: ...
 
     #
-    @override
-    @overload
-    def __init__(self, /, A: LinearOperator[_SCT_co], alpha: _SCT_co | complex, xp: ModuleType | None = None) -> None: ...  # pyrefly:ignore[bad-override]
     @overload
     def __init__(
-        self: _ScaledLinearOperator[np.float64],
+        self, /, A: LinearOperator[_SCT_co, _ShapeT_co], alpha: _SCT_co | complex, xp: ModuleType | None = None
+    ) -> None: ...
+    @overload
+    def __init__[ShapeT: _Shape](
+        self: _ScaledLinearOperator[np.float64, ShapeT],
         /,
-        A: LinearOperator[npc.floating],
+        A: LinearOperator[npc.floating, ShapeT],
         alpha: onp.ToFloat64,
         xp: ModuleType | None = None,
     ) -> None: ...
     @overload
-    def __init__(
-        self: _ScaledLinearOperator[np.complex128], /, A: LinearOperator, alpha: onp.ToComplex128, xp: ModuleType | None = None
+    def __init__[ShapeT: _Shape](
+        self: _ScaledLinearOperator[np.complex128, ShapeT],
+        /,
+        A: LinearOperator[Any, ShapeT],
+        alpha: onp.ToComplex128,
+        xp: ModuleType | None = None,
     ) -> None: ...
 
     #
@@ -572,77 +558,83 @@ class _ScaledLinearOperator(LinearOperator[_SCT_co], Generic[_SCT_co]):
     def _adjoint(self, /) -> Self: ...
 
 @final
-class _PowerLinearOperator(LinearOperator[_SCT_co], Generic[_SCT_co]):
-    args: tuple[LinearOperator[_SCT_co], SupportsIndex]
+class _PowerLinearOperator(LinearOperator[_SCT_co, _ShapeT_co], Generic[_SCT_co, _ShapeT_co]):
+    args: tuple[LinearOperator[_SCT_co, _ShapeT_co], SupportsIndex]
 
     @override
-    def __new__(cls, A: LinearOperator[_SCT_co], p: SupportsIndex, xp: ModuleType | None = None) -> Self: ...  # pyrefly:ignore[bad-override]
+    def __new__(cls, A: LinearOperator[_SCT_co, _ShapeT_co], p: SupportsIndex, xp: ModuleType | None = None) -> Self: ...  # pyrefly:ignore[bad-override]
     @override
-    def __init__(self, /, A: LinearOperator[_SCT_co], p: SupportsIndex, xp: ModuleType | None = None) -> None: ...  # pyrefly:ignore[bad-override]
+    def __init__(self, /, A: LinearOperator[_SCT_co, _ShapeT_co], p: SupportsIndex, xp: ModuleType | None = None) -> None: ...  # pyrefly:ignore[bad-override]
 
     #
     @override
     def _adjoint(self, /) -> Self: ...
 
-class MatrixLinearOperator(LinearOperator[_SCT_co], Generic[_SCT_co]):
-    A: _spbase | onp.Array2D[_SCT_co]
-    args: tuple[_spbase | onp.Array2D[_SCT_co]]
+class MatrixLinearOperator(LinearOperator[_SCT_co, _ShapeT_co], Generic[_SCT_co, _ShapeT_co]):
+    A: _spbase[_SCT_co, _ShapeT_co] | onp.ArrayND[_SCT_co, _ShapeT_co]
+    args: tuple[_spbase[_SCT_co, _ShapeT_co] | onp.ArrayND[_SCT_co, _ShapeT_co]]
 
-    @override
-    def __new__(cls, /, A: _spbase | onp.ArrayND[_SCT_co], xp: ModuleType | None = None) -> Self: ...  # pyrefly:ignore[bad-override]
-    @override
-    def __init__(self, /, A: _spbase | onp.ArrayND[_SCT_co], xp: ModuleType | None = None) -> None: ...  # pyrefly:ignore[bad-override]
-
-    #
-    @override
-    def _adjoint(self, /) -> _AdjointMatrixOperator[_SCT_co]: ...
-
-@final
-class _AdjointMatrixOperator(MatrixLinearOperator[_SCT_co], Generic[_SCT_co]):
-    # pyrefly: ignore [bad-override]
-    args: tuple[LinearOperator[_SCT_co]]  # type: ignore[assignment]  # pyright: ignore[reportIncompatibleVariableOverride]
-
-    #
-    @override
-    def __new__(cls, A: LinearOperator[_SCT_co], xp: ModuleType | None = None) -> Self: ...  # pyrefly:ignore[bad-override]
-    @override
-    def __init__(self, /, A: LinearOperator[_SCT_co], xp: ModuleType | None = None) -> None: ...  # pyrefly:ignore[bad-override]
-
-    #
-    @override
-    def _adjoint(self, /) -> MatrixLinearOperator[_SCT_co]: ...  # type: ignore[override] # pyright: ignore[reportIncompatibleMethodOverride] # pyrefly: ignore[bad-override] # ty: ignore[invalid-method-override]
-
-class IdentityOperator(LinearOperator[_SCT_co], Generic[_SCT_co]):
-    @override
-    @overload
-    def __new__(cls, shape: _ToShape, dtype: onp.ToDType[_SCT_co], xp: None = None) -> Self: ...  # pyrefly:ignore[bad-override]
-    @overload
     def __new__(
-        cls, shape: _ToShape, dtype: onp.AnyFloat64DType | None = None, xp: None = None
-    ) -> IdentityOperator[np.float64]: ...
-    @overload
-    def __new__(cls, shape: _ToShape, dtype: onp.AnyComplex128DType, xp: None = None) -> IdentityOperator[np.complex128]: ...
-    @overload
-    def __new__(cls, shape: _ToShape, dtype: str, xp: None = None) -> IdentityOperator[Any]: ...
-    @overload
-    def __new__(cls, shape: _ToShape, dtype: Incomplete | None = None, *, xp: ModuleType) -> IdentityOperator[Any]: ...
+        cls, /, A: _spbase[_SCT_co, _ShapeT_co] | onp.ArrayND[_SCT_co, _ShapeT_co], xp: ModuleType | None = None
+    ) -> Self: ...
+    def __init__(
+        self, /, A: _spbase[_SCT_co, _ShapeT_co] | onp.ArrayND[_SCT_co, _ShapeT_co], xp: ModuleType | None = None
+    ) -> None: ...
 
     #
     @override
+    def _adjoint(self, /) -> _AdjointMatrixOperator[_SCT_co, _ShapeT_co]: ...
+
+@final
+class _AdjointMatrixOperator(MatrixLinearOperator[_SCT_co, _ShapeT_co], Generic[_SCT_co, _ShapeT_co]):
+    # pyrefly: ignore [bad-override]
+    args: tuple[LinearOperator[_SCT_co, _ShapeT_co]]  # type: ignore[assignment]  # pyright: ignore[reportIncompatibleVariableOverride]
+
+    #
+    @override
+    def __new__(cls, A: LinearOperator[_SCT_co, _ShapeT_co], xp: ModuleType | None = None) -> Self: ...  # pyrefly:ignore[bad-override]
+    @override
+    def __init__(self, /, A: LinearOperator[_SCT_co, _ShapeT_co], xp: ModuleType | None = None) -> None: ...  # pyrefly:ignore[bad-override]
+
+    #
+    @override
+    def _adjoint(self, /) -> MatrixLinearOperator[_SCT_co, _ShapeT_co]: ...  # type: ignore[override] # pyright: ignore[reportIncompatibleMethodOverride] # pyrefly: ignore[bad-override] # ty: ignore[invalid-method-override]
+
+class IdentityOperator(LinearOperator[_SCT_co, _ShapeT_co], Generic[_SCT_co, _ShapeT_co]):
     @overload
-    def __init__(self, /, shape: _ToShape, dtype: onp.ToDType[_SCT_co], xp: None = None) -> None: ...  # pyrefly:ignore[bad-override]
+    def __new__(cls, shape: _ShapeT_co, dtype: onp.ToDType[_SCT_co], xp: None = None) -> Self: ...
     @overload
-    def __init__(
-        self: IdentityOperator[np.float64], /, shape: _ToShape, dtype: onp.AnyFloat64DType | None = None, xp: None = None
+    def __new__[ShapeT: _Shape](
+        cls, shape: ShapeT, dtype: onp.AnyFloat64DType | None = None, xp: None = None
+    ) -> IdentityOperator[np.float64, ShapeT]: ...
+    @overload
+    def __new__[ShapeT: _Shape](
+        cls, shape: ShapeT, dtype: onp.AnyComplex128DType, xp: None = None
+    ) -> IdentityOperator[np.complex128, ShapeT]: ...
+    @overload
+    def __new__[ShapeT: _Shape](cls, shape: ShapeT, dtype: str, xp: None = None) -> IdentityOperator[Any, ShapeT]: ...
+    @overload
+    def __new__[ShapeT: _Shape](
+        cls, shape: ShapeT, dtype: Incomplete | None = None, *, xp: ModuleType
+    ) -> IdentityOperator[Any, ShapeT]: ...
+
+    #
+    @overload
+    def __init__(self, /, shape: _ShapeT_co, dtype: onp.ToDType[_SCT_co], xp: None = None) -> None: ...
+    @overload
+    def __init__[ShapeT: _Shape](
+        self: IdentityOperator[np.float64, ShapeT], /, shape: ShapeT, dtype: onp.AnyFloat64DType | None = None, xp: None = None
     ) -> None: ...
     @overload
-    def __init__(
-        self: IdentityOperator[np.complex128], /, shape: _ToShape, dtype: onp.AnyComplex128DType, xp: None = None
+    def __init__[ShapeT: _Shape](
+        self: IdentityOperator[np.complex128, ShapeT], /, shape: ShapeT, dtype: onp.AnyComplex128DType, xp: None = None
     ) -> None: ...
     @overload
-    def __init__(self: IdentityOperator[Any], /, shape: _ToShape, dtype: str, xp: None = None) -> None: ...
+    def __init__[ShapeT: _Shape](self: IdentityOperator[Any, ShapeT], /, shape: ShapeT, dtype: str, xp: None = None) -> None: ...
     @overload
-    def __init__(self: IdentityOperator[Any], /, shape: _ToShape, dtype: Incomplete | None = None, *, xp: ModuleType) -> None: ...
+    def __init__[ShapeT: _Shape](
+        self: IdentityOperator[Any, ShapeT], /, shape: ShapeT, dtype: Incomplete | None = None, *, xp: ModuleType
+    ) -> None: ...
 
     #
     @override
@@ -650,14 +642,22 @@ class IdentityOperator(LinearOperator[_SCT_co], Generic[_SCT_co]):
 
 #
 @overload
-def aslinearoperator[InexactT: npc.inexact](A: onp.CanArrayND[InexactT]) -> MatrixLinearOperator[InexactT]: ...
+def aslinearoperator[InexactT: npc.inexact, ShapeT: _Shape](
+    A: onp.CanArrayND[InexactT, ShapeT],
+) -> MatrixLinearOperator[InexactT, ShapeT]: ...
 @overload
-def aslinearoperator[InexactT: npc.inexact](A: _spbase[InexactT]) -> MatrixLinearOperator[InexactT]: ...
+def aslinearoperator[InexactT: npc.inexact, ShapeT: _Shape](
+    A: _spbase[InexactT, ShapeT],
+) -> MatrixLinearOperator[InexactT, ShapeT]: ...
 @overload
-def aslinearoperator(
-    A: onp.ArrayND[np.bool | npc.integer | np.float64] | _spbase[np.bool | npc.integer | np.float64],
-) -> MatrixLinearOperator[np.float64]: ...
+def aslinearoperator[ShapeT: _Shape](
+    A: onp.ArrayND[np.bool | npc.integer | np.float64, ShapeT] | _spbase[np.bool | npc.integer | np.float64, ShapeT],
+) -> MatrixLinearOperator[np.float64, ShapeT]: ...
 @overload
-def aslinearoperator[InexactT: npc.inexact](A: _HasShapeAndDTypeAndMatVec[InexactT]) -> MatrixLinearOperator[InexactT]: ...
+def aslinearoperator[InexactT: npc.inexact, ShapeT: _Shape](
+    A: _HasShapeAndDTypeAndMatVec[InexactT, ShapeT],
+) -> MatrixLinearOperator[InexactT, ShapeT]: ...
 @overload
-def aslinearoperator[InexactT: npc.inexact](A: _HasShapeAndMatVec[InexactT]) -> MatrixLinearOperator[InexactT]: ...
+def aslinearoperator[InexactT: npc.inexact, ShapeT: _Shape](
+    A: _HasShapeAndMatVec[InexactT, ShapeT],
+) -> MatrixLinearOperator[InexactT, ShapeT]: ...

--- a/tests/sparse/linalg/test__interface.pyi
+++ b/tests/sparse/linalg/test__interface.pyi
@@ -8,29 +8,51 @@ from scipy.sparse import csr_array
 from scipy.sparse.linalg import LinearOperator, aslinearoperator
 from scipy.sparse.linalg._interface import MatrixLinearOperator, _CustomLinearOperator
 
-int_type: type[int]
-float_type: type[float]
-complex_type: type[complex]
+_type_int: type[int]
+_type_float: type[float]
+_type_complex: type[complex]
+
+_2d: tuple[int, int]
+_3d: tuple[int, int, int]
+
+_2d_i64: onp.Array2D[np.int64]
+_2d_f64: onp.Array2D[np.float64]
+_2d_c128: onp.Array2D[np.complex128]
+
+_3d_i64: onp.Array3D[np.int64]
+_3d_f64: onp.Array3D[np.float64]
+_3d_c128: onp.Array3D[np.complex128]
+
+_sp_f64: csr_array[np.float64]
+_sp_c128: csr_array[np.complex128]
 
 ###
+#
 
 def mv(v: npt.NDArray[np.float64 | np.complex128]) -> npt.NDArray[np.float64 | np.complex128]: ...
 
-assert_type(LinearOperator((2, 2), matvec=mv, dtype=np.int16), _CustomLinearOperator[np.int16])
-assert_type(LinearOperator((2, 2), matvec=mv, dtype=int), _CustomLinearOperator[np.int_])
-assert_type(LinearOperator((2, 2), matvec=mv, dtype=float), _CustomLinearOperator[np.float64])
-assert_type(LinearOperator((2, 2), matvec=mv, dtype=complex), _CustomLinearOperator[np.complex128])
-assert_type(LinearOperator((2, 2), matvec=mv), _CustomLinearOperator[np.int8 | Any])
+assert_type(LinearOperator(_2d, matvec=mv, dtype=np.int16), _CustomLinearOperator[np.int16, tuple[int, int]])
+assert_type(LinearOperator(_2d, matvec=mv, dtype=int), _CustomLinearOperator[np.int_, tuple[int, int]])
+assert_type(LinearOperator(_2d, matvec=mv, dtype=float), _CustomLinearOperator[np.float64, tuple[int, int]])
+assert_type(LinearOperator(_2d, matvec=mv, dtype=complex), _CustomLinearOperator[np.complex128, tuple[int, int]])
+assert_type(LinearOperator(_2d, matvec=mv), _CustomLinearOperator[np.int8 | Any, tuple[int, int]])
 
+assert_type(LinearOperator(_3d, matvec=mv, dtype=np.int16), _CustomLinearOperator[np.int16, tuple[int, int, int]])
+assert_type(LinearOperator(_3d, matvec=mv, dtype=int), _CustomLinearOperator[np.int_, tuple[int, int, int]])
+assert_type(LinearOperator(_3d, matvec=mv, dtype=float), _CustomLinearOperator[np.float64, tuple[int, int, int]])
+assert_type(LinearOperator(_3d, matvec=mv, dtype=complex), _CustomLinearOperator[np.complex128, tuple[int, int, int]])
+assert_type(LinearOperator(_3d, matvec=mv), _CustomLinearOperator[np.int8 | Any, tuple[int, int, int]])
+
+###
 # aslinearoperator
-a_f64: onp.Array2D[np.float64]
-a_c128: onp.Array2D[np.complex128]
-a_i64: onp.Array2D[np.int64]
-sp_f64: csr_array[np.float64]
-sp_c128: csr_array[np.complex128]
 
-assert_type(aslinearoperator(a_f64), MatrixLinearOperator[np.float64])
-assert_type(aslinearoperator(a_c128), MatrixLinearOperator[np.complex128])
-assert_type(aslinearoperator(a_i64), MatrixLinearOperator[np.float64])
-assert_type(aslinearoperator(sp_f64), MatrixLinearOperator[np.float64])
-assert_type(aslinearoperator(sp_c128), MatrixLinearOperator[np.complex128])
+assert_type(aslinearoperator(_2d_f64), MatrixLinearOperator[np.float64, tuple[int, int]])
+assert_type(aslinearoperator(_2d_c128), MatrixLinearOperator[np.complex128, tuple[int, int]])
+assert_type(aslinearoperator(_2d_i64), MatrixLinearOperator[np.float64, tuple[int, int]])
+
+assert_type(aslinearoperator(_3d_f64), MatrixLinearOperator[np.float64, tuple[int, int, int]])
+assert_type(aslinearoperator(_3d_c128), MatrixLinearOperator[np.complex128, tuple[int, int, int]])
+assert_type(aslinearoperator(_3d_i64), MatrixLinearOperator[np.float64, tuple[int, int, int]])
+
+assert_type(aslinearoperator(_sp_f64), MatrixLinearOperator[np.float64, tuple[int, int]])
+assert_type(aslinearoperator(_sp_c128), MatrixLinearOperator[np.complex128, tuple[int, int]])

--- a/tests/sparse/linalg/test__interface.pyi
+++ b/tests/sparse/linalg/test__interface.pyi
@@ -27,7 +27,7 @@ _sp_f64: csr_array[np.float64]
 _sp_c128: csr_array[np.complex128]
 
 ###
-#
+# LinearOperator.__new__
 
 def mv(v: npt.NDArray[np.float64 | np.complex128]) -> npt.NDArray[np.float64 | np.complex128]: ...
 


### PR DESCRIPTION
From the 1.18.0rc1 relnotes (https://github.com/scipy/scipy/releases/tag/v1.18.0rc1):

> Support for n-dimensional linear operators has been added to
`scipy.sparse.linalg.LinearOperator`.

towards #1614