### PR TITLE
🐛 `interpolate.NdPPoly.integrate`: accept any-length tuple for `ranges`

### DIFF
--- a/scipy-stubs/interpolate/_interpolate.pyi
+++ b/scipy-stubs/interpolate/_interpolate.pyi
@@ -246,7 +246,7 @@ class NdPPoly(Generic[_CT_co]):
 
     #
     def integrate(
-        self, /, ranges: tuple[tuple[onp.ToFloat, onp.ToFloat]], extrapolate: bool | None = None
+        self, /, ranges: tuple[tuple[onp.ToFloat, onp.ToFloat], ...], extrapolate: bool | None = None
     ) -> onp.ArrayND[_CT_co]: ...
 
 #


### PR DESCRIPTION
fixes #1859