### PR TITLE
👽️ `stats.binomtest`: batching support (undocumented)

### DIFF
--- a/scipy-stubs/stats/_binomtest.pyi
+++ b/scipy-stubs/stats/_binomtest.pyi
@@ -1,21 +1,55 @@
 from types import ModuleType
-from typing import Literal
+from typing import Generic, Literal, overload
+from typing_extensions import TypeVar
+
+import numpy as np
+import optype.numpy as onp
+import optype.numpy.compat as npc
 
 from ._common import ConfidenceInterval
 from ._typing import Alternative
 
 ###
 
-class BinomTestResult:
-    k: int
-    n: int
-    alternative: Alternative
-    statistic: float
-    pvalue: float
+_NumT_co = TypeVar("_NumT_co", bound=np.float64 | onp.ArrayND[np.float64], default=np.float64, covariant=True)
 
-    def __init__(self, /, k: int, n: int, alternative: Alternative, statistic: float, pvalue: float, xp: ModuleType) -> None: ...
+###
+
+class BinomTestResult(Generic[_NumT_co]):
+    k: _NumT_co
+    n: _NumT_co
+    alternative: Alternative
+    statistic: _NumT_co
+    pvalue: _NumT_co
+    proportion_estimate: _NumT_co  # alias of `statistic` for backwards compatibility
+
+    def __init__(
+        self, /, k: _NumT_co, n: _NumT_co, alternative: Alternative, statistic: _NumT_co, pvalue: _NumT_co, xp: ModuleType
+    ) -> None: ...
     def proportion_ci(
         self, /, confidence_level: float = 0.95, method: Literal["exact", "wilson", "wilsoncc"] = "exact"
-    ) -> ConfidenceInterval: ...
+    ) -> ConfidenceInterval[_NumT_co]: ...
 
-def binomtest(k: int, n: int, p: float = 0.5, alternative: Alternative = "two-sided") -> BinomTestResult: ...
+@overload
+def binomtest(k: int, n: int, p: float = 0.5, alternative: Alternative = "two-sided") -> BinomTestResult[np.float64]: ...
+@overload
+def binomtest(
+    k: onp.ToArrayND[int, npc.integer] | int,
+    n: onp.ToArrayND[int, npc.integer],
+    p: onp.ToArrayND[float, npc.floating] | float = 0.5,
+    alternative: Alternative = "two-sided",
+) -> BinomTestResult[onp.ArrayND[np.float64]]: ...
+@overload
+def binomtest(
+    k: onp.ToArrayND[int, npc.integer],
+    n: onp.ToArrayND[int, npc.integer] | int,
+    p: onp.ToArrayND[float, npc.floating] | float = 0.5,
+    alternative: Alternative = "two-sided",
+) -> BinomTestResult[onp.ArrayND[np.float64]]: ...
+@overload
+def binomtest(
+    k: onp.ToArrayND[int, npc.integer] | int,
+    n: onp.ToArrayND[int, npc.integer] | int,
+    p: onp.ToArrayND[float, npc.floating],
+    alternative: Alternative = "two-sided",
+) -> BinomTestResult[onp.ArrayND[np.float64]]: ...

--- a/scipy-stubs/stats/_common.pyi
+++ b/scipy-stubs/stats/_common.pyi
@@ -2,9 +2,8 @@ from typing import Generic, NamedTuple
 from typing_extensions import TypeVar
 
 import numpy as np
-import optype.numpy.compat as npc
 
-_FltT_co = TypeVar("_FltT_co", bound=npc.floating, default=np.float64, covariant=True)
+_FltT_co = TypeVar("_FltT_co", default=np.float64, covariant=True)
 
 class ConfidenceInterval(NamedTuple, Generic[_FltT_co]):
     low: _FltT_co

--- a/tests/stats/test__binomtest.pyi
+++ b/tests/stats/test__binomtest.pyi
@@ -2,21 +2,26 @@
 
 from typing import assert_type
 
+import numpy as np
+import optype.numpy as onp
+
 from scipy.stats import binomtest
-from scipy.stats._binomtest import BinomTestResult
-from scipy.stats._common import ConfidenceInterval
 
 ###
 # binomtest
 
-_r = binomtest(5, 10)
-assert_type(_r, BinomTestResult)
-assert_type(_r.k, int)
-assert_type(_r.n, int)
-assert_type(_r.statistic, float)
-assert_type(_r.pvalue, float)
-assert_type(_r.proportion_ci(), ConfidenceInterval)
-assert_type(_r.proportion_ci(confidence_level=0.99, method="wilson"), ConfidenceInterval)
+_r_0d = binomtest(5, 10)
+assert_type(_r_0d.k, np.float64)
+assert_type(_r_0d.n, np.float64)
+assert_type(_r_0d.statistic, np.float64)
+assert_type(_r_0d.pvalue, np.float64)
+assert_type(_r_0d.proportion_ci().low, np.float64)
+assert_type(_r_0d.proportion_ci().high, np.float64)
 
-assert_type(binomtest(5, 10, p=0.3, alternative="less"), BinomTestResult)
-assert_type(binomtest(5, 10, alternative="greater"), BinomTestResult)
+_r_1d = binomtest([5], [10, 20])
+assert_type(_r_1d.k, onp.ArrayND[np.float64])
+assert_type(_r_1d.n, onp.ArrayND[np.float64])
+assert_type(_r_1d.statistic, onp.ArrayND[np.float64])
+assert_type(_r_1d.pvalue, onp.ArrayND[np.float64])
+assert_type(_r_1d.proportion_ci().low, onp.ArrayND[np.float64])
+assert_type(_r_1d.proportion_ci().high, onp.ArrayND[np.float64])


### PR DESCRIPTION
The types of the `k` and `n` attributes of the reutrned  `BinomTestResult` instance changed from `int` to `np.float64`, even if you pass `k` and `n` as `int`. Technically speaking, this is a breaking change, but I'm guessing that this was an oversight.

`scipy.stats.binomtest` now also supports batching of `k` and `n` and `p`. This is undocumented (not even in the docstring), and not (directly) mentioned in the release notes. 