### PR TITLE
🐛 `stats.expectile`: add missing overloads for `axis` and `keepdims`

### DIFF
--- a/scipy-stubs/stats/_stats_py.pyi
+++ b/scipy-stubs/stats/_stats_py.pyi
@@ -5234,6 +5234,37 @@ def rankdata(
 ) -> onp.ArrayND[np.float64]: ...
 
 #
+@overload  # axis=None (default)
+def expectile(
+    a: onp.ToFloatND,
+    alpha: float = 0.5,
+    *,
+    weights: onp.ToFloatND | None = None,
+    axis: None = None,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: L[False] = False,
+) -> np.float64: ...
+@overload  # axis=<given>
+def expectile(
+    a: onp.ToFloatND,
+    alpha: float = 0.5,
+    *,
+    weights: onp.ToFloatND | None = None,
+    axis: int,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: L[False] = False,
+) -> onp.ArrayND[np.float64]: ...
+@overload  # known shape, keepdims=True
+def expectile[ShapeT: tuple[int, ...]](
+    a: onp.ArrayND[npc.floating | npc.integer, ShapeT],
+    alpha: float = 0.5,
+    *,
+    weights: onp.ToFloatND | None = None,
+    axis: int | None = None,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: L[True],
+) -> onp.ArrayND[np.float64, ShapeT]: ...
+@overload  # known shape, keepdims=True
 def expectile(
     a: onp.ToFloatND,
     alpha: float = 0.5,
@@ -5241,8 +5272,8 @@ def expectile(
     weights: onp.ToFloatND | None = None,
     axis: int | None = None,
     nan_policy: NanPolicy = "propagate",
-    keepdims: bool = False,
-) -> np.float64: ...
+    keepdims: L[True],
+) -> onp.ArrayND[np.float64]: ...
 
 #
 @overload  # ?d, ?d

--- a/tests/stats/test__stats_py.pyi
+++ b/tests/stats/test__stats_py.pyi
@@ -1188,6 +1188,14 @@ assert_type(energy_distance(_f64_1d, _f64_1d), np.float64)
 # expectile
 
 assert_type(expectile(_f64_1d), np.float64)
+assert_type(expectile(_f64_2d), np.float64)
+assert_type(expectile(_f64_3d), np.float64)
+assert_type(expectile(_f64_1d, axis=1), onp.ArrayND[np.float64])
+assert_type(expectile(_f64_2d, axis=1), onp.ArrayND[np.float64])
+assert_type(expectile(_f64_3d, axis=1), onp.ArrayND[np.float64])
+assert_type(expectile(_f64_1d, keepdims=True), onp.Array1D[np.float64])
+assert_type(expectile(_f64_2d, keepdims=True), onp.Array2D[np.float64])
+assert_type(expectile(_f64_3d, keepdims=True), onp.Array3D[np.float64])
 
 # iqr
 


### PR DESCRIPTION
closes #1779