### PR TITLE
🐛 `stats.quantile`: fix `axis` / `keepdims` overloads

### DIFF
--- a/scipy-stubs/stats/_quantile.pyi
+++ b/scipy-stubs/stats/_quantile.pyi
@@ -28,29 +28,41 @@ type _QuantileMethod = Literal[
 # NOTE: And of course, Pyright reports a different overload error (obvously a false positive) for `estimated_cdf` on `numpy<2.1`
 # pyright: reportOverlappingOverload=false
 
-@overload
+# TODO(@jorenham): propagate floating dtype
+@overload  # 1d, 0d
 def quantile(
     x: onp.ToFloatStrict1D,
     p: onp.ToJustFloat,
     *,
     method: _QuantileMethod = "linear",
-    axis: Literal[-1, 0] | None = 0,
+    axis: int = 0,
     nan_policy: NanPolicy = "propagate",
-    keepdims: bool | None = None,
+    keepdims: Literal[False] | None = None,
     weights: onp.ToJustFloatStrict1D | None = None,
 ) -> np.float64: ...
-@overload
+@overload  # 2d, 0d
 def quantile(
-    x: onp.ToFloatND,
+    x: onp.ToFloatStrict2D,
     p: onp.ToJustFloat,
     *,
     method: _QuantileMethod = "linear",
-    axis: int | None = 0,
+    axis: int = 0,
     nan_policy: NanPolicy = "propagate",
-    keepdims: onp.ToFalse | None = None,
-    weights: onp.ToJustFloatND | None = None,
-) -> np.float64: ...
-@overload
+    keepdims: Literal[False] | None = None,
+    weights: onp.ToJustFloatStrict1D | None = None,
+) -> onp.Array1D[np.float64]: ...
+@overload  # 3d, 0d
+def quantile(
+    x: onp.ToFloatStrict3D,
+    p: onp.ToJustFloat,
+    *,
+    method: _QuantileMethod = "linear",
+    axis: int = 0,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: Literal[False] | None = None,
+    weights: onp.ToJustFloatStrict1D | None = None,
+) -> onp.Array2D[np.float64]: ...
+@overload  # Nd, >0d
 def quantile(
     x: onp.ToFloatND,
     p: onp.ToJustFloatND,
@@ -61,7 +73,18 @@ def quantile(
     keepdims: bool | None = None,
     weights: onp.ToJustFloatND | None = None,
 ) -> onp.ArrayND[np.float64]: ...
-@overload
+@overload  # axis=None
+def quantile(
+    x: onp.ToFloatND,
+    p: onp.ToJustFloat | onp.ToJustFloatND,
+    *,
+    method: _QuantileMethod = "linear",
+    axis: None,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: Literal[False] | None = None,
+    weights: onp.ToJustFloatND | None = None,
+) -> np.float64: ...
+@overload  # keepdims=True
 def quantile(
     x: onp.ToFloatND,
     p: onp.ToJustFloat | onp.ToJustFloatND,
@@ -69,9 +92,20 @@ def quantile(
     method: _QuantileMethod = "linear",
     axis: int | None = 0,
     nan_policy: NanPolicy = "propagate",
-    keepdims: onp.ToTrue,
+    keepdims: Literal[True],
     weights: onp.ToJustFloatND | None = None,
 ) -> onp.ArrayND[np.float64]: ...
+@overload  # Nd, Nd  (fallback)
+def quantile(
+    x: onp.ToFloatND,
+    p: onp.ToJustFloat | onp.ToJustFloatND,
+    *,
+    method: _QuantileMethod = "linear",
+    axis: int = 0,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: bool | None = None,
+    weights: onp.ToJustFloatND | None = None,
+) -> onp.ArrayND[np.float64] | np.float64: ...
 
 #
 @overload  # ?d T, 0d float (workaround)

--- a/tests/stats/test__quantile.pyi
+++ b/tests/stats/test__quantile.pyi
@@ -28,10 +28,30 @@ _py_f_3d: list[list[list[float]]]
 # quantile
 
 assert_type(quantile(_py_f_1d, 0.5), np.float64)
+assert_type(quantile(_py_f_2d, 0.5), onp.Array1D[np.float64])
+assert_type(quantile(_py_f_3d, 0.5), onp.Array2D[np.float64])
 assert_type(quantile(_f64_1d, 0.5), np.float64)
-assert_type(quantile(_f64_nd, 0.5, axis=None), np.float64)
+assert_type(quantile(_f64_2d, 0.5), onp.Array1D[np.float64])
+assert_type(quantile(_f64_3d, 0.5), onp.Array2D[np.float64])
+assert_type(quantile(_f64_1d, 0.5, axis=None), np.float64)
+assert_type(quantile(_f64_2d, 0.5, axis=None), np.float64)
+assert_type(quantile(_f64_3d, 0.5, axis=None), np.float64)
+assert_type(quantile(_f64_1d, 0.5, keepdims=True), onp.ArrayND[np.float64])
 assert_type(quantile(_f64_2d, 0.5, keepdims=True), onp.ArrayND[np.float64])
-assert_type(quantile(_f64_1d, 0.5, method="hazen"), np.float64)
+assert_type(quantile(_f64_3d, 0.5, keepdims=True), onp.ArrayND[np.float64])
+
+assert_type(quantile(_py_f_1d, _f64_1d), onp.ArrayND[np.float64])
+assert_type(quantile(_py_f_2d, _f64_1d), onp.ArrayND[np.float64])
+assert_type(quantile(_py_f_3d, _f64_1d), onp.ArrayND[np.float64])
+assert_type(quantile(_f64_1d, _f64_1d), onp.ArrayND[np.float64])
+assert_type(quantile(_f64_2d, _f64_1d), onp.ArrayND[np.float64])
+assert_type(quantile(_f64_3d, _f64_1d), onp.ArrayND[np.float64])
+assert_type(quantile(_f64_1d, _f64_1d, axis=None), np.float64)
+assert_type(quantile(_f64_2d, _f64_1d, axis=None), np.float64)
+assert_type(quantile(_f64_3d, _f64_1d, axis=None), np.float64)
+assert_type(quantile(_f64_1d, _f64_1d, keepdims=True), onp.ArrayND[np.float64])
+assert_type(quantile(_f64_2d, _f64_1d, keepdims=True), onp.ArrayND[np.float64])
+assert_type(quantile(_f64_3d, _f64_1d, keepdims=True), onp.ArrayND[np.float64])
 
 ###
 # estimated_cdf


### PR DESCRIPTION
closes #1776