### PR TITLE
🐛✨ `signal`: `fft_mode`-dependent `ShortTimeFFT.istft` sctype

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ See the `scipy` columns below for which classes are subscriptable at runtime.
 | generic type                                         | `scipy-stubs` | `scipy`  |                                                                                                 |
 | ---------------------------------------------------- | ------------- | -------- | ----------------------------------------------------------------------------------------------- |
 | `ShortTimeFFT[T: inexact]`                           | `>=1.16.0.0`  | `>=1.17` | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.ShortTimeFFT.html)     |
+| `ShortTimeFFT[T: inexact, I: f64 \| c128]`           | `>=1.18.0.0`  | `>=1.17` | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.ShortTimeFFT.html)     |
 | `StateSpace[Z: inexact, P: floating, D: scalar]`     | `>=1.15.2.0`  | `>=1.17` | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.StateSpace.html)       |
 | `TransferFunction[P: floating, D: scalar]`           | `>=1.15.2.0`  | `>=1.17` | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.TransferFunction.html) |
 | `ZerosPolesGain[Z: inexact, P: floating, D: scalar]` | `>=1.15.2.0`  | `>=1.17` | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.ZerosPolesGain.html)   |

--- a/scipy-stubs/signal/_short_time_fft.pyi
+++ b/scipy-stubs/signal/_short_time_fft.pyi
@@ -221,7 +221,7 @@ class ShortTimeFFT(Generic[_InexactT_co, _Inexact128T_co]):
     def __init__[InexactT: npc.inexact](
         self: ShortTimeFFT[InexactT, np.float64],
         /,
-        win: onp.ArrayND[_InexactT_co],
+        win: onp.ArrayND[InexactT],
         hop: int,
         fs: float,
         *,

--- a/scipy-stubs/signal/_short_time_fft.pyi
+++ b/scipy-stubs/signal/_short_time_fft.pyi
@@ -1,6 +1,6 @@
 import types
 from collections.abc import Callable
-from typing import Any, Final, Generic, Literal, Self, overload
+from typing import Any, Final, Generic, Literal, Never, overload
 from typing_extensions import TypeVar
 
 import numpy as np
@@ -14,11 +14,18 @@ __all__ = ["ShortTimeFFT", "closest_STFT_dual_window"]
 ###
 
 _InexactT_co = TypeVar("_InexactT_co", bound=npc.inexact, default=Any, covariant=True)
+# `float64` if `fft_mode in {"onesided", "onesided2X"}` otherwise `complex128`; only affects `istft`
+_Inexact128T_co = TypeVar("_Inexact128T_co", bound=np.float64 | np.complex128, default=Any, covariant=True)
 
 type _PadType = Literal["zeros", "edge", "even", "odd"]
-type _FFTMode = Literal["twosided", "centered", "onesided", "onesided2X"]
+
+type _FFTMode1 = Literal["onesided", "onesided2X"]
+type _FFTMode2 = Literal["twosided", "centered"]
+type _FFTMode = Literal[_FFTMode1, _FFTMode2]
+
 type _ScaleTo = Literal["magnitude", "psd"]
 type _Scaling = Literal[_ScaleTo, "unitary"]
+
 type _Detr = (
     Literal["linear", "constant"]
     | Callable[[onp.ArrayND[np.float64]], onp.ToComplexND]
@@ -27,7 +34,7 @@ type _Detr = (
 
 ###
 
-class ShortTimeFFT(Generic[_InexactT_co]):
+class ShortTimeFFT(Generic[_InexactT_co, _Inexact128T_co]):
     _win: onp.Array1D[_InexactT_co]
     _dual_win: onp.Array1D[_InexactT_co] | None = None
     _hop: Final[int]
@@ -49,18 +56,37 @@ class ShortTimeFFT(Generic[_InexactT_co]):
 
     @classmethod
     def __class_getitem__(cls, arg: object, /) -> types.GenericAlias: ...
+
+    #
+    @overload
     @classmethod
-    def from_dual(
+    def from_dual[InexactT: npc.inexact](
         cls,
-        dual_win: onp.ArrayND[_InexactT_co],
+        dual_win: onp.ArrayND[InexactT],
         hop: int,
         fs: float,
         *,
-        fft_mode: _FFTMode = "onesided",
+        fft_mode: _FFTMode1 = "onesided",
         mfft: int | None = None,
         scale_to: _ScaleTo | None = None,
         phase_shift: int | None = 0,
-    ) -> Self: ...
+    ) -> ShortTimeFFT[InexactT, np.float64]: ...
+    @overload
+    @classmethod
+    def from_dual[InexactT: npc.inexact](
+        cls,
+        dual_win: onp.ArrayND[InexactT],
+        hop: int,
+        fs: float,
+        *,
+        fft_mode: _FFTMode2,
+        mfft: int | None = None,
+        scale_to: _ScaleTo | None = None,
+        phase_shift: int | None = 0,
+    ) -> ShortTimeFFT[InexactT, np.complex128]: ...
+
+    #
+    @overload
     @classmethod
     def from_window(
         cls,
@@ -70,23 +96,54 @@ class ShortTimeFFT(Generic[_InexactT_co]):
         noverlap: int,
         *,
         symmetric_win: bool = False,
-        fft_mode: _FFTMode = "onesided",
+        fft_mode: _FFTMode1 = "onesided",
         mfft: int | None = None,
         scale_to: _ScaleTo | None = None,
         phase_shift: int | None = 0,
-    ) -> ShortTimeFFT[np.float64]: ...
+    ) -> ShortTimeFFT[np.float64, np.float64]: ...
+    @overload
     @classmethod
-    def from_win_equals_dual(
+    def from_window(
         cls,
-        desired_win: onp.ArrayND[npc.inexact],
+        win_param: _ToWindow,
+        fs: float,
+        nperseg: int,
+        noverlap: int,
+        *,
+        symmetric_win: bool = False,
+        fft_mode: _FFTMode2,
+        mfft: int | None = None,
+        scale_to: _ScaleTo | None = None,
+        phase_shift: int | None = 0,
+    ) -> ShortTimeFFT[np.float64, np.complex128]: ...
+
+    #
+    @overload
+    @classmethod
+    def from_win_equals_dual[InexactT: npc.inexact](
+        cls,
+        desired_win: onp.ArrayND[InexactT],
         hop: int,
         fs: float,
         *,
-        fft_mode: _FFTMode = "onesided",
+        fft_mode: _FFTMode1 = "onesided",
         mfft: int | None = None,
         scale_to: _Scaling | None = None,
         phase_shift: int | None = 0,
-    ) -> Self: ...
+    ) -> ShortTimeFFT[InexactT, np.float64]: ...
+    @overload
+    @classmethod
+    def from_win_equals_dual[InexactT: npc.inexact](
+        cls,
+        desired_win: onp.ArrayND[InexactT],
+        hop: int,
+        fs: float,
+        *,
+        fft_mode: _FFTMode2,
+        mfft: int | None = None,
+        scale_to: _Scaling | None = None,
+        phase_shift: int | None = 0,
+    ) -> ShortTimeFFT[InexactT, np.complex128]: ...
 
     #
     @property
@@ -139,8 +196,8 @@ class ShortTimeFFT(Generic[_InexactT_co]):
     #
     @property
     def fft_mode(self, /) -> _FFTMode: ...
-    @fft_mode.setter
-    def fft_mode(self, /, t: _FFTMode) -> None: ...
+    @fft_mode.setter  # `fft_mode` affects the 2nd generic type (`_Inexact128T_co`), so changing it would be type-unsafe
+    def fft_mode(self, /, t: Never) -> None: ...
 
     #
     @property
@@ -160,16 +217,31 @@ class ShortTimeFFT(Generic[_InexactT_co]):
     def _post_padding(self, /, n: int) -> tuple[int, int]: ...
 
     #
-    def __init__(
-        self,
+    @overload
+    def __init__[InexactT: npc.inexact](
+        self: ShortTimeFFT[InexactT, np.float64],
         /,
         win: onp.ArrayND[_InexactT_co],
         hop: int,
         fs: float,
         *,
-        fft_mode: _FFTMode = "onesided",
+        fft_mode: _FFTMode1 = "onesided",
         mfft: int | None = None,
-        dual_win: onp.ArrayND[_InexactT_co] | None = None,
+        dual_win: onp.ArrayND[InexactT] | None = None,
+        scale_to: _ScaleTo | None = None,
+        phase_shift: int | None = 0,
+    ) -> None: ...
+    @overload
+    def __init__[InexactT: npc.inexact](
+        self: ShortTimeFFT[InexactT, np.complex128],
+        /,
+        win: onp.ArrayND[InexactT],
+        hop: int,
+        fs: float,
+        *,
+        fft_mode: _FFTMode2,
+        mfft: int | None = None,
+        dual_win: onp.ArrayND[InexactT] | None = None,
         scale_to: _ScaleTo | None = None,
         phase_shift: int | None = 0,
     ) -> None: ...
@@ -352,7 +424,7 @@ class ShortTimeFFT(Generic[_InexactT_co]):
     #
     def istft(
         self, /, S: onp.ArrayND[npc.inexact], k0: int = 0, k1: int | None = None, *, f_axis: int = -2, t_axis: int = -1
-    ) -> onp.ArrayND[np.complex128]: ...
+    ) -> onp.ArrayND[_Inexact128T_co]: ...
 
     #
     def extent(

--- a/tests/signal/test_short_time_fft.pyi
+++ b/tests/signal/test_short_time_fft.pyi
@@ -16,64 +16,71 @@ c128_1d: onp.Array1D[np.complex128]
 ###
 # ShortTimeFFT.from_window / from_dual / from_win_equals_dual
 
-stft_f64 = ShortTimeFFT.from_window("hann", 1.0, 64, 32)
-assert_type(stft_f64, ShortTimeFFT[np.float64])
+stft_f64_1 = ShortTimeFFT.from_window("hann", 1.0, 64, 32)
+stft_f64_2 = ShortTimeFFT.from_window("hann", 1.0, 64, 32, fft_mode="twosided")
+assert_type(stft_f64_1, ShortTimeFFT[np.float64, np.float64])
+assert_type(stft_f64_2, ShortTimeFFT[np.float64, np.complex128])
 
-stft_c128 = ShortTimeFFT(c128_1d, hop=32, fs=1.0)
-assert_type(stft_c128, ShortTimeFFT[np.complex128])
+stft_c128_1 = ShortTimeFFT(c128_1d, hop=32, fs=1.0)
+stft_c128_2 = ShortTimeFFT(c128_1d, hop=32, fs=1.0, fft_mode="twosided")
+assert_type(stft_c128_1, ShortTimeFFT[np.complex128, np.float64])
+assert_type(stft_c128_2, ShortTimeFFT[np.complex128, np.complex128])
 
 ###
 # properties
 
-assert_type(stft_f64.win, onp.Array1D[np.float64])
-assert_type(stft_f64.dual_win, onp.Array1D[np.float64])
-assert_type(stft_f64.hop, int)
-assert_type(stft_f64.f, onp.Array1D[np.float64])
-assert_type(stft_f64.invertible, bool)
-assert_type(stft_f64.f_pts, int)
-assert_type(stft_f64.m_num, int)
-assert_type(stft_f64.delta_t, float)
-assert_type(stft_f64.delta_f, float)
+assert_type(stft_f64_1.win, onp.Array1D[np.float64])
+assert_type(stft_f64_1.dual_win, onp.Array1D[np.float64])
+assert_type(stft_f64_1.hop, int)
+assert_type(stft_f64_1.f, onp.Array1D[np.float64])
+assert_type(stft_f64_1.invertible, bool)
+assert_type(stft_f64_1.f_pts, int)
+assert_type(stft_f64_1.m_num, int)
+assert_type(stft_f64_1.delta_t, float)
+assert_type(stft_f64_1.delta_f, float)
 
 ###
 # t / k_max / p_range / upper_border_begin / lower_border_end
 
-assert_type(stft_f64.t(128), onp.Array1D[np.float64])
-assert_type(stft_f64.k_max(128), int)
-assert_type(stft_f64.p_num(128), int)
-assert_type(stft_f64.p_range(128), tuple[int, int])
-assert_type(stft_f64.upper_border_begin(128), tuple[int, int])
-assert_type(stft_f64.lower_border_end, tuple[int, int])
+assert_type(stft_f64_1.t(128), onp.Array1D[np.float64])
+assert_type(stft_f64_1.k_max(128), int)
+assert_type(stft_f64_1.p_num(128), int)
+assert_type(stft_f64_1.p_range(128), tuple[int, int])
+assert_type(stft_f64_1.upper_border_begin(128), tuple[int, int])
+assert_type(stft_f64_1.lower_border_end, tuple[int, int])
 
 ###
 # stft
 
-assert_type(stft_f64.stft(f64_1d), onp.Array2D[np.complex128])
-assert_type(stft_f64.stft(f64_2d), onp.Array3D[np.complex128])
+assert_type(stft_f64_1.stft(f64_1d), onp.Array2D[np.complex128])
+assert_type(stft_f64_1.stft(f64_2d), onp.Array3D[np.complex128])
 
 ###
 # stft_detrend
 
-assert_type(stft_f64.stft_detrend(f64_1d, "constant"), onp.Array2D[np.complex128])
-assert_type(stft_f64.stft_detrend(f64_2d, None), onp.Array3D[np.complex128])
+assert_type(stft_f64_1.stft_detrend(f64_1d, "constant"), onp.Array2D[np.complex128])
+assert_type(stft_f64_1.stft_detrend(f64_2d, None), onp.Array3D[np.complex128])
 
 ###
 # spectrogram
 
-assert_type(stft_f64.spectrogram(f64_1d), onp.Array2D[np.float64])
-assert_type(stft_f64.spectrogram(f64_1d, f64_1d), onp.Array2D[np.complex128])
-assert_type(stft_f64.spectrogram(f64_2d), onp.Array3D[np.float64])
-assert_type(stft_f64.spectrogram(f64_2d, f64_2d), onp.Array3D[np.complex128])
+assert_type(stft_f64_1.spectrogram(f64_1d), onp.Array2D[np.float64])
+assert_type(stft_f64_1.spectrogram(f64_1d, f64_1d), onp.Array2D[np.complex128])
+assert_type(stft_f64_1.spectrogram(f64_2d), onp.Array3D[np.float64])
+assert_type(stft_f64_1.spectrogram(f64_2d, f64_2d), onp.Array3D[np.complex128])
 
 ###
 # istft
 
-assert_type(stft_f64.istft(f64_2d), onp.ArrayND[np.complex128])
+assert_type(stft_f64_1.istft(f64_2d), onp.ArrayND[np.float64])
+assert_type(stft_f64_2.istft(f64_2d), onp.ArrayND[np.complex128])
+assert_type(stft_c128_1.istft(f64_2d), onp.ArrayND[np.float64])
+assert_type(stft_c128_2.istft(f64_2d), onp.ArrayND[np.complex128])
 
 ###
 # extent
 
-assert_type(stft_f64.extent(128), tuple[float, float, float, float])
+assert_type(stft_f64_1.extent(128), tuple[float, float, float, float])
 
 ###
 # closest_STFT_dual_window


### PR DESCRIPTION
The `fft_mode` of `scipy.signal.ShortTimeFFT` affects the returned scalar type of its `istft` method. For one-sided modes it's `float64` and for two-sided ones it's `complex128`. This adds a new 2nd generic type parameter to `ShortTimeFFT` to capture this instance-scoped difference in `istft` return types. 

For the sake of type-safety this also changes the `ShortTimeFFT.setter` to no longer accept any values, effectively disallowing mutations, as this would violate the fundamental "types do not change" rule. At runtime this is still possible, but doing so would be type-unsafe (i.e. a bad idea).

Closes #1728