### PR TITLE
🐛 `optimize`: fix global optimizer `func` type when `jac=True`

### DIFF
--- a/scipy-stubs/optimize/_basinhopping.pyi
+++ b/scipy-stubs/optimize/_basinhopping.pyi
@@ -1,12 +1,12 @@
 from collections.abc import Callable
-from typing import Concatenate, Literal, Protocol, TypeVar, type_check_only
+from typing import Concatenate, Literal, Protocol, TypeVar, overload, type_check_only
 
 import numpy as np
 import optype.numpy as onp
 
 from ._minimize import OptimizeResult as _MinimizeResult
 from ._optimize import OptimizeResult as _OptimizeResult
-from ._typing import MinimizerKwargs
+from ._typing import MinimizerKwargs, MinimizerKwargsJac
 
 __all__ = ["basinhopping"]
 
@@ -43,21 +43,42 @@ class OptimizeResult(_OptimizeResult):
 
 ###
 
+@overload
 def basinhopping(
     func: Callable[Concatenate[_Float1D, ...], onp.ToFloat],
     x0: onp.ToFloat1D,
-    niter: onp.ToJustInt = 100,
+    niter: int = 100,
     T: onp.ToFloat = 1.0,
     stepsize: onp.ToFloat = 0.5,
     minimizer_kwargs: MinimizerKwargs | None = None,
     take_step: Callable[[_Float1D], onp.ToFloat] | None = None,
     accept_test: _AcceptTestFun[onp.ToFloat] | None = None,
     callback: _CallbackFun[float] | _CallbackFun[np.float64] | None = None,
-    interval: onp.ToJustInt = 50,
+    interval: int = 50,
     disp: bool = False,
-    niter_success: onp.ToJustInt | None = None,
+    niter_success: int | None = None,
     rng: onp.random.ToRNG | None = None,
     *,
+    seed: onp.random.ToRNG | None = None,
+    target_accept_rate: onp.ToFloat = 0.5,
+    stepwise_factor: onp.ToFloat = 0.9,
+) -> OptimizeResult: ...
+@overload  # minimizer_kwargs={"jac": True, ...}
+def basinhopping(
+    func: Callable[Concatenate[_Float1D, ...], tuple[onp.ToFloat, onp.ToFloat1D]],
+    x0: onp.ToFloat1D,
+    niter: int = 100,
+    T: onp.ToFloat = 1.0,
+    stepsize: onp.ToFloat = 0.5,
+    *,
+    minimizer_kwargs: MinimizerKwargsJac,
+    take_step: Callable[[_Float1D], onp.ToFloat] | None = None,
+    accept_test: _AcceptTestFun[onp.ToFloat] | None = None,
+    callback: _CallbackFun[float] | _CallbackFun[np.float64] | None = None,
+    interval: int = 50,
+    disp: bool = False,
+    niter_success: int | None = None,
+    rng: onp.random.ToRNG | None = None,
     seed: onp.random.ToRNG | None = None,
     target_accept_rate: onp.ToFloat = 0.5,
     stepwise_factor: onp.ToFloat = 0.9,

--- a/scipy-stubs/optimize/_dual_annealing.pyi
+++ b/scipy-stubs/optimize/_dual_annealing.pyi
@@ -1,14 +1,21 @@
 from collections.abc import Callable
-from typing import Concatenate, Literal
+from typing import Concatenate, Literal, overload
 
 import numpy as np
 import optype.numpy as onp
 
 from ._constraints import Bounds
-from ._typing import MinimizerKwargs
+from ._typing import MinimizerKwargs, MinimizerKwargsJac
 from scipy.optimize import OptimizeResult as _OptimizeResult
 
 __all__ = ["dual_annealing"]
+
+###
+
+type _ToBounds = Bounds | tuple[onp.ToFloat1D, onp.ToFloat1D] | onp.ToFloat2D
+type _CallbackFun = Callable[[onp.Array1D[np.float64], float, Literal[0, 1, 2]], bool | None]
+
+###
 
 class OptimizeResult(_OptimizeResult):
     success: bool
@@ -21,21 +28,41 @@ class OptimizeResult(_OptimizeResult):
     nhev: int
     message: str
 
+@overload
 def dual_annealing(
     func: Callable[Concatenate[onp.Array1D[np.float64], ...], onp.ToFloat],
-    bounds: Bounds | tuple[onp.ToFloat1D, onp.ToFloat1D] | onp.ToFloat2D,
+    bounds: _ToBounds,
     args: tuple[object, ...] = (),
-    maxiter: onp.ToJustInt = 1_000,
+    maxiter: int = 1_000,
     minimizer_kwargs: MinimizerKwargs | None = None,
     initial_temp: onp.ToFloat = 5_230.0,
-    restart_temp_ratio: onp.ToFloat = 2e-05,
+    restart_temp_ratio: onp.ToFloat = 2e-5,
     visit: onp.ToFloat = 2.62,
     accept: onp.ToFloat = -5.0,
     maxfun: onp.ToFloat = 10_000_000.0,
     rng: onp.random.ToRNG | None = None,
     no_local_search: bool = False,
-    callback: Callable[[onp.Array1D[np.float64], float, Literal[0, 1, 2]], bool | None] | None = None,
+    callback: _CallbackFun | None = None,
     x0: onp.ToFloat1D | None = None,
     *,
+    seed: onp.random.ToRNG | None = None,
+) -> _OptimizeResult: ...
+@overload  # minimizer_kwargs={"jac": True, ...}
+def dual_annealing(
+    func: Callable[Concatenate[onp.Array1D[np.float64], ...], tuple[onp.ToFloat, onp.ToFloat1D]],
+    bounds: _ToBounds,
+    args: tuple[object, ...] = (),
+    maxiter: int = 1_000,
+    *,
+    minimizer_kwargs: MinimizerKwargsJac,
+    initial_temp: onp.ToFloat = 5_230.0,
+    restart_temp_ratio: onp.ToFloat = 2e-5,
+    visit: onp.ToFloat = 2.62,
+    accept: onp.ToFloat = -5.0,
+    maxfun: onp.ToFloat = 10_000_000.0,
+    rng: onp.random.ToRNG | None = None,
+    no_local_search: bool = False,
+    callback: _CallbackFun | None = None,
+    x0: onp.ToFloat1D | None = None,
     seed: onp.random.ToRNG | None = None,
 ) -> _OptimizeResult: ...

--- a/scipy-stubs/optimize/_shgo.pyi
+++ b/scipy-stubs/optimize/_shgo.pyi
@@ -1,12 +1,12 @@
 from collections.abc import Callable, Iterable, Sequence
-from typing import Concatenate, Literal, Protocol, TypedDict, type_check_only
+from typing import Concatenate, Literal, Protocol, TypedDict, overload, type_check_only
 
 import numpy as np
 import optype.numpy as onp
 
 from ._constraints import Bounds
 from ._optimize import OptimizeResult as _OptimizeResult
-from ._typing import Constraints, MinimizerKwargs
+from ._typing import Constraints, MinimizerKwargs, MinimizerKwargsJac
 
 __all__ = ["shgo"]
 
@@ -15,6 +15,9 @@ __all__ = ["shgo"]
 type _Float = float | np.float64
 type _Float1D = onp.Array1D[np.float64]
 type _Fun1D[_RT] = Callable[Concatenate[_Float1D, ...], _RT]
+
+type _ToBounds = tuple[onp.ToFloat | onp.ToFloat1D, onp.ToFloat | onp.ToFloat1D] | Bounds
+type _SamplingMethod = Callable[[int, int], onp.ToFloat2D] | Literal["simplicial", "halton", "sobol"]
 
 @type_check_only
 class _SHGOOptions(TypedDict, total=False):
@@ -53,17 +56,33 @@ class OptimizeResult(_OptimizeResult):
     nlhev: int  # undocumented
     nit: int
 
+@overload
 def shgo(
     func: _Fun1D[onp.ToFloat],
-    bounds: tuple[onp.ToFloat | onp.ToFloat1D, onp.ToFloat | onp.ToFloat1D] | Bounds,
+    bounds: _ToBounds,
     args: tuple[object, ...] = (),
     constraints: Constraints | None = None,
-    n: onp.ToJustInt = 100,
-    iters: onp.ToJustInt = 1,
+    n: int = 100,
+    iters: int = 1,
     callback: Callable[[_Float1D], None] | None = None,
     minimizer_kwargs: MinimizerKwargs | None = None,
     options: _SHGOOptions | None = None,
-    sampling_method: Callable[[int, int], onp.ToFloat2D] | Literal["simplicial", "halton", "sobol"] = "simplicial",
+    sampling_method: _SamplingMethod = "simplicial",
     *,
-    workers: onp.ToJustInt | _DoesMap = 1,
+    workers: int | _DoesMap = 1,
+) -> OptimizeResult: ...
+@overload  # minimizer_kwargs={"jac": True, ...}
+def shgo(
+    func: _Fun1D[tuple[onp.ToFloat, onp.ToFloat1D]],
+    bounds: _ToBounds,
+    args: tuple[object, ...] = (),
+    constraints: Constraints | None = None,
+    n: int = 100,
+    iters: int = 1,
+    callback: Callable[[_Float1D], None] | None = None,
+    *,
+    minimizer_kwargs: MinimizerKwargsJac,
+    options: _SHGOOptions | None = None,
+    sampling_method: _SamplingMethod = "simplicial",
+    workers: int | _DoesMap = 1,
 ) -> OptimizeResult: ...

--- a/scipy-stubs/optimize/_typing.pyi
+++ b/scipy-stubs/optimize/_typing.pyi
@@ -1,7 +1,7 @@
 # type-check-only helper types for internal use
 
 from collections.abc import Callable, Sequence
-from typing import Concatenate, Literal, NotRequired, type_check_only
+from typing import Concatenate, Literal, NotRequired, Required, type_check_only
 from typing_extensions import TypedDict
 
 import numpy as np
@@ -24,6 +24,7 @@ __all__ = [
     "MethodMinimizeScalar",
     "MethodRootScalar",
     "MinimizerKwargs",
+    "MinimizerKwargsJac",
     "Solver",
     "TRSolver",
 ]
@@ -97,13 +98,20 @@ type MethodAll = Literal[
 type _FDMethod = Literal["2-point", "3-point", "cs"]
 
 @type_check_only
-class MinimizerKwargs(TypedDict, total=False):
+class _MinimizerKwargsBase(TypedDict, total=False):
     args: _Args
     method: MethodMimimize
-    jac: Callable[Concatenate[_Float1D, ...], onp.ToFloat1D] | _FDMethod | bool
     hess: Callable[Concatenate[_Float1D, ...], onp.ToFloat2D] | _FDMethod | HessianUpdateStrategy
     hessp: Callable[Concatenate[_Float1D, _Float1D, ...], onp.ToFloat1D]
     bounds: Bounds
     constraints: Constraints
     tol: onp.ToFloat
     options: _MinimizeOptions
+
+@type_check_only
+class MinimizerKwargs(_MinimizerKwargsBase):
+    jac: NotRequired[Callable[Concatenate[_Float1D, ...], onp.ToFloat1D] | _FDMethod | Literal[False]]
+
+@type_check_only
+class MinimizerKwargsJac(_MinimizerKwargsBase):
+    jac: Required[Literal[True]]

--- a/tests/optimize/test_basinhopping.pyi
+++ b/tests/optimize/test_basinhopping.pyi
@@ -8,6 +8,7 @@ from scipy.optimize import basinhopping
 ###
 
 def _fn_f64_1d(x: onp.Array1D[np.float64]) -> float: ...
+def _fn_f64_1d_jac(x: onp.Array1D[np.float64]) -> tuple[float, onp.Array1D[np.float64]]: ...
 
 _f64_1d: onp.Array1D[np.float64]
 
@@ -24,3 +25,7 @@ assert_type(basinhopping(_fn_f64_1d, _f64_1d).lowest_optimization_result.status,
 # https://github.com/scipy/scipy-stubs/issues/1730
 assert_type(basinhopping(_fn_f64_1d, _f64_1d, minimizer_kwargs={"args": (1, 2)}).x, onp.Array1D[np.float64])
 assert_type(basinhopping(_fn_f64_1d, _f64_1d, minimizer_kwargs={"bounds": [(0, 1)]}).x, onp.Array1D[np.float64])
+
+# https://github.com/scipy/scipy-stubs/issues/1733
+assert_type(basinhopping(_fn_f64_1d, _f64_1d, minimizer_kwargs={"jac": False}).x, onp.Array1D[np.float64])
+assert_type(basinhopping(_fn_f64_1d_jac, _f64_1d, minimizer_kwargs={"jac": True}).x, onp.Array1D[np.float64])


### PR DESCRIPTION
When `"jac": True` in the `minimizer kwargs` of `basinhopping`, `dual_annealing`, and `shgo`, the objective function type has a 2-tuple as return type, instead of just a scalar. 

Closes #1733