### PR TITLE
🐛 `optimize`: missing `minimizer_kwargs` items for global optimizers

### DIFF
--- a/scipy-stubs/optimize/_typing.pyi
+++ b/scipy-stubs/optimize/_typing.pyi
@@ -1,3 +1,5 @@
+# type-check-only helper types for internal use
+
 from collections.abc import Callable, Sequence
 from typing import Concatenate, Literal, NotRequired, type_check_only
 from typing_extensions import TypedDict
@@ -27,6 +29,7 @@ __all__ = [
 ]
 
 type _Float1D = onp.Array1D[np.float64]
+type _Args = tuple[object, ...]
 
 # bounds
 type Bound = tuple[onp.ToFloat | None, onp.ToFloat | None]
@@ -38,7 +41,7 @@ class _ConstraintDict(TypedDict):
     type: Literal["eq", "ineq"]
     fun: Callable[Concatenate[_Float1D, ...], onp.ToFloat]
     jac: NotRequired[Callable[Concatenate[_Float1D, ...], onp.ToFloat1D]]
-    args: NotRequired[tuple[object, ...]]
+    args: NotRequired[_Args]
 
 type Constraint = LinearConstraint | NonlinearConstraint | _ConstraintDict
 type Constraints = Constraint | Sequence[Constraint]
@@ -95,10 +98,12 @@ type _FDMethod = Literal["2-point", "3-point", "cs"]
 
 @type_check_only
 class MinimizerKwargs(TypedDict, total=False):
+    args: _Args
     method: MethodMimimize
     jac: Callable[Concatenate[_Float1D, ...], onp.ToFloat1D] | _FDMethod | bool
     hess: Callable[Concatenate[_Float1D, ...], onp.ToFloat2D] | _FDMethod | HessianUpdateStrategy
     hessp: Callable[Concatenate[_Float1D, _Float1D, ...], onp.ToFloat1D]
+    bounds: Bounds
     constraints: Constraints
     tol: onp.ToFloat
     options: _MinimizeOptions

--- a/tests/optimize/test_basinhopping.pyi
+++ b/tests/optimize/test_basinhopping.pyi
@@ -4,10 +4,23 @@ import numpy as np
 import optype.numpy as onp
 
 from scipy.optimize import basinhopping
-from scipy.optimize._basinhopping import OptimizeResult
 
-def obj(x: onp.Array1D[np.float64]) -> float: ...
+###
 
-x0: onp.Array1D[np.float64]
+def _fn_f64_1d(x: onp.Array1D[np.float64]) -> float: ...
 
-assert_type(basinhopping(obj, x0), OptimizeResult)
+_f64_1d: onp.Array1D[np.float64]
+
+###
+
+assert_type(basinhopping(_fn_f64_1d, _f64_1d).success, bool)
+assert_type(basinhopping(_fn_f64_1d, _f64_1d).nit, int)
+assert_type(basinhopping(_fn_f64_1d, _f64_1d).message, str)
+assert_type(basinhopping(_fn_f64_1d, _f64_1d).x, onp.Array1D[np.float64])
+assert_type(basinhopping(_fn_f64_1d, _f64_1d).fun, float | np.float64)
+assert_type(basinhopping(_fn_f64_1d, _f64_1d).minimization_failures, int)
+assert_type(basinhopping(_fn_f64_1d, _f64_1d).lowest_optimization_result.status, int)
+
+# https://github.com/scipy/scipy-stubs/issues/1730
+assert_type(basinhopping(_fn_f64_1d, _f64_1d, minimizer_kwargs={"args": (1, 2)}).x, onp.Array1D[np.float64])
+assert_type(basinhopping(_fn_f64_1d, _f64_1d, minimizer_kwargs={"bounds": [(0, 1)]}).x, onp.Array1D[np.float64])


### PR DESCRIPTION
This adds the missing `args` and `bounds` items to the `MinimizerKwargs` typed dict that annotates the `minimizer_kwargs` param of  the following public `scipy.optimize` global optimization functions:

- `basinhopping`
- `dual_annealing`
- `shgo`

Closes #1730