### PR TITLE
🐛 `signal.peak_widths`: fix dtype of 2nd output array

### DIFF
--- a/scipy-stubs/signal/_peak_finding.pyi
+++ b/scipy-stubs/signal/_peak_finding.pyi
@@ -37,7 +37,12 @@ def peak_widths(
     rel_height: float = 0.5,
     prominence_data: _PeakProminences | None = None,
     wlen: float | None = None,
-) -> tuple[onp.ArrayND[np.float64], onp.ArrayND[np.int_], onp.ArrayND[np.float64], onp.ArrayND[np.float64]]: ...
+) -> tuple[
+    onp.ArrayND[np.float64],  # widths
+    onp.ArrayND[np.float64],  # width_heights
+    onp.ArrayND[np.float64],  # left_ips
+    onp.ArrayND[np.float64],  # right_ips
+]: ...
 
 #
 def find_peaks_cwt(

--- a/tests/signal/test_peak_finding.pyi
+++ b/tests/signal/test_peak_finding.pyi
@@ -47,7 +47,7 @@ assert_type(peak_prominences(_f64_1d, _i64_1d), tuple[onp.ArrayND[np.float64], o
 
 assert_type(
     peak_widths(_f64_1d, _i64_1d),
-    tuple[onp.ArrayND[np.float64], onp.ArrayND[np.int_], onp.ArrayND[np.float64], onp.ArrayND[np.float64]],
+    tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64], onp.ArrayND[np.float64], onp.ArrayND[np.float64]],
 )
 
 # find_peaks_cwt


### PR DESCRIPTION
fixes #1819