### PR TITLE
👽️ `linalg.cho_factor`: change 2nd return type to bool array

### DIFF
--- a/scipy-stubs/linalg/_decomp_cholesky.pyi
+++ b/scipy-stubs/linalg/_decomp_cholesky.pyi
@@ -107,131 +107,155 @@ def cholesky_banded(
 @overload  # Nd +f64
 def cho_factor[Shape2T: tuple[int, int, *tuple[int, ...]]](  # type: ignore[overload-overlap]
     a: nptc.CanArray[Shape2T, np.dtype[_as_f64]], lower: bool = False, overwrite_a: bool = False, check_finite: bool = True
-) -> tuple[onp.ArrayND[np.float64, Shape2T], bool]: ...
+) -> tuple[onp.ArrayND[np.float64, Shape2T], onp.ArrayND[np.bool]]: ...
 @overload  # Nd +f32
 def cho_factor[Shape2T: tuple[int, int, *tuple[int, ...]]](
     a: nptc.CanArray[Shape2T, np.dtype[_as_f32]], lower: bool = False, overwrite_a: bool = False, check_finite: bool = True
-) -> tuple[onp.ArrayND[np.float32, Shape2T], bool]: ...
+) -> tuple[onp.ArrayND[np.float32, Shape2T], onp.ArrayND[np.bool]]: ...
 @overload  # Nd +c128
 def cho_factor[Shape2T: tuple[int, int, *tuple[int, ...]]](
     a: nptc.CanArray[Shape2T, np.dtype[_as_c128]], lower: bool = False, overwrite_a: bool = False, check_finite: bool = True
-) -> tuple[onp.ArrayND[np.complex128, Shape2T], bool]: ...
+) -> tuple[onp.ArrayND[np.complex128, Shape2T], onp.ArrayND[np.bool]]: ...
 @overload  # Nd ~c64
 def cho_factor[Shape2T: tuple[int, int, *tuple[int, ...]]](
     a: nptc.CanArray[Shape2T, np.dtype[_as_c64]], lower: bool = False, overwrite_a: bool = False, check_finite: bool = True
-) -> tuple[onp.ArrayND[np.complex64, Shape2T], bool]: ...
+) -> tuple[onp.ArrayND[np.complex64, Shape2T], onp.ArrayND[np.bool]]: ...
 @overload  # Nd ~number
 def cho_factor[Shape2T: tuple[int, int, *tuple[int, ...]]](
     a: nptc.CanArray[Shape2T, np.dtype[npc.number]], lower: bool = False, overwrite_a: bool = False, check_finite: bool = True
-) -> tuple[onp.ArrayND[Any, Shape2T], bool]: ...
+) -> tuple[onp.ArrayND[Any, Shape2T], onp.ArrayND[np.bool]]: ...
 @overload  # 2d +f64
 def cho_factor(
     a: _Sequence2D[float], lower: bool = False, overwrite_a: bool = False, check_finite: bool = True
-) -> tuple[onp.Array2D[np.float64], bool]: ...
+) -> tuple[onp.Array2D[np.float64], onp.ArrayND[np.bool]]: ...
 @overload  # 2d ~c128
 def cho_factor(
     a: Sequence[MutableSequence[complex]], lower: bool = False, overwrite_a: bool = False, check_finite: bool = True
-) -> tuple[onp.Array2D[np.complex128], bool]: ...
+) -> tuple[onp.Array2D[np.complex128], onp.ArrayND[np.bool]]: ...
 @overload  # ?d +f64
 def cho_factor(
     a: onp.SequenceND[_Sequence2D[float]], lower: bool = False, overwrite_a: bool = False, check_finite: bool = True
-) -> tuple[onp.ArrayND[np.float64], bool]: ...
+) -> tuple[onp.ArrayND[np.float64], onp.ArrayND[np.bool]]: ...
 @overload  # ?d ~c128
 def cho_factor(
     a: onp.SequenceND[Sequence[MutableSequence[complex]]],
     lower: bool = False,
     overwrite_a: bool = False,
     check_finite: bool = True,
-) -> tuple[onp.ArrayND[np.complex128], bool]: ...
+) -> tuple[onp.ArrayND[np.complex128], onp.ArrayND[np.bool]]: ...
 
 # keep in sync with `cho_solve_banded` and `lu_solve` in `_decomp_lu`
 @overload  # ?d +f64\+f32, ?d +f64
 def cho_solve(  # type: ignore[overload-overlap]
-    c_and_lower: tuple[onp.ToArrayND[float, _as_f64], bool],
+    c_and_lower: tuple[onp.ToArrayND[float, _as_f64], onp.ToBool | onp.ToBoolND],
     b: onp.ToFloatND,
     overwrite_b: bool = False,
     check_finite: bool = True,
 ) -> onp.ArrayND[np.float64]: ...
 @overload  # ?d +f64, ?d +f64\+f32
 def cho_solve(  # type: ignore[overload-overlap]
-    c_and_lower: tuple[onp.ToFloatND, bool],
+    c_and_lower: tuple[onp.ToFloatND, onp.ToBool | onp.ToBoolND],
     b: onp.ToArrayND[float, _as_f64],
     overwrite_b: bool = False,
     check_finite: bool = True,
 ) -> onp.ArrayND[np.float64]: ...
 @overload  # ?d +f32, ?d +f32
 def cho_solve(
-    c_and_lower: tuple[onp.ToFloat32_ND, bool], b: onp.ToFloat32_ND, overwrite_b: bool = False, check_finite: bool = True
+    c_and_lower: tuple[onp.ToFloat32_ND, onp.ToBool | onp.ToBoolND],
+    b: onp.ToFloat32_ND,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
 ) -> onp.ArrayND[np.float32]: ...
 @overload  # ?d ~c128|c160, ?d +c128
 def cho_solve(
-    c_and_lower: tuple[onp.ToJustComplex128_ND | onp.ToJustCLongDoubleND, bool],
+    c_and_lower: tuple[onp.ToJustComplex128_ND | onp.ToJustCLongDoubleND, onp.ToBool | onp.ToBoolND],
     b: onp.ToComplexND,
     overwrite_b: bool = False,
     check_finite: bool = True,
 ) -> onp.ArrayND[np.complex128]: ...
 @overload  # ?d +c128, ?d ~c128|c160
 def cho_solve(
-    c_and_lower: tuple[onp.ToComplexND, bool],
+    c_and_lower: tuple[onp.ToComplexND, onp.ToBool | onp.ToBoolND],
     b: onp.ToJustComplex128_ND | onp.ToJustCLongDoubleND,
     overwrite_b: bool = False,
     check_finite: bool = True,
 ) -> onp.ArrayND[np.complex128]: ...
 @overload  # ?d ~c64, ?d +c64
 def cho_solve(
-    c_and_lower: tuple[onp.ToJustComplex64_ND, bool], b: onp.ToComplex64_ND, overwrite_b: bool = False, check_finite: bool = True
+    c_and_lower: tuple[onp.ToJustComplex64_ND, onp.ToBool | onp.ToBoolND],
+    b: onp.ToComplex64_ND,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
 ) -> onp.ArrayND[np.complex64]: ...
 @overload  # ?d +c64, ?d ~c64
 def cho_solve(
-    c_and_lower: tuple[onp.ToComplex64_ND, bool], b: onp.ToJustComplex64_ND, overwrite_b: bool = False, check_finite: bool = True
+    c_and_lower: tuple[onp.ToComplex64_ND, onp.ToBool | onp.ToBoolND],
+    b: onp.ToJustComplex64_ND,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
 ) -> onp.ArrayND[np.complex64]: ...
 @overload  # ?d +cfloating, ?d ~cfloating (fallback)
 def cho_solve(
-    c_and_lower: tuple[onp.ToComplexND, bool], b: onp.ToComplexND, overwrite_b: bool = False, check_finite: bool = True
+    c_and_lower: tuple[onp.ToComplexND, onp.ToBool | onp.ToBoolND],
+    b: onp.ToComplexND,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
 ) -> onp.ArrayND[Any]: ...
 
 # keep in sync with `cho_solve`
 @overload  # ?d +f64\+f32, ?d +f64
 def cho_solve_banded(  # type: ignore[overload-overlap]
-    cb_and_lower: tuple[onp.ToArrayND[float, _as_f64], bool],
+    cb_and_lower: tuple[onp.ToArrayND[float, _as_f64], onp.ToBool | onp.ToBoolND],
     b: onp.ToFloatND,
     overwrite_b: bool = False,
     check_finite: bool = True,
 ) -> onp.ArrayND[np.float64]: ...
 @overload  # ?d +f64, ?d +f64\+f32
 def cho_solve_banded(  # type: ignore[overload-overlap]
-    cb_and_lower: tuple[onp.ToFloatND, bool],
+    cb_and_lower: tuple[onp.ToFloatND, onp.ToBool | onp.ToBoolND],
     b: onp.ToArrayND[float, _as_f64],
     overwrite_b: bool = False,
     check_finite: bool = True,
 ) -> onp.ArrayND[np.float64]: ...
 @overload  # ?d +f32, ?d +f32
 def cho_solve_banded(
-    cb_and_lower: tuple[onp.ToFloat32_ND, bool], b: onp.ToFloat32_ND, overwrite_b: bool = False, check_finite: bool = True
+    cb_and_lower: tuple[onp.ToFloat32_ND, onp.ToBool | onp.ToBoolND],
+    b: onp.ToFloat32_ND,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
 ) -> onp.ArrayND[np.float32]: ...
 @overload  # ?d ~c128|c160, ?d +c128
 def cho_solve_banded(
-    cb_and_lower: tuple[onp.ToJustComplex128_ND | onp.ToJustCLongDoubleND, bool],
+    cb_and_lower: tuple[onp.ToJustComplex128_ND | onp.ToJustCLongDoubleND, onp.ToBool | onp.ToBoolND],
     b: onp.ToComplexND,
     overwrite_b: bool = False,
     check_finite: bool = True,
 ) -> onp.ArrayND[np.complex128]: ...
 @overload  # ?d +c128, ?d ~c128|c160
 def cho_solve_banded(
-    cb_and_lower: tuple[onp.ToComplexND, bool],
+    cb_and_lower: tuple[onp.ToComplexND, onp.ToBool | onp.ToBoolND],
     b: onp.ToJustComplex128_ND | onp.ToJustCLongDoubleND,
     overwrite_b: bool = False,
     check_finite: bool = True,
 ) -> onp.ArrayND[np.complex128]: ...
 @overload  # ?d ~c64, ?d +c64
 def cho_solve_banded(
-    cb_and_lower: tuple[onp.ToJustComplex64_ND, bool], b: onp.ToComplex64_ND, overwrite_b: bool = False, check_finite: bool = True
+    cb_and_lower: tuple[onp.ToJustComplex64_ND, onp.ToBool | onp.ToBoolND],
+    b: onp.ToComplex64_ND,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
 ) -> onp.ArrayND[np.complex64]: ...
 @overload  # ?d +c64, ?d ~c64
 def cho_solve_banded(
-    cb_and_lower: tuple[onp.ToComplex64_ND, bool], b: onp.ToJustComplex64_ND, overwrite_b: bool = False, check_finite: bool = True
+    cb_and_lower: tuple[onp.ToComplex64_ND, onp.ToBool | onp.ToBoolND],
+    b: onp.ToJustComplex64_ND,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
 ) -> onp.ArrayND[np.complex64]: ...
 @overload  # ?d +cfloating, ?d ~cfloating (fallback)
 def cho_solve_banded(
-    cb_and_lower: tuple[onp.ToComplexND, bool], b: onp.ToComplexND, overwrite_b: bool = False, check_finite: bool = True
+    cb_and_lower: tuple[onp.ToComplexND, onp.ToBool | onp.ToBoolND],
+    b: onp.ToComplexND,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
 ) -> onp.ArrayND[Any]: ...

--- a/tests/linalg/test__decomp_cholesky.pyi
+++ b/tests/linalg/test__decomp_cholesky.pyi
@@ -68,28 +68,28 @@ assert_type(cholesky(_py_c_3d), onp.ArrayND[np.complex128])
 ###
 # cho_factor (congruent with cholesky)
 
-assert_type(cho_factor(_bool_2d), tuple[onp.Array2D[np.float32], bool])
-assert_type(cho_factor(_i8_2d), tuple[onp.Array2D[np.float32], bool])
-assert_type(cho_factor(_i16_2d), tuple[onp.Array2D[np.float32], bool])
-assert_type(cho_factor(_i32_2d), tuple[onp.Array2D[np.float64], bool])
-assert_type(cho_factor(_i64_2d), tuple[onp.Array2D[np.float64], bool])
-assert_type(cho_factor(_f16_2d), tuple[onp.Array2D[np.float32], bool])
-assert_type(cho_factor(_f32_2d), tuple[onp.Array2D[np.float32], bool])
-assert_type(cho_factor(_f64_2d), tuple[onp.Array2D[np.float64], bool])
-assert_type(cho_factor(_f80_2d), tuple[onp.Array2D[np.float64], bool])
-assert_type(cho_factor(_c64_2d), tuple[onp.Array2D[np.complex64], bool])
-assert_type(cho_factor(_c128_2d), tuple[onp.Array2D[np.complex128], bool])
-assert_type(cho_factor(_c160_2d), tuple[onp.Array2D[np.complex128], bool])
-assert_type(cho_factor(_number_2d), tuple[onp.Array2D[Any], bool])
+assert_type(cho_factor(_bool_2d), tuple[onp.Array2D[np.float32], onp.ArrayND[np.bool]])
+assert_type(cho_factor(_i8_2d), tuple[onp.Array2D[np.float32], onp.ArrayND[np.bool]])
+assert_type(cho_factor(_i16_2d), tuple[onp.Array2D[np.float32], onp.ArrayND[np.bool]])
+assert_type(cho_factor(_i32_2d), tuple[onp.Array2D[np.float64], onp.ArrayND[np.bool]])
+assert_type(cho_factor(_i64_2d), tuple[onp.Array2D[np.float64], onp.ArrayND[np.bool]])
+assert_type(cho_factor(_f16_2d), tuple[onp.Array2D[np.float32], onp.ArrayND[np.bool]])
+assert_type(cho_factor(_f32_2d), tuple[onp.Array2D[np.float32], onp.ArrayND[np.bool]])
+assert_type(cho_factor(_f64_2d), tuple[onp.Array2D[np.float64], onp.ArrayND[np.bool]])
+assert_type(cho_factor(_f80_2d), tuple[onp.Array2D[np.float64], onp.ArrayND[np.bool]])
+assert_type(cho_factor(_c64_2d), tuple[onp.Array2D[np.complex64], onp.ArrayND[np.bool]])
+assert_type(cho_factor(_c128_2d), tuple[onp.Array2D[np.complex128], onp.ArrayND[np.bool]])
+assert_type(cho_factor(_c160_2d), tuple[onp.Array2D[np.complex128], onp.ArrayND[np.bool]])
+assert_type(cho_factor(_number_2d), tuple[onp.Array2D[Any], onp.ArrayND[np.bool]])
 
 cho_factor(_f64_1d)  # type:ignore[type-var] # pyright:ignore[reportArgumentType,reportCallIssue] # pyrefly:ignore[no-matching-overload]
-assert_type(cho_factor(_f64_3d), tuple[onp.Array3D[np.float64], bool])
-assert_type(cho_factor(_f64_nd), tuple[onp.ArrayND[np.float64], bool])  # pyrefly:ignore[assert-type]
+assert_type(cho_factor(_f64_3d), tuple[onp.Array3D[np.float64], onp.ArrayND[np.bool]])
+assert_type(cho_factor(_f64_nd), tuple[onp.ArrayND[np.float64], onp.ArrayND[np.bool]])  # pyrefly:ignore[assert-type]
 
-assert_type(cho_factor(_py_f_2d), tuple[onp.Array2D[np.float64], bool])
-assert_type(cho_factor(_py_f_3d), tuple[onp.ArrayND[np.float64], bool])
-assert_type(cho_factor(_py_c_2d), tuple[onp.Array2D[np.complex128], bool])
-assert_type(cho_factor(_py_c_3d), tuple[onp.ArrayND[np.complex128], bool])
+assert_type(cho_factor(_py_f_2d), tuple[onp.Array2D[np.float64], onp.ArrayND[np.bool]])
+assert_type(cho_factor(_py_f_3d), tuple[onp.ArrayND[np.float64], onp.ArrayND[np.bool]])
+assert_type(cho_factor(_py_c_2d), tuple[onp.Array2D[np.complex128], onp.ArrayND[np.bool]])
+assert_type(cho_factor(_py_c_3d), tuple[onp.ArrayND[np.complex128], onp.ArrayND[np.bool]])
 
 ###
 # cholesky_banded (same signature as cholesky)


### PR DESCRIPTION
The second return type of `scipy.linalg.cho_factor` silently changed from `bool` to `NDArray[np.bool]`, even if 0d (which may or may not have been intentional).
Either way, it should probably be mentioned in the release notes, because this could be a breaking change in some cases.