### PR TITLE
✨ `io.matlab._mio`: accept FileLike

### DIFF
--- a/scipy-stubs/io/matlab/_mio.pyi
+++ b/scipy-stubs/io/matlab/_mio.pyi
@@ -5,7 +5,7 @@ from typing_extensions import deprecated
 import optype as op
 
 from ._miobase import MatFileReader
-from scipy.io._typing import ByteOrder, FileName
+from scipy.io._typing import ByteOrder, FileLike
 from scipy.sparse import coo_array, coo_matrix, csc_array, csc_matrix
 
 __all__ = ["loadmat", "savemat", "whosmat"]
@@ -48,14 +48,14 @@ class _ReaderKwargs(TypedDict, total=False):
 ###
 
 def mat_reader_factory(
-    file_name: FileName, appendmat: bool = True, **kwargs: Unpack[_ReaderKwargs]
+    file_name: FileLike[bytes], appendmat: bool = True, **kwargs: Unpack[_ReaderKwargs]
 ) -> tuple[MatFileReader, bool]: ...
 
 #
 @overload
 @deprecated("The default value for `spmatrix` is changing to False in v1.20.")
 def loadmat(
-    file_name: FileName,
+    file_name: FileLike[bytes],
     mdict: Mapping[str, object] | None = None,
     appendmat: bool = True,
     *,
@@ -64,7 +64,7 @@ def loadmat(
 ) -> dict[str, csc_matrix[Any] | coo_matrix[Any]]: ...
 @overload
 def loadmat(
-    file_name: FileName,
+    file_name: FileLike[bytes],
     mdict: Mapping[str, object] | None = None,
     appendmat: bool = True,
     *,
@@ -73,7 +73,7 @@ def loadmat(
 ) -> dict[str, csc_matrix[Any] | coo_matrix[Any]]: ...
 @overload
 def loadmat(
-    file_name: FileName,
+    file_name: FileLike[bytes],
     mdict: Mapping[str, object] | None = None,
     appendmat: bool = True,
     *,
@@ -83,7 +83,7 @@ def loadmat(
 
 #
 def savemat(
-    file_name: FileName,
+    file_name: FileLike[bytes],
     mdict: Mapping[str, object],
     appendmat: bool = True,
     format: Literal["5", "4"] = "5",
@@ -94,5 +94,5 @@ def savemat(
 
 #
 def whosmat(
-    file_name: FileName, appendmat: bool = True, **kwargs: Unpack[_ReaderKwargs]
+    file_name: FileLike[bytes], appendmat: bool = True, **kwargs: Unpack[_ReaderKwargs]
 ) -> list[tuple[str, tuple[int, ...], _DataClass]]: ...


### PR DESCRIPTION
This patch loosens the type annotations for the first argument of `mat_reader_factory`, `loadmat`, `savemat`, and `whosmat` to `FileLike[bytes]` from `FileName`.

- In internal uses of `mat_reader_factory` ([L241](https://github.com/scipy/scipy/blob/88776dae99516ccf07b66fdbb2f67091099ffc53/scipy/io/matlab/_mio.py#L241), [L395](https://github.com/scipy/scipy/blob/88776dae99516ccf07b66fdbb2f67091099ffc53/scipy/io/matlab/_mio.py#L395)), the first argument always gets an open file-like object rather than a path, so its signature probably should contain file-like objects.
-  The [docstring](https://github.com/scipy/scipy/blob/88776dae99516ccf07b66fdbb2f67091099ffc53/scipy/io/matlab/_mio.py#L287) and [code](https://github.com/scipy/scipy/blob/88776dae99516ccf07b66fdbb2f67091099ffc53/scipy/io/matlab/_mio.py#L325) of `savemat` both accept paths as well as file-like objects.

Remaining question:
- `loadmat`'s docstring does not mention that it accepts file-like objects, although the [code](https://github.com/scipy/scipy/blob/88776dae99516ccf07b66fdbb2f67091099ffc53/scipy/io/matlab/_mio.py#L240) does.
Should exclude `loadmat` from this patch? Or would it be fine for me to open another PR over `scipy` too? (I feel bad opening two consecutive DOC PRs 😅)