### PR TITLE
👽️ `linalg.{blas,lapack}`: add `HAS_{I}LP64` constants

### DIFF
--- a/scipy-stubs/linalg/blas.pyi
+++ b/scipy-stubs/linalg/blas.pyi
@@ -1,6 +1,6 @@
 from _typeshed import Incomplete
 from collections.abc import Iterable, Iterator, Sequence
-from typing import Literal as L, Protocol, SupportsIndex, TypeVar, overload, type_check_only
+from typing import Final, Literal as L, Protocol, SupportsIndex, TypeVar, overload, type_check_only
 
 import numpy as np
 import numpy.typing as npt
@@ -197,6 +197,9 @@ class _FortranFunction(Protocol):
     def __call__(self, /, *args: object, **kwargs: object) -> Incomplete: ...
 
 ###
+
+HAS_LP64: Final[bool] = ...
+HAS_ILP64: Final[bool] = ...
 
 # see `scipy.linalg.blas._type_conv`
 def find_best_blas_type(

--- a/scipy-stubs/linalg/lapack.pyi
+++ b/scipy-stubs/linalg/lapack.pyi
@@ -633,6 +633,7 @@ from .blas import _FortranFunction
 
 __all__ = ["get_lapack_funcs"]
 
+HAS_LP64: Final[bool] = ...
 HAS_ILP64: Final[bool] = ...
 
 def get_lapack_funcs(


### PR DESCRIPTION
Publically named, but not in `__all__` or in the docs, so probably not worth adding to the relnotes.