### PR TITLE
🐛 `optimize.{basinhopping,dual_annealing}`: fix result `.message` type (`str` -> `list[str]`)

### DIFF
--- a/scipy-stubs/optimize/_basinhopping.pyi
+++ b/scipy-stubs/optimize/_basinhopping.pyi
@@ -33,7 +33,7 @@ class OptimizeResult(_OptimizeResult):
     x: _Float1D
     fun: _Float
 
-    message: str
+    message: list[str]
     nit: int
     success: bool
 

--- a/scipy-stubs/optimize/_dual_annealing.pyi
+++ b/scipy-stubs/optimize/_dual_annealing.pyi
@@ -26,7 +26,7 @@ class OptimizeResult(_OptimizeResult):
     nfev: int
     njev: int
     nhev: int
-    message: str
+    message: list[str]
 
 @overload
 def dual_annealing(

--- a/tests/optimize/test_basinhopping.pyi
+++ b/tests/optimize/test_basinhopping.pyi
@@ -16,7 +16,7 @@ _f64_1d: onp.Array1D[np.float64]
 
 assert_type(basinhopping(_fn_f64_1d, _f64_1d).success, bool)
 assert_type(basinhopping(_fn_f64_1d, _f64_1d).nit, int)
-assert_type(basinhopping(_fn_f64_1d, _f64_1d).message, str)
+assert_type(basinhopping(_fn_f64_1d, _f64_1d).message, list[str])
 assert_type(basinhopping(_fn_f64_1d, _f64_1d).x, onp.Array1D[np.float64])
 assert_type(basinhopping(_fn_f64_1d, _f64_1d).fun, float | np.float64)
 assert_type(basinhopping(_fn_f64_1d, _f64_1d).minimization_failures, int)


### PR DESCRIPTION
fixes #1793