### PR TITLE
🐛 `sparse.linalg.svds`: add missing overloads for `return_singular_vectors`

### DIFF
--- a/scipy-stubs/sparse/linalg/_eigen/_svds.pyi
+++ b/scipy-stubs/sparse/linalg/_eigen/_svds.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Mapping
-from typing import Literal
+from typing import Literal, overload
 
 import numpy as np
 import optype.numpy as onp
@@ -12,15 +12,17 @@ __all__ = ["svds"]
 ###
 
 type _Inexact = np.float32 | np.float64 | np.complex64 | np.complex128
-type _ToMatrix[ScalarT: _Inexact] = onp.ArrayND[ScalarT] | LinearOperator[ScalarT] | _spbase
+type _ToMatrix[ScalarT: _Inexact] = onp.ArrayND[ScalarT] | LinearOperator[ScalarT] | _spbase[ScalarT]
 
 type _Which = Literal["LM", "SM"]
-type _ReturnSingularVectors = Literal["u", "v"] | bool
 type _Solver = Literal["arpack", "propack", "lobpcg"]
 
 ###
 
-def svds[ScalarT: _Inexact](
+# the mypy overload-overlap errors below are false positives
+
+@overload  # return_singular_vectors=True  (default), f64|c128
+def svds[ScalarT: np.float64 | np.complex128](  # type: ignore[overload-overlap]
     A: _ToMatrix[ScalarT],
     k: int = 6,
     ncv: int | None = None,
@@ -28,10 +30,122 @@ def svds[ScalarT: _Inexact](
     which: _Which = "LM",
     v0: onp.ArrayND[ScalarT] | None = None,
     maxiter: int | None = None,
-    return_singular_vectors: _ReturnSingularVectors = True,
+    return_singular_vectors: Literal[True] = True,
     solver: _Solver = "arpack",
     rng: onp.random.ToRNG | None = None,
     options: Mapping[str, object] | None = None,
     *,
     random_state: onp.random.ToRNG | None = None,
-) -> tuple[onp.Array2D[ScalarT], onp.ArrayND[np.float32 | np.float64], onp.ArrayND[ScalarT]]: ...
+) -> tuple[onp.Array2D[ScalarT], onp.Array1D[np.float64], onp.Array2D[ScalarT]]: ...
+@overload  # return_singular_vectors=True  (default), f32|c64
+def svds[ScalarT: np.float32 | np.complex64](
+    A: _ToMatrix[ScalarT],
+    k: int = 6,
+    ncv: int | None = None,
+    tol: float = 0,
+    which: _Which = "LM",
+    v0: onp.ArrayND[ScalarT] | None = None,
+    maxiter: int | None = None,
+    return_singular_vectors: Literal[True] = True,
+    solver: _Solver = "arpack",
+    rng: onp.random.ToRNG | None = None,
+    options: Mapping[str, object] | None = None,
+    *,
+    random_state: onp.random.ToRNG | None = None,
+) -> tuple[onp.Array2D[ScalarT], onp.Array1D[np.float32], onp.Array2D[ScalarT]]: ...
+@overload  # return_singular_vectors=False, f64|c128
+def svds(  # type: ignore[overload-overlap]
+    A: _ToMatrix[np.float64 | np.complex128],
+    k: int = 6,
+    ncv: int | None = None,
+    tol: float = 0,
+    which: _Which = "LM",
+    v0: onp.ArrayND[np.float64 | np.complex128] | None = None,
+    maxiter: int | None = None,
+    *,
+    return_singular_vectors: Literal[False],
+    solver: _Solver = "arpack",
+    rng: onp.random.ToRNG | None = None,
+    options: Mapping[str, object] | None = None,
+    random_state: onp.random.ToRNG | None = None,
+) -> onp.Array1D[np.float64]: ...
+@overload  # return_singular_vectors=False, f32|c64
+def svds(
+    A: _ToMatrix[np.float32 | np.complex64],
+    k: int = 6,
+    ncv: int | None = None,
+    tol: float = 0,
+    which: _Which = "LM",
+    v0: onp.ArrayND[np.float32 | np.complex64] | None = None,
+    maxiter: int | None = None,
+    *,
+    return_singular_vectors: Literal[False],
+    solver: _Solver = "arpack",
+    rng: onp.random.ToRNG | None = None,
+    options: Mapping[str, object] | None = None,
+    random_state: onp.random.ToRNG | None = None,
+) -> onp.Array1D[np.float32]: ...
+@overload  # return_singular_vectors="u", f64|c128
+def svds[ScalarT: np.float64 | np.complex128](  # type: ignore[overload-overlap]
+    A: _ToMatrix[ScalarT],
+    k: int = 6,
+    ncv: int | None = None,
+    tol: float = 0,
+    which: _Which = "LM",
+    v0: onp.ArrayND[ScalarT] | None = None,
+    maxiter: int | None = None,
+    *,
+    return_singular_vectors: Literal["u"],
+    solver: _Solver = "arpack",
+    rng: onp.random.ToRNG | None = None,
+    options: Mapping[str, object] | None = None,
+    random_state: onp.random.ToRNG | None = None,
+) -> tuple[onp.Array2D[ScalarT], onp.Array1D[np.float64], None]: ...
+@overload  # return_singular_vectors="u", f32|c64
+def svds[ScalarT: np.float32 | np.complex64](
+    A: _ToMatrix[ScalarT],
+    k: int = 6,
+    ncv: int | None = None,
+    tol: float = 0,
+    which: _Which = "LM",
+    v0: onp.ArrayND[ScalarT] | None = None,
+    maxiter: int | None = None,
+    *,
+    return_singular_vectors: Literal["u"],
+    solver: _Solver = "arpack",
+    rng: onp.random.ToRNG | None = None,
+    options: Mapping[str, object] | None = None,
+    random_state: onp.random.ToRNG | None = None,
+) -> tuple[onp.Array2D[ScalarT], onp.Array1D[np.float32], None]: ...
+@overload  # return_singular_vectors="vh", f64|c128
+def svds[ScalarT: np.float64 | np.complex128](  # type: ignore[overload-overlap]
+    A: _ToMatrix[ScalarT],
+    k: int = 6,
+    ncv: int | None = None,
+    tol: float = 0,
+    which: _Which = "LM",
+    v0: onp.ArrayND[ScalarT] | None = None,
+    maxiter: int | None = None,
+    *,
+    return_singular_vectors: Literal["vh"],
+    solver: _Solver = "arpack",
+    rng: onp.random.ToRNG | None = None,
+    options: Mapping[str, object] | None = None,
+    random_state: onp.random.ToRNG | None = None,
+) -> tuple[None, onp.Array1D[np.float64], onp.Array2D[ScalarT]]: ...
+@overload  # return_singular_vectors="vh", f32|c64
+def svds[ScalarT: np.float32 | np.complex64](
+    A: _ToMatrix[ScalarT],
+    k: int = 6,
+    ncv: int | None = None,
+    tol: float = 0,
+    which: _Which = "LM",
+    v0: onp.ArrayND[ScalarT] | None = None,
+    maxiter: int | None = None,
+    *,
+    return_singular_vectors: Literal["vh"],
+    solver: _Solver = "arpack",
+    rng: onp.random.ToRNG | None = None,
+    options: Mapping[str, object] | None = None,
+    random_state: onp.random.ToRNG | None = None,
+) -> tuple[None, onp.Array1D[np.float32], onp.Array2D[ScalarT]]: ...

--- a/scipy-stubs/sparse/linalg/_eigen/_svds.pyi
+++ b/scipy-stubs/sparse/linalg/_eigen/_svds.pyi
@@ -19,10 +19,11 @@ type _Solver = Literal["arpack", "propack", "lobpcg"]
 
 ###
 
-# the mypy overload-overlap errors below are false positives
+# mypy reports 4 false positive `overload-overlap` errors on numpy>=2.2
+# mypy: disable-error-code=overload-overlap
 
 @overload  # return_singular_vectors=True  (default), f64|c128
-def svds[ScalarT: np.float64 | np.complex128](  # type: ignore[overload-overlap]
+def svds[ScalarT: np.float64 | np.complex128](
     A: _ToMatrix[ScalarT],
     k: int = 6,
     ncv: int | None = None,
@@ -54,7 +55,7 @@ def svds[ScalarT: np.float32 | np.complex64](
     random_state: onp.random.ToRNG | None = None,
 ) -> tuple[onp.Array2D[ScalarT], onp.Array1D[np.float32], onp.Array2D[ScalarT]]: ...
 @overload  # return_singular_vectors=False, f64|c128
-def svds(  # type: ignore[overload-overlap]
+def svds(
     A: _ToMatrix[np.float64 | np.complex128],
     k: int = 6,
     ncv: int | None = None,
@@ -86,7 +87,7 @@ def svds(
     random_state: onp.random.ToRNG | None = None,
 ) -> onp.Array1D[np.float32]: ...
 @overload  # return_singular_vectors="u", f64|c128
-def svds[ScalarT: np.float64 | np.complex128](  # type: ignore[overload-overlap]
+def svds[ScalarT: np.float64 | np.complex128](
     A: _ToMatrix[ScalarT],
     k: int = 6,
     ncv: int | None = None,
@@ -118,7 +119,7 @@ def svds[ScalarT: np.float32 | np.complex64](
     random_state: onp.random.ToRNG | None = None,
 ) -> tuple[onp.Array2D[ScalarT], onp.Array1D[np.float32], None]: ...
 @overload  # return_singular_vectors="vh", f64|c128
-def svds[ScalarT: np.float64 | np.complex128](  # type: ignore[overload-overlap]
+def svds[ScalarT: np.float64 | np.complex128](
     A: _ToMatrix[ScalarT],
     k: int = 6,
     ncv: int | None = None,

--- a/tests/sparse/linalg/test__svds.pyi
+++ b/tests/sparse/linalg/test__svds.pyi
@@ -5,13 +5,32 @@ import optype.numpy as onp
 
 from scipy.sparse.linalg import svds
 
-a_f32: onp.Array2D[np.float32]
-a_f64: onp.Array2D[np.float64]
-a_c64: onp.Array2D[np.complex64]
-a_c128: onp.Array2D[np.complex128]
+###
 
+_f32_2d: onp.Array2D[np.float32]
+_f64_2d: onp.Array2D[np.float64]
+_c64_2d: onp.Array2D[np.complex64]
+_c128_2d: onp.Array2D[np.complex128]
+
+###
 # svds
-assert_type(svds(a_f32), tuple[onp.Array2D[np.float32], onp.ArrayND[np.float32 | np.float64], onp.ArrayND[np.float32]])
-assert_type(svds(a_f64), tuple[onp.Array2D[np.float64], onp.ArrayND[np.float32 | np.float64], onp.ArrayND[np.float64]])
-assert_type(svds(a_c64), tuple[onp.Array2D[np.complex64], onp.ArrayND[np.float32 | np.float64], onp.ArrayND[np.complex64]])
-assert_type(svds(a_c128), tuple[onp.Array2D[np.complex128], onp.ArrayND[np.float32 | np.float64], onp.ArrayND[np.complex128]])
+
+assert_type(svds(_f32_2d), tuple[onp.Array2D[np.float32], onp.Array1D[np.float32], onp.Array2D[np.float32]])
+assert_type(svds(_f64_2d), tuple[onp.Array2D[np.float64], onp.Array1D[np.float64], onp.Array2D[np.float64]])
+assert_type(svds(_c64_2d), tuple[onp.Array2D[np.complex64], onp.Array1D[np.float32], onp.Array2D[np.complex64]])
+assert_type(svds(_c128_2d), tuple[onp.Array2D[np.complex128], onp.Array1D[np.float64], onp.Array2D[np.complex128]])
+
+assert_type(svds(_f32_2d, return_singular_vectors=False), onp.Array1D[np.float32])
+assert_type(svds(_f64_2d, return_singular_vectors=False), onp.Array1D[np.float64])
+assert_type(svds(_c64_2d, return_singular_vectors=False), onp.Array1D[np.float32])
+assert_type(svds(_c128_2d, return_singular_vectors=False), onp.Array1D[np.float64])
+
+assert_type(svds(_f32_2d, return_singular_vectors="u"), tuple[onp.Array2D[np.float32], onp.Array1D[np.float32], None])
+assert_type(svds(_f64_2d, return_singular_vectors="u"), tuple[onp.Array2D[np.float64], onp.Array1D[np.float64], None])
+assert_type(svds(_c64_2d, return_singular_vectors="u"), tuple[onp.Array2D[np.complex64], onp.Array1D[np.float32], None])
+assert_type(svds(_c128_2d, return_singular_vectors="u"), tuple[onp.Array2D[np.complex128], onp.Array1D[np.float64], None])
+
+assert_type(svds(_f32_2d, return_singular_vectors="vh"), tuple[None, onp.Array1D[np.float32], onp.Array2D[np.float32]])
+assert_type(svds(_f64_2d, return_singular_vectors="vh"), tuple[None, onp.Array1D[np.float64], onp.Array2D[np.float64]])
+assert_type(svds(_c64_2d, return_singular_vectors="vh"), tuple[None, onp.Array1D[np.float32], onp.Array2D[np.complex64]])
+assert_type(svds(_c128_2d, return_singular_vectors="vh"), tuple[None, onp.Array1D[np.float64], onp.Array2D[np.complex128]])


### PR DESCRIPTION
this also narrows the dtype of the returned singular values array

closes #1765