### PR TITLE
🐛 `linalg.eig`: fix output dtypes and output sizes

### DIFF
--- a/scipy-stubs/linalg/_decomp.pyi
+++ b/scipy-stubs/linalg/_decomp.pyi
@@ -43,115 +43,14 @@ type _DriverSTE = Literal["stemr", "stebz", "sterf", "stev"]
 type _DriverAuto = Literal["auto"]
 
 # output types
-type _FloatND = onp.ArrayND[np.float32 | np.float64]
-type _ComplexND = onp.ArrayND[np.complex64 | np.complex128]
-type _InexactND = onp.ArrayND[np.float32 | np.float64 | np.complex64 | np.complex128]
+type _FloatND = onp.ArrayND[np.float64 | np.float32]
+type _ComplexND = onp.ArrayND[np.complex128 | np.complex64]
+type _InexactND = onp.ArrayND[np.complex128 | np.complex64 | np.float64 | np.float32]
 
 ###
 
-@overload  # float, left: True (positional), right: True = ...
-def eig(
-    a: onp.ToFloatND,
-    b: onp.ToFloatND | None,
-    left: Literal[True],
-    right: Literal[True] = True,
-    overwrite_a: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-    homogeneous_eigvals: bool = False,
-) -> tuple[_ComplexND, _FloatND]: ...
-@overload  # float, left: True (keyword), right: True = ...
-def eig(
-    a: onp.ToFloatND,
-    b: onp.ToFloatND | None = None,
-    *,
-    left: Literal[True],
-    right: Literal[True] = True,
-    overwrite_a: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-    homogeneous_eigvals: bool = False,
-) -> tuple[_ComplexND, _FloatND]: ...
-@overload  # float, left: False, right: False (positional)
-def eig(
-    a: onp.ToFloatND,
-    b: onp.ToFloatND | None,
-    left: Literal[False],
-    right: Literal[False],
-    overwrite_a: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-    homogeneous_eigvals: bool = False,
-) -> tuple[_ComplexND, _FloatND]: ...
-@overload  # float, left: False = ..., right: False (keyword)
-def eig(
-    a: onp.ToFloatND,
-    b: onp.ToFloatND | None = None,
-    left: Literal[False] = False,
-    *,
-    right: Literal[False],
-    overwrite_a: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-    homogeneous_eigvals: bool = False,
-) -> tuple[_ComplexND, _FloatND]: ...
-@overload  # float, left: True (positional), right: False
-def eig(
-    a: onp.ToFloatND,
-    b: onp.ToFloatND | None,
-    left: Literal[True],
-    right: Literal[False],
-    overwrite_a: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-    homogeneous_eigvals: bool = False,
-) -> tuple[_ComplexND, _FloatND, _FloatND]: ...
-@overload  # float, left: True (keyword), right: False
-def eig(
-    a: onp.ToFloatND,
-    b: onp.ToFloatND | None = None,
-    *,
-    left: Literal[True],
-    right: Literal[False],
-    overwrite_a: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-    homogeneous_eigvals: bool = False,
-) -> tuple[_ComplexND, _FloatND, _FloatND]: ...
-@overload  # complex, left: False = ..., right: True = ...
-def eig(
-    a: onp.ToComplexND,
-    b: onp.ToComplexND | None = None,
-    left: Literal[False] = False,
-    right: Literal[True] = True,
-    overwrite_a: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-    homogeneous_eigvals: bool = False,
-) -> _ComplexND: ...
-@overload  # complex, left: True (positional), right: True = ...
-def eig(
-    a: onp.ToComplexND,
-    b: onp.ToComplexND | None,
-    left: Literal[True],
-    right: Literal[True] = True,
-    overwrite_a: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-    homogeneous_eigvals: bool = False,
-) -> tuple[_ComplexND, _InexactND]: ...
-@overload  # complex, left: True (keyword), right: True = ...
-def eig(
-    a: onp.ToComplexND,
-    b: onp.ToComplexND | None = None,
-    *,
-    left: Literal[True],
-    right: Literal[True] = True,
-    overwrite_a: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-    homogeneous_eigvals: bool = False,
-) -> tuple[_ComplexND, _InexactND]: ...
+# NOTE: The eigenvectors of real `a` can be either real or complex, depending on its values.
+# TODO(@jorenham): f32/f64/c64/c128-specific overloads
 @overload  # complex, left: False, right: False (positional)
 def eig(
     a: onp.ToComplexND,
@@ -162,7 +61,7 @@ def eig(
     overwrite_b: bool = False,
     check_finite: bool = True,
     homogeneous_eigvals: bool = False,
-) -> tuple[_ComplexND, _InexactND]: ...
+) -> _ComplexND: ...
 @overload  # complex, left: False = ..., right: False (keyword)
 def eig(
     a: onp.ToComplexND,
@@ -174,10 +73,43 @@ def eig(
     overwrite_b: bool = False,
     check_finite: bool = True,
     homogeneous_eigvals: bool = False,
+) -> _ComplexND: ...
+@overload  # float, left: False = ..., right: True = ...
+def eig(
+    a: onp.ToFloatND,
+    b: onp.ToFloatND | None = None,
+    left: Literal[False] = False,
+    right: Literal[True] = True,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    homogeneous_eigvals: bool = False,
+) -> tuple[_ComplexND, _InexactND]: ...
+@overload  # complex, left: False = ..., right: True = ...
+def eig(
+    a: onp.ToJustComplexND,
+    b: onp.ToComplexND | None = None,
+    left: Literal[False] = False,
+    right: Literal[True] = True,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    homogeneous_eigvals: bool = False,
+) -> tuple[_ComplexND, _ComplexND]: ...
+@overload  # float, left: True (positional), right: False
+def eig(
+    a: onp.ToFloatND,
+    b: onp.ToFloatND | None,
+    left: Literal[True],
+    right: Literal[False],
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    homogeneous_eigvals: bool = False,
 ) -> tuple[_ComplexND, _InexactND]: ...
 @overload  # complex, left: True (positional), right: False
 def eig(
-    a: onp.ToComplexND,
+    a: onp.ToJustComplexND,
     b: onp.ToComplexND | None,
     left: Literal[True],
     right: Literal[False],
@@ -185,10 +117,22 @@ def eig(
     overwrite_b: bool = False,
     check_finite: bool = True,
     homogeneous_eigvals: bool = False,
-) -> tuple[_ComplexND, _InexactND, _InexactND]: ...
+) -> tuple[_ComplexND, _ComplexND]: ...
+@overload  # float, left: True (keyword), right: False
+def eig(
+    a: onp.ToFloatND,
+    b: onp.ToFloatND | None = None,
+    *,
+    left: Literal[True],
+    right: Literal[False],
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    homogeneous_eigvals: bool = False,
+) -> tuple[_ComplexND, _InexactND]: ...
 @overload  # complex, left: True (keyword), right: False (keyword)
 def eig(
-    a: onp.ToComplexND,
+    a: onp.ToJustComplexND,
     b: onp.ToComplexND | None = None,
     *,
     left: Literal[True],
@@ -197,7 +141,53 @@ def eig(
     overwrite_b: bool = False,
     check_finite: bool = True,
     homogeneous_eigvals: bool = False,
+) -> tuple[_ComplexND, _ComplexND]: ...
+@overload  # float, left: True (positional), right: True = ...
+def eig(
+    a: onp.ToFloatND,
+    b: onp.ToFloatND | None,
+    left: Literal[True],
+    right: Literal[True] = True,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    homogeneous_eigvals: bool = False,
 ) -> tuple[_ComplexND, _InexactND, _InexactND]: ...
+@overload  # complex, left: True (positional), right: True = ...
+def eig(
+    a: onp.ToJustComplexND,
+    b: onp.ToComplexND | None,
+    left: Literal[True],
+    right: Literal[True] = True,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    homogeneous_eigvals: bool = False,
+) -> tuple[_ComplexND, _ComplexND, _ComplexND]: ...
+@overload  # float, left: True (keyword), right: True = ...
+def eig(
+    a: onp.ToFloatND,
+    b: onp.ToFloatND | None = None,
+    *,
+    left: Literal[True],
+    right: Literal[True] = True,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    homogeneous_eigvals: bool = False,
+) -> tuple[_ComplexND, _InexactND, _InexactND]: ...
+@overload  # complex, left: True (keyword), right: True = ...
+def eig(
+    a: onp.ToJustComplexND,
+    b: onp.ToComplexND | None = None,
+    *,
+    left: Literal[True],
+    right: Literal[True] = True,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    homogeneous_eigvals: bool = False,
+) -> tuple[_ComplexND, _ComplexND, _ComplexND]: ...
 @overload  # catch-all
 def eig(
     a: onp.ToComplexND,

--- a/scipy-stubs/linalg/_decomp.pyi
+++ b/scipy-stubs/linalg/_decomp.pyi
@@ -49,8 +49,7 @@ type _InexactND = onp.ArrayND[np.float32 | np.float64 | np.complex64 | np.comple
 
 ###
 
-# `eig` has `2 * (6 + 7) + 1 == 27` overloads...
-@overload  # float, left: True (positional), right: True = ..., homogeneous_eigvals: False = ...
+@overload  # float, left: True (positional), right: True = ...
 def eig(
     a: onp.ToFloatND,
     b: onp.ToFloatND | None,
@@ -59,21 +58,9 @@ def eig(
     overwrite_a: bool = False,
     overwrite_b: bool = False,
     check_finite: bool = True,
-    homogeneous_eigvals: Literal[False] = False,
+    homogeneous_eigvals: bool = False,
 ) -> tuple[_ComplexND, _FloatND]: ...
-@overload  # float, left: True (positional), right: True = ..., homogeneous_eigvals: True (keyword)
-def eig(
-    a: onp.ToFloatND,
-    b: onp.ToFloatND | None,
-    left: Literal[True],
-    right: Literal[True] = True,
-    overwrite_a: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-    *,
-    homogeneous_eigvals: Literal[True],
-) -> tuple[_ComplexND, _FloatND]: ...
-@overload  # float, left: True (keyword), right: True = ..., homogeneous_eigvals: False = ...
+@overload  # float, left: True (keyword), right: True = ...
 def eig(
     a: onp.ToFloatND,
     b: onp.ToFloatND | None = None,
@@ -83,21 +70,9 @@ def eig(
     overwrite_a: bool = False,
     overwrite_b: bool = False,
     check_finite: bool = True,
-    homogeneous_eigvals: Literal[False] = False,
+    homogeneous_eigvals: bool = False,
 ) -> tuple[_ComplexND, _FloatND]: ...
-@overload  # float, left: True (keyword), right: True = ..., homogeneous_eigvals: True
-def eig(
-    a: onp.ToFloatND,
-    b: onp.ToFloatND | None = None,
-    *,
-    left: Literal[True],
-    right: Literal[True] = True,
-    overwrite_a: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-    homogeneous_eigvals: Literal[True],
-) -> tuple[_ComplexND, _FloatND]: ...
-@overload  # float, left: False, right: False (positional), homogeneous_eigvals: False = ...
+@overload  # float, left: False, right: False (positional)
 def eig(
     a: onp.ToFloatND,
     b: onp.ToFloatND | None,
@@ -106,21 +81,9 @@ def eig(
     overwrite_a: bool = False,
     overwrite_b: bool = False,
     check_finite: bool = True,
-    homogeneous_eigvals: Literal[False] = False,
+    homogeneous_eigvals: bool = False,
 ) -> tuple[_ComplexND, _FloatND]: ...
-@overload  # float, left: False, right: False (positional), homogeneous_eigvals: True (keyword)
-def eig(
-    a: onp.ToFloatND,
-    b: onp.ToFloatND | None,
-    left: Literal[False],
-    right: Literal[False],
-    overwrite_a: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-    *,
-    homogeneous_eigvals: Literal[True],
-) -> tuple[_ComplexND, _FloatND]: ...
-@overload  # float, left: False = ..., right: False (keyword), homogeneous_eigvals: False = ...
+@overload  # float, left: False = ..., right: False (keyword)
 def eig(
     a: onp.ToFloatND,
     b: onp.ToFloatND | None = None,
@@ -130,21 +93,9 @@ def eig(
     overwrite_a: bool = False,
     overwrite_b: bool = False,
     check_finite: bool = True,
-    homogeneous_eigvals: Literal[False] = False,
+    homogeneous_eigvals: bool = False,
 ) -> tuple[_ComplexND, _FloatND]: ...
-@overload  # float, left: False = ..., right: False (keyword), homogeneous_eigvals: True
-def eig(
-    a: onp.ToFloatND,
-    b: onp.ToFloatND | None = None,
-    left: Literal[False] = False,
-    *,
-    right: Literal[False],
-    overwrite_a: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-    homogeneous_eigvals: Literal[True],
-) -> tuple[_ComplexND, _FloatND]: ...
-@overload  # float, left: True (positional), right: False, homogeneous_eigvals: False = ...
+@overload  # float, left: True (positional), right: False
 def eig(
     a: onp.ToFloatND,
     b: onp.ToFloatND | None,
@@ -153,21 +104,9 @@ def eig(
     overwrite_a: bool = False,
     overwrite_b: bool = False,
     check_finite: bool = True,
-    homogeneous_eigvals: Literal[False] = False,
+    homogeneous_eigvals: bool = False,
 ) -> tuple[_ComplexND, _FloatND, _FloatND]: ...
-@overload  # float, left: True (positional), right: False, homogeneous_eigvals: True (keyword)
-def eig(
-    a: onp.ToFloatND,
-    b: onp.ToFloatND | None,
-    left: Literal[True],
-    right: Literal[False],
-    overwrite_a: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-    *,
-    homogeneous_eigvals: Literal[True],
-) -> tuple[_ComplexND, _FloatND, _FloatND]: ...
-@overload  # float, left: True (keyword), right: False, homogeneous_eigvals: False = ...
+@overload  # float, left: True (keyword), right: False
 def eig(
     a: onp.ToFloatND,
     b: onp.ToFloatND | None = None,
@@ -177,21 +116,9 @@ def eig(
     overwrite_a: bool = False,
     overwrite_b: bool = False,
     check_finite: bool = True,
-    homogeneous_eigvals: Literal[False] = False,
+    homogeneous_eigvals: bool = False,
 ) -> tuple[_ComplexND, _FloatND, _FloatND]: ...
-@overload  # float, left: True (keyword), right: False, homogeneous_eigvals: True
-def eig(
-    a: onp.ToFloatND,
-    b: onp.ToFloatND | None = None,
-    *,
-    left: Literal[True],
-    right: Literal[False],
-    overwrite_a: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-    homogeneous_eigvals: Literal[True],
-) -> tuple[_ComplexND, _FloatND, _FloatND]: ...
-@overload  # complex, left: False = ..., right: True = ..., homogeneous_eigvals: False = ...
+@overload  # complex, left: False = ..., right: True = ...
 def eig(
     a: onp.ToComplexND,
     b: onp.ToComplexND | None = None,
@@ -200,21 +127,9 @@ def eig(
     overwrite_a: bool = False,
     overwrite_b: bool = False,
     check_finite: bool = True,
-    homogeneous_eigvals: Literal[False] = False,
+    homogeneous_eigvals: bool = False,
 ) -> _ComplexND: ...
-@overload  # complex, left: False = ..., right: True = ..., homogeneous_eigvals: True (keyword)
-def eig(
-    a: onp.ToComplexND,
-    b: onp.ToComplexND | None = None,
-    left: Literal[False] = False,
-    right: Literal[True] = True,
-    overwrite_a: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-    *,
-    homogeneous_eigvals: Literal[True],
-) -> _ComplexND: ...
-@overload  # complex, left: True (positional), right: True = ..., homogeneous_eigvals: False = ...
+@overload  # complex, left: True (positional), right: True = ...
 def eig(
     a: onp.ToComplexND,
     b: onp.ToComplexND | None,
@@ -223,21 +138,9 @@ def eig(
     overwrite_a: bool = False,
     overwrite_b: bool = False,
     check_finite: bool = True,
-    homogeneous_eigvals: Literal[False] = False,
+    homogeneous_eigvals: bool = False,
 ) -> tuple[_ComplexND, _InexactND]: ...
-@overload  # complex, left: True (positional), right: True = ..., homogeneous_eigvals: True (keyword)
-def eig(
-    a: onp.ToComplexND,
-    b: onp.ToComplexND | None,
-    left: Literal[True],
-    right: Literal[True] = True,
-    overwrite_a: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-    *,
-    homogeneous_eigvals: Literal[True],
-) -> tuple[_ComplexND, _InexactND]: ...
-@overload  # complex, left: True (keyword), right: True = ..., homogeneous_eigvals: False = ...
+@overload  # complex, left: True (keyword), right: True = ...
 def eig(
     a: onp.ToComplexND,
     b: onp.ToComplexND | None = None,
@@ -247,21 +150,9 @@ def eig(
     overwrite_a: bool = False,
     overwrite_b: bool = False,
     check_finite: bool = True,
-    homogeneous_eigvals: Literal[False] = False,
+    homogeneous_eigvals: bool = False,
 ) -> tuple[_ComplexND, _InexactND]: ...
-@overload  # complex, left: True (keyword), right: True = ..., homogeneous_eigvals: True
-def eig(
-    a: onp.ToComplexND,
-    b: onp.ToComplexND | None = None,
-    *,
-    left: Literal[True],
-    right: Literal[True] = True,
-    overwrite_a: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-    homogeneous_eigvals: Literal[True],
-) -> tuple[_ComplexND, _InexactND]: ...
-@overload  # complex, left: False, right: False (positional), homogeneous_eigvals: False = ...
+@overload  # complex, left: False, right: False (positional)
 def eig(
     a: onp.ToComplexND,
     b: onp.ToComplexND | None,
@@ -270,21 +161,9 @@ def eig(
     overwrite_a: bool = False,
     overwrite_b: bool = False,
     check_finite: bool = True,
-    homogeneous_eigvals: Literal[False] = False,
+    homogeneous_eigvals: bool = False,
 ) -> tuple[_ComplexND, _InexactND]: ...
-@overload  # complex, left: False, right: False (positional), homogeneous_eigvals: True (keyword)
-def eig(
-    a: onp.ToComplexND,
-    b: onp.ToComplexND | None,
-    left: Literal[False],
-    right: Literal[False],
-    overwrite_a: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-    *,
-    homogeneous_eigvals: Literal[True],
-) -> tuple[_ComplexND, _InexactND]: ...
-@overload  # complex, left: False = ..., right: False (keyword), homogeneous_eigvals: False = ...
+@overload  # complex, left: False = ..., right: False (keyword)
 def eig(
     a: onp.ToComplexND,
     b: onp.ToComplexND | None = None,
@@ -294,21 +173,9 @@ def eig(
     overwrite_a: bool = False,
     overwrite_b: bool = False,
     check_finite: bool = True,
-    homogeneous_eigvals: Literal[False] = False,
+    homogeneous_eigvals: bool = False,
 ) -> tuple[_ComplexND, _InexactND]: ...
-@overload  # complex, left: False = ..., right: False (keyword), homogeneous_eigvals: True
-def eig(
-    a: onp.ToComplexND,
-    b: onp.ToComplexND | None = None,
-    left: Literal[False] = False,
-    *,
-    right: Literal[False],
-    overwrite_a: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-    homogeneous_eigvals: Literal[True],
-) -> tuple[_ComplexND, _InexactND]: ...
-@overload  # complex, left: True (positional), right: False, homogeneous_eigvals: False = ...
+@overload  # complex, left: True (positional), right: False
 def eig(
     a: onp.ToComplexND,
     b: onp.ToComplexND | None,
@@ -317,21 +184,9 @@ def eig(
     overwrite_a: bool = False,
     overwrite_b: bool = False,
     check_finite: bool = True,
-    homogeneous_eigvals: Literal[False] = False,
+    homogeneous_eigvals: bool = False,
 ) -> tuple[_ComplexND, _InexactND, _InexactND]: ...
-@overload  # complex, left: True (positional), right: False, homogeneous_eigvals: True (keyword)
-def eig(
-    a: onp.ToComplexND,
-    b: onp.ToComplexND | None,
-    left: Literal[True],
-    right: Literal[False],
-    overwrite_a: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-    *,
-    homogeneous_eigvals: Literal[True],
-) -> tuple[_ComplexND, _InexactND, _InexactND]: ...
-@overload  # complex, left: True (keyword), right: False (keyword), homogeneous_eigvals: False = ...
+@overload  # complex, left: True (keyword), right: False (keyword)
 def eig(
     a: onp.ToComplexND,
     b: onp.ToComplexND | None = None,
@@ -341,19 +196,7 @@ def eig(
     overwrite_a: bool = False,
     overwrite_b: bool = False,
     check_finite: bool = True,
-    homogeneous_eigvals: Literal[False] = False,
-) -> tuple[_ComplexND, _InexactND, _InexactND]: ...
-@overload  # complex, left: True (keyword), right: False (keyword), homogeneous_eigvals: True
-def eig(
-    a: onp.ToComplexND,
-    b: onp.ToComplexND | None = None,
-    *,
-    left: Literal[True],
-    right: Literal[False],
-    overwrite_a: bool = False,
-    overwrite_b: bool = False,
-    check_finite: bool = True,
-    homogeneous_eigvals: Literal[True],
+    homogeneous_eigvals: bool = False,
 ) -> tuple[_ComplexND, _InexactND, _InexactND]: ...
 @overload  # catch-all
 def eig(

--- a/tests/linalg/test__decomp.pyi
+++ b/tests/linalg/test__decomp.pyi
@@ -20,103 +20,119 @@ from scipy.linalg import (
 
 ###
 
-type _FloatND = onp.ArrayND[np.float32 | np.float64]
-type _ComplexND = onp.ArrayND[np.complex64 | np.complex128]
-type _InexactND = onp.ArrayND[np.float32 | np.float64 | np.complex64 | np.complex128]
+type _FloatND = onp.ArrayND[np.float64 | np.float32]
+type _ComplexND = onp.ArrayND[np.complex128 | np.complex64]
+type _InexactND = onp.ArrayND[np.complex128 | np.complex64 | np.float64 | np.float32]
 
 ###
 # Input arrays
 
-f32_nd: onp.ArrayND[np.float32]
-c128_nd: onp.ArrayND[np.complex128]
+_f32_nd: onp.ArrayND[np.float32]
+_f64_nd: onp.ArrayND[np.float64]
+_c64_nd: onp.ArrayND[np.complex64]
+_c128_nd: onp.ArrayND[np.complex128]
 
-py_f_1d: list[float]
-py_f_2d: list[list[float]]
-
-w_f64: onp.ArrayND[np.float64]
-v_f64: onp.ArrayND[np.float64]
-w_f32: onp.ArrayND[np.float32]
-v_f32: onp.ArrayND[np.float32]
+_py_f_1d: list[float]
+_py_f_2d: list[list[float]]
+_py_c_2d: list[list[complex]]
 
 ###
 # eigvals
 
-assert_type(eigvals(f32_nd), _ComplexND)
-assert_type(eigvals(c128_nd), _ComplexND)
-assert_type(eigvals(f32_nd, homogeneous_eigvals=True), _ComplexND)
-assert_type(eigvals(c128_nd, homogeneous_eigvals=True), _ComplexND)
+assert_type(eigvals(_f32_nd), _ComplexND)
+assert_type(eigvals(_c128_nd), _ComplexND)
+assert_type(eigvals(_f32_nd, homogeneous_eigvals=True), _ComplexND)
+assert_type(eigvals(_c128_nd, homogeneous_eigvals=True), _ComplexND)
 
 ###
 # eigvalsh
 
-assert_type(eigvalsh(f32_nd), _FloatND)
-assert_type(eigvalsh(c128_nd), _FloatND)
+assert_type(eigvalsh(_f32_nd), _FloatND)
+assert_type(eigvalsh(_c128_nd), _FloatND)
 
 ###
 # eigvalsh_tridiagonal
 
-assert_type(eigvalsh_tridiagonal(py_f_1d, py_f_1d), _FloatND)
-assert_type(eigvalsh_tridiagonal(py_f_1d, py_f_1d, "v", [0.5, 1.5]), _FloatND)
-assert_type(eigvalsh_tridiagonal(py_f_1d, py_f_1d, "i", [0, 2]), _FloatND)
+assert_type(eigvalsh_tridiagonal(_py_f_1d, _py_f_1d), _FloatND)
+assert_type(eigvalsh_tridiagonal(_py_f_1d, _py_f_1d, "v", [0.5, 1.5]), _FloatND)
+assert_type(eigvalsh_tridiagonal(_py_f_1d, _py_f_1d, "i", [0, 2]), _FloatND)
 
 ###
 # eigvals_banded
 
-assert_type(eigvals_banded(py_f_2d), _FloatND)
-assert_type(eigvals_banded(py_f_2d, select="v", select_range=[0.5, 1.5]), _FloatND)
-assert_type(eigvals_banded(py_f_2d, select="i", select_range=[0, 2]), _FloatND)
+assert_type(eigvals_banded(_py_f_2d), _FloatND)
+assert_type(eigvals_banded(_py_f_2d, select="v", select_range=[0.5, 1.5]), _FloatND)
+assert_type(eigvals_banded(_py_f_2d, select="i", select_range=[0, 2]), _FloatND)
 
 ###
 # eigh_tridiagonal
 
-assert_type(eigh_tridiagonal(py_f_1d, py_f_1d), tuple[_FloatND, _FloatND])
-assert_type(eigh_tridiagonal(py_f_1d, py_f_1d, False, "v", [0.5, 1.5]), tuple[_FloatND, _FloatND])
-assert_type(eigh_tridiagonal(py_f_1d, py_f_1d, False, "i", [0, 2]), tuple[_FloatND, _FloatND])
-assert_type(eigh_tridiagonal(py_f_1d, py_f_1d, True), _FloatND)
-assert_type(eigh_tridiagonal(py_f_1d, py_f_1d, True, "v", [0.5, 1.5]), _FloatND)
-assert_type(eigh_tridiagonal(py_f_1d, py_f_1d, True, "i", [0, 2]), _FloatND)
+assert_type(eigh_tridiagonal(_py_f_1d, _py_f_1d), tuple[_FloatND, _FloatND])
+assert_type(eigh_tridiagonal(_py_f_1d, _py_f_1d, False, "v", [0.5, 1.5]), tuple[_FloatND, _FloatND])
+assert_type(eigh_tridiagonal(_py_f_1d, _py_f_1d, False, "i", [0, 2]), tuple[_FloatND, _FloatND])
+assert_type(eigh_tridiagonal(_py_f_1d, _py_f_1d, True), _FloatND)
+assert_type(eigh_tridiagonal(_py_f_1d, _py_f_1d, True, "v", [0.5, 1.5]), _FloatND)
+assert_type(eigh_tridiagonal(_py_f_1d, _py_f_1d, True, "i", [0, 2]), _FloatND)
 
 ###
 # eigh
 
-assert_type(eigh(f32_nd), tuple[_FloatND, _FloatND])
-assert_type(eigh(c128_nd), tuple[_FloatND, _ComplexND])
-assert_type(eigh(f32_nd, eigvals_only=True), _FloatND)
-assert_type(eigh(c128_nd, eigvals_only=True), onp.ArrayND[np.float64])
+assert_type(eigh(_f32_nd), tuple[_FloatND, _FloatND])
+assert_type(eigh(_c128_nd), tuple[_FloatND, _ComplexND])
+assert_type(eigh(_f32_nd, eigvals_only=True), _FloatND)
+assert_type(eigh(_c128_nd, eigvals_only=True), onp.ArrayND[np.float64])
 
 ###
 # eig
 
-assert_type(eig(c128_nd), _ComplexND)
-assert_type(eig(c128_nd, None, True), tuple[_ComplexND, _InexactND])
-assert_type(eig(c128_nd, None, True, False), tuple[_ComplexND, _InexactND, _InexactND])
+assert_type(eig(_f32_nd), tuple[_ComplexND, _InexactND])
+assert_type(eig(_f64_nd), tuple[_ComplexND, _InexactND])
+assert_type(eig(_c64_nd), tuple[_ComplexND, _ComplexND])
+assert_type(eig(_c128_nd), tuple[_ComplexND, _ComplexND])
 
-assert_type(eig(f32_nd), _ComplexND)
-assert_type(eig(f32_nd, None, True), tuple[_ComplexND, _FloatND])
+assert_type(eig(_f32_nd, left=False, right=False), _ComplexND)
+assert_type(eig(_f64_nd, left=False, right=False), _ComplexND)
+assert_type(eig(_c64_nd, left=False, right=False), _ComplexND)
+assert_type(eig(_c128_nd, left=False, right=False), _ComplexND)
+
+assert_type(eig(_f32_nd, left=False, right=True), tuple[_ComplexND, _InexactND])
+assert_type(eig(_f64_nd, left=False, right=True), tuple[_ComplexND, _InexactND])
+assert_type(eig(_c64_nd, left=False, right=True), tuple[_ComplexND, _ComplexND])
+assert_type(eig(_c128_nd, left=False, right=True), tuple[_ComplexND, _ComplexND])
+
+assert_type(eig(_f32_nd, left=True, right=False), tuple[_ComplexND, _InexactND])
+assert_type(eig(_f64_nd, left=True, right=False), tuple[_ComplexND, _InexactND])
+assert_type(eig(_c64_nd, left=True, right=False), tuple[_ComplexND, _ComplexND])
+assert_type(eig(_c128_nd, left=True, right=False), tuple[_ComplexND, _ComplexND])
+
+assert_type(eig(_f32_nd, left=True, right=True), tuple[_ComplexND, _InexactND, _InexactND])
+assert_type(eig(_f64_nd, left=True, right=True), tuple[_ComplexND, _InexactND, _InexactND])
+assert_type(eig(_c64_nd, left=True, right=True), tuple[_ComplexND, _ComplexND, _ComplexND])
+assert_type(eig(_c128_nd, left=True, right=True), tuple[_ComplexND, _ComplexND, _ComplexND])
 
 ###
 # eig_banded
 
-assert_type(eig_banded(py_f_2d), tuple[_FloatND, _FloatND])
-assert_type(eig_banded(c128_nd), tuple[_FloatND, _InexactND])
-assert_type(eig_banded(py_f_2d, eigvals_only=True), _FloatND)
-assert_type(eig_banded(c128_nd, True, True), _FloatND)
+assert_type(eig_banded(_py_f_2d), tuple[_FloatND, _FloatND])
+assert_type(eig_banded(_c128_nd), tuple[_FloatND, _InexactND])
+assert_type(eig_banded(_py_f_2d, eigvals_only=True), _FloatND)
+assert_type(eig_banded(_c128_nd, True, True), _FloatND)
 
 ###
 # hessenberg
 
-assert_type(hessenberg(f32_nd), _FloatND)
-assert_type(hessenberg(f32_nd, True), tuple[_FloatND, _FloatND])
+assert_type(hessenberg(_f32_nd), _FloatND)
+assert_type(hessenberg(_f32_nd, True), tuple[_FloatND, _FloatND])
 
-assert_type(hessenberg(c128_nd), _InexactND)
-assert_type(hessenberg(c128_nd, True), tuple[_InexactND, _InexactND])
+assert_type(hessenberg(_c128_nd), _InexactND)
+assert_type(hessenberg(_c128_nd, True), tuple[_InexactND, _InexactND])
 
 ###
 # cdf2rdf
 
-assert_type(cdf2rdf(w_f64, v_f64), tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64]])
-assert_type(cdf2rdf(w_f32, v_f32), tuple[onp.ArrayND[np.float32], onp.ArrayND[np.float32]])
-assert_type(cdf2rdf(w_f64, v_f32), tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float32]])
-assert_type(cdf2rdf(w_f64, c128_nd), tuple[onp.ArrayND[np.float64], _FloatND])
-assert_type(cdf2rdf(c128_nd, v_f64), tuple[_FloatND, onp.ArrayND[np.float64]])
-assert_type(cdf2rdf(c128_nd, c128_nd), tuple[_FloatND, _FloatND])
+assert_type(cdf2rdf(_f64_nd, _f64_nd), tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64]])
+assert_type(cdf2rdf(_f32_nd, _f32_nd), tuple[onp.ArrayND[np.float32], onp.ArrayND[np.float32]])
+assert_type(cdf2rdf(_f64_nd, _f32_nd), tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float32]])
+assert_type(cdf2rdf(_f64_nd, _c128_nd), tuple[onp.ArrayND[np.float64], _FloatND])
+assert_type(cdf2rdf(_c128_nd, _f64_nd), tuple[_FloatND, onp.ArrayND[np.float64]])
+assert_type(cdf2rdf(_c128_nd, _c128_nd), tuple[_FloatND, _FloatND])


### PR DESCRIPTION
closes #1757