### PR TITLE
👽️ `spatial.transform.Rotation.approx_equal`: return `np.bool` if both rotations are single.

### DIFF
--- a/scipy-stubs/spatial/transform/_rotation.pyi
+++ b/scipy-stubs/spatial/transform/_rotation.pyi
@@ -19,12 +19,10 @@ type _RotAxisSeq = L[
 ]  # fmt: skip
 type _RotAxis = L["X", "Y", "Z"]
 
-type _JustAnyShape = tuple[Never, Never, Never]
+type _JustAnyShape = tuple[Never, Never, Never, Never]
 type _ToFloatStrictND = onp.ArrayND[npc.floating | npc.integer, _JustAnyShape]
 
-_ShapeT = TypeVar("_ShapeT", bound=tuple[int, ...])
 _ShapeT_co = TypeVar("_ShapeT_co", bound=tuple[int, ...], default=tuple[Any, ...], covariant=True)
-_RotationT = TypeVar("_RotationT", bound=Rotation)
 
 ###
 
@@ -212,9 +210,31 @@ class Rotation(Generic[_ShapeT_co]):
     @overload
     def apply(self, /, vectors: onp.ToFloatND, inverse: bool = False) -> onp.ArrayND[np.float64]: ...
 
-    # NOTE: The docstring incorrectly states that this can return a bool, but it always returns an array, even for single
-    # rotations. See https://github.com/scipy/scipy/pull/24763
-    def approx_equal(self, /, other: Rotation, atol: float | None = None, degrees: bool = False) -> onp.ArrayND[np.bool]: ...
+    # returns `np.bool` if both are single since 1.18.0
+    @overload
+    def approx_equal(
+        self: Rotation[_JustAnyShape], /, other: Rotation[_JustAnyShape], atol: float | None = None, degrees: bool = False
+    ) -> onp.ArrayND[np.bool] | np.bool: ...
+    @overload
+    def approx_equal(
+        self: Rotation[tuple[()]], /, other: Rotation[tuple[()]], atol: float | None = None, degrees: bool = False
+    ) -> np.bool: ...
+    @overload
+    def approx_equal(
+        self: Rotation[tuple[int] | tuple[int, int] | tuple[int, int, int]],
+        /,
+        other: Rotation,
+        atol: float | None = None,
+        degrees: bool = False,
+    ) -> onp.ArrayND[np.bool]: ...
+    @overload
+    def approx_equal(
+        self: Rotation,
+        /,
+        other: Rotation[tuple[int] | tuple[int, int] | tuple[int, int, int]],
+        atol: float | None = None,
+        degrees: bool = False,
+    ) -> onp.ArrayND[np.bool]: ...
 
     #
     @overload
@@ -292,9 +312,9 @@ class Rotation(Generic[_ShapeT_co]):
     def from_euler(seq: str, angles: onp.ToFloat, degrees: bool = False) -> Rotation[tuple[()]]: ...
     @overload
     @staticmethod
-    def from_euler(
-        seq: str, angles: onp.ArrayND[npc.floating | npc.integer, _ShapeT], degrees: bool = False
-    ) -> Rotation[_ShapeT]: ...
+    def from_euler[ShapeT: tuple[int, ...]](
+        seq: str, angles: onp.ArrayND[npc.floating | npc.integer, ShapeT], degrees: bool = False
+    ) -> Rotation[ShapeT]: ...
     @overload
     @staticmethod
     def from_euler(seq: str, angles: onp.ToFloatND, degrees: bool = False) -> Rotation: ...
@@ -307,9 +327,9 @@ class Rotation(Generic[_ShapeT_co]):
     ) -> Rotation[tuple[()]]: ...
     @overload
     @staticmethod
-    def from_davenport(
-        axes: onp.ToFloatND, order: _RotOrder, angles: onp.ArrayND[npc.floating | npc.integer, _ShapeT], degrees: bool = False
-    ) -> Rotation[_ShapeT]: ...
+    def from_davenport[ShapeT: tuple[int, ...]](
+        axes: onp.ToFloatND, order: _RotOrder, angles: onp.ArrayND[npc.floating | npc.integer, ShapeT], degrees: bool = False
+    ) -> Rotation[ShapeT]: ...
     @overload
     @staticmethod
     def from_davenport(axes: onp.ToFloatND, order: _RotOrder, angles: onp.ToFloatND, degrees: bool = False) -> Rotation: ...
@@ -317,7 +337,7 @@ class Rotation(Generic[_ShapeT_co]):
     #
     @overload
     @staticmethod
-    def concatenate(rotations: _RotationT) -> _RotationT: ...
+    def concatenate[RotationT: Rotation](rotations: RotationT) -> RotationT: ...
     @overload
     @staticmethod
     def concatenate(rotations: Sequence[Rotation[_JustAnyShape]]) -> Rotation: ...
@@ -347,7 +367,7 @@ class Rotation(Generic[_ShapeT_co]):
     def identity(num: None = None, *, shape: int) -> Rotation[tuple[int]]: ...
     @overload
     @staticmethod
-    def identity(num: None = None, *, shape: _ShapeT) -> Rotation[_ShapeT]: ...
+    def identity[ShapeT: tuple[int, ...]](num: None = None, *, shape: ShapeT) -> Rotation[ShapeT]: ...
 
     #
     @overload
@@ -362,9 +382,9 @@ class Rotation(Generic[_ShapeT_co]):
     ) -> Rotation[tuple[int]]: ...
     @overload
     @staticmethod
-    def random(
-        num: None = None, rng: onp.random.ToRNG | None = None, *, shape: _ShapeT, random_state: onp.random.ToRNG | None = None
-    ) -> Rotation[_ShapeT]: ...
+    def random[ShapeT: tuple[int, ...]](
+        num: None = None, rng: onp.random.ToRNG | None = None, *, shape: ShapeT, random_state: onp.random.ToRNG | None = None
+    ) -> Rotation[ShapeT]: ...
 
     #
     @overload

--- a/tests/spatial/test__rotation.pyi
+++ b/tests/spatial/test__rotation.pyi
@@ -156,9 +156,9 @@ assert_type(_rot_nd.apply(_f64_nd), onp.ArrayND[np.float64])
 
 # approx_equal
 
-assert_type(_rot_0d.approx_equal(_rot_0d), onp.ArrayND[np.bool])
+assert_type(_rot_0d.approx_equal(_rot_0d), np.bool)
 assert_type(_rot_1d.approx_equal(_rot_1d), onp.ArrayND[np.bool])
-assert_type(_rot_nd.approx_equal(_rot_nd), onp.ArrayND[np.bool])
+assert_type(_rot_nd.approx_equal(_rot_nd), np.bool | onp.ArrayND[np.bool])  # type:ignore[assert-type]  # mypy infers `Any`
 
 # as_* with known shapes
 


### PR DESCRIPTION
The docstring already said this was the case before 1.18.0, so it's probably not worth mentioning in the relnotes, even though this technically is an undocumented breaking API change.