### PR TITLE
👽️ `sparse.{bsr,dok}_{array,matrix}.count_nonzero`: support for `axis` 

### DIFF
--- a/scipy-stubs/sparse/_bsr.pyi
+++ b/scipy-stubs/sparse/_bsr.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from typing import Any, ClassVar, Generic, Literal, Never, overload, override, type_check_only
+from typing import Any, ClassVar, Generic, Literal, Never, SupportsIndex, overload, override, type_check_only
 from typing_extensions import TypeIs, TypeVar
 
 import numpy as np
@@ -69,6 +69,13 @@ class _bsr_base(_cs_matrix[_ScalarT_co, tuple[int, int]], _minmax_mixin[_ScalarT
     @override
     # pyrefly: ignore [bad-override]
     def __setitem__(self, key: Never, val: object, /) -> Never: ...  # type: ignore[override]  # pyright: ignore[reportIncompatibleMethodOverride]  # ty: ignore[invalid-method-override]
+
+    #
+    @override
+    @overload
+    def count_nonzero(self, /, axis: None = None) -> np.intp: ...
+    @overload
+    def count_nonzero(self, /, axis: SupportsIndex) -> onp.Array1D[np.intp]: ...
 
 class bsr_array(_bsr_base[_ScalarT_co], sparray[_ScalarT_co, tuple[int, int]], Generic[_ScalarT_co]):
     # NOTE: These four methods do not exist at runtime.

--- a/scipy-stubs/sparse/_dok.pyi
+++ b/scipy-stubs/sparse/_dok.pyi
@@ -2,7 +2,7 @@
 # mypy: disable-error-code="misc, override"
 
 from collections.abc import Iterable, Sequence
-from typing import Any, ClassVar, Generic, Literal, Never, Self, overload, override, type_check_only
+from typing import Any, ClassVar, Generic, Literal, Never, Self, SupportsIndex, overload, override, type_check_only
 from typing_extensions import TypeIs, TypeVar
 
 import numpy as np
@@ -118,7 +118,10 @@ class _dok_base(  # pyright: ignore[reportIncompatibleMethodOverride]
 
     #
     @override
-    def count_nonzero(self, /, axis: None = None) -> int: ...  # pyright: ignore[reportIncompatibleMethodOverride] # pyrefly: ignore[bad-override] # ty: ignore[invalid-method-override]
+    @overload
+    def count_nonzero(self, /, axis: None = None) -> np.intp: ...
+    @overload
+    def count_nonzero(self: _dok_base[Any, tuple[int, int]], /, axis: SupportsIndex) -> onp.Array1D[np.intp]: ...
 
     #
     @override

--- a/tests/sparse/test_dok.pyi
+++ b/tests/sparse/test_dok.pyi
@@ -1,6 +1,7 @@
 from typing import Literal, assert_type
 
 import numpy as np
+import optype.numpy as onp
 
 from ._types import ScalarType, dok_arr, dok_mat, dok_vec
 from scipy.sparse import dok_array, dok_matrix
@@ -71,16 +72,13 @@ assert_type(dok_arr.ndim, Literal[1, 2])
 assert_type(dok_mat.ndim, Literal[2])
 
 # .count_nonzero() (defined in `_dok_base`), so no need to check for `dok_matrix`
-assert_type(dok_vec.count_nonzero(), int)
-assert_type(dok_arr.count_nonzero(), int)
-# pyrefly: ignore [bad-argument-type]
-dok_vec.count_nonzero(0)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
-# pyrefly: ignore [bad-argument-type]
-dok_arr.count_nonzero(0)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
-# pyrefly: ignore [bad-argument-type]
+assert_type(dok_vec.count_nonzero(), np.intp)
+assert_type(dok_arr.count_nonzero(), np.intp)
+assert_type(dok_vec.count_nonzero(), np.intp)
+assert_type(dok_arr.count_nonzero(), np.intp)
+# pyrefly: ignore [no-matching-overload]
 dok_vec.count_nonzero(axis=0)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
-# pyrefly: ignore [bad-argument-type]
-dok_arr.count_nonzero(axis=0)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
+assert_type(dok_arr.count_nonzero(axis=0), onp.Array1D[np.intp])
 
 # .get()
 assert_type(dok_vec.get((0,)), ScalarType | float)


### PR DESCRIPTION
Passing `axis=` to `count_nonzero` used to raise a `NotImplementedError` for the BSR and DOK types, which changed in 1.18.0rc1.

This isn't mentioned in the [release notes](https://github.com/scipy/scipy/releases/tag/v1.18.0rc1), that's why I missed it before.