### PR TITLE
🧑‍💻 restrict lefthook zuban glob to `scipy-stubs/*.{py,pyi}`

### DIFF
--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -30,7 +30,7 @@ pre-commit:
       run: uv run ty check {staged_files}
 
     - name: zuban
-      glob: "*.{py,pyi}"
+      glob: "scipy-stubs/*.{py,pyi}"
       run: uv run zuban check {staged_files}
 
     - name: unstubbed-modules


### PR DESCRIPTION
it was causing lefthook to fail when I changed the tests (zuban isn't run on those (yet?))