### PR TITLE
🐛 `io.loadmat`: fix incorrect value type of the returned `dict`

### DIFF
--- a/scipy-stubs/io/matlab/_mio.pyi
+++ b/scipy-stubs/io/matlab/_mio.pyi
@@ -6,7 +6,6 @@ import optype as op
 
 from ._miobase import MatFileReader
 from scipy.io._typing import ByteOrder, FileLike
-from scipy.sparse import coo_array, coo_matrix, csc_array, csc_matrix
 
 __all__ = ["loadmat", "savemat", "whosmat"]
 
@@ -61,25 +60,16 @@ def loadmat(
     *,
     spmatrix: _NoValueType = ...,
     **kwargs: Unpack[_ReaderKwargs],
-) -> dict[str, csc_matrix[Any] | coo_matrix[Any]]: ...
+) -> dict[str, Any]: ...
 @overload
 def loadmat(
     file_name: FileLike[bytes],
     mdict: Mapping[str, object] | None = None,
     appendmat: bool = True,
     *,
-    spmatrix: Literal[True],
+    spmatrix: bool,
     **kwargs: Unpack[_ReaderKwargs],
-) -> dict[str, csc_matrix[Any] | coo_matrix[Any]]: ...
-@overload
-def loadmat(
-    file_name: FileLike[bytes],
-    mdict: Mapping[str, object] | None = None,
-    appendmat: bool = True,
-    *,
-    spmatrix: Literal[False],
-    **kwargs: Unpack[_ReaderKwargs],
-) -> dict[str, csc_array[Any] | coo_array[Any, tuple[int, int]]]: ...
+) -> dict[str, Any]: ...
 
 #
 def savemat(

--- a/tests/io/test_matlab.pyi
+++ b/tests/io/test_matlab.pyi
@@ -1,25 +1,24 @@
 from typing import Any, Literal, assert_type
 
 from scipy.io import loadmat, savemat, whosmat
-from scipy.sparse import coo_array, coo_matrix, csc_array, csc_matrix
 
 ###
 
 # loadmat
-assert_type(loadmat("file.mat"), dict[str, csc_matrix | coo_matrix])  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]
-assert_type(loadmat("file.mat", mdict={}), dict[str, csc_matrix | coo_matrix])  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]
-assert_type(loadmat("file.mat", appendmat=False), dict[str, csc_matrix | coo_matrix])  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]
-assert_type(loadmat("file.mat", spmatrix=True), dict[str, csc_matrix | coo_matrix])
-assert_type(loadmat("file.mat", spmatrix=False), dict[str, csc_array | coo_array[Any, tuple[int, int]]])
-assert_type(loadmat("file.mat", byte_order="native"), dict[str, csc_matrix | coo_matrix])  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]
-assert_type(loadmat("file.mat", mat_dtype=True), dict[str, csc_matrix | coo_matrix])  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]
-assert_type(loadmat("file.mat", squeeze_me=False), dict[str, csc_matrix | coo_matrix])  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]
-assert_type(loadmat("file.mat", chars_as_strings=False), dict[str, csc_matrix | coo_matrix])  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]
-assert_type(loadmat("file.mat", matlab_compatible=True), dict[str, csc_matrix | coo_matrix])  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]
-assert_type(loadmat("file.mat", struct_as_record=True), dict[str, csc_matrix | coo_matrix])  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]
-assert_type(loadmat("file.mat", verify_compressed_data_integrity=True), dict[str, csc_matrix | coo_matrix])  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]
-assert_type(loadmat("file.mat", simplify_cells=True), dict[str, csc_matrix | coo_matrix])  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]
-assert_type(loadmat("file.mat", variable_names=("a", "b")), dict[str, csc_matrix | coo_matrix])  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]
+assert_type(loadmat("file.mat"), dict[str, Any])  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]
+assert_type(loadmat("file.mat", mdict={}), dict[str, Any])  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]
+assert_type(loadmat("file.mat", appendmat=False), dict[str, Any])  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]
+assert_type(loadmat("file.mat", spmatrix=True), dict[str, Any])
+assert_type(loadmat("file.mat", spmatrix=False), dict[str, Any])
+assert_type(loadmat("file.mat", byte_order="native"), dict[str, Any])  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]
+assert_type(loadmat("file.mat", mat_dtype=True), dict[str, Any])  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]
+assert_type(loadmat("file.mat", squeeze_me=False), dict[str, Any])  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]
+assert_type(loadmat("file.mat", chars_as_strings=False), dict[str, Any])  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]
+assert_type(loadmat("file.mat", matlab_compatible=True), dict[str, Any])  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]
+assert_type(loadmat("file.mat", struct_as_record=True), dict[str, Any])  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]
+assert_type(loadmat("file.mat", verify_compressed_data_integrity=True), dict[str, Any])  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]
+assert_type(loadmat("file.mat", simplify_cells=True), dict[str, Any])  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]
+assert_type(loadmat("file.mat", variable_names=("a", "b")), dict[str, Any])  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]
 
 # savemat
 assert_type(savemat("file.mat", {"": ""}), None)


### PR DESCRIPTION
closes #1758