### PR TITLE
🐛 `cluster.hierarchy.dendogram`: fix result dict `{i,d}coord` list element types (`int` -> `float`)

### DIFF
--- a/scipy-stubs/cluster/hierarchy/_hierarchy_impl.pyi
+++ b/scipy-stubs/cluster/hierarchy/_hierarchy_impl.pyi
@@ -55,11 +55,11 @@ type _Orientation = Literal["top", "bottom", "left", "right"]
 
 @type_check_only
 class _DendrogramResult(TypedDict):
-    color_list: list[str]
-    icoord: list[list[int]]
-    dcoord: list[list[int]]
+    icoord: list[list[float]]
+    dcoord: list[list[float]]
     ivl: list[str]
     leaves: list[int] | None
+    color_list: list[str]
     leaves_color_list: list[str]
 
 ###

--- a/tests/cluster/test_hierarchy.pyi
+++ b/tests/cluster/test_hierarchy.pyi
@@ -112,8 +112,8 @@ assert_type(maxRstat(f64_2d, f64_2d, 0), onp.Array1D[np.float64])
 
 # dendrogram
 assert_type(dendrogram(f64_2d)["color_list"], list[str])
-assert_type(dendrogram(f64_2d)["icoord"], list[list[int]])
-assert_type(dendrogram(f64_2d)["dcoord"], list[list[int]])
+assert_type(dendrogram(f64_2d)["icoord"], list[list[float]])
+assert_type(dendrogram(f64_2d)["dcoord"], list[list[float]])
 assert_type(dendrogram(f64_2d)["ivl"], list[str])
 assert_type(dendrogram(f64_2d)["leaves"], list[int] | None)
 assert_type(dendrogram(f64_2d)["leaves_color_list"], list[str])


### PR DESCRIPTION
closes #1841