### PR TITLE
🐛 `optimize.lsq_linear`: fix result attr typo (`const` -> `cost`)

### DIFF
--- a/scipy-stubs/optimize/_lsq/lsq_linear.pyi
+++ b/scipy-stubs/optimize/_lsq/lsq_linear.pyi
@@ -23,7 +23,7 @@ type _TerminationStatus = Literal[-1, 0, 1, 2, 3]
 class _OptimizeResult(OptimizeResult):
     x: _Float1D
     fun: _Float1D
-    const: _Float
+    cost: _Float
     optimality: _Float
     active_mask: _Int1D
     unbounded_sol: tuple[float | onp.ArrayND[npc.number], ...]

--- a/tests/optimize/test__lsq_linear.pyi
+++ b/tests/optimize/test__lsq_linear.pyi
@@ -14,7 +14,7 @@ _b: list[float]
 _res = lsq_linear(_A, _b)
 assert_type(_res.x, onp.Array1D[np.float64])
 assert_type(_res.fun, onp.Array1D[np.float64])
-assert_type(_res.const, float | np.float64)
+assert_type(_res.cost, float | np.float64)
 assert_type(_res.optimality, float | np.float64)
 assert_type(_res.active_mask, onp.Array1D[np.intp])
 assert_type(_res.nit, int)


### PR DESCRIPTION
closes #1792