### PR TITLE
🐛 `spatial.geometric_slerp`: 1d output for scalar `t`

### DIFF
--- a/scipy-stubs/spatial/_geometric_slerp.pyi
+++ b/scipy-stubs/spatial/_geometric_slerp.pyi
@@ -1,8 +1,11 @@
+from typing import overload
+
 import numpy as np
 import optype.numpy as onp
 
 __all__ = ["geometric_slerp"]
 
-def geometric_slerp(
-    start: onp.ToFloat1D, end: onp.ToFloat1D, t: onp.ToFloat | onp.ToFloat1D, tol: onp.ToFloat = 1e-07
-) -> onp.Array2D[np.float64]: ...
+@overload
+def geometric_slerp(start: onp.ToFloat1D, end: onp.ToFloat1D, t: onp.ToFloat, tol: float = 1e-7) -> onp.Array1D[np.float64]: ...
+@overload
+def geometric_slerp(start: onp.ToFloat1D, end: onp.ToFloat1D, t: onp.ToFloat1D, tol: float = 1e-7) -> onp.Array2D[np.float64]: ...

--- a/tests/spatial/test__geometric_slerp.pyi
+++ b/tests/spatial/test__geometric_slerp.pyi
@@ -16,7 +16,7 @@ _float_list: list[float]
 ###
 # geometric_slerp
 
-assert_type(geometric_slerp(_f64_1d, _f64_1d, t=0.5), onp.Array2D[np.float64])
-assert_type(geometric_slerp(_f64_1d, _f64_1d, t=_f64), onp.Array2D[np.float64])
+assert_type(geometric_slerp(_f64_1d, _f64_1d, t=0.5), onp.Array1D[np.float64])
+assert_type(geometric_slerp(_f64_1d, _f64_1d, t=_f64), onp.Array1D[np.float64])
 assert_type(geometric_slerp(_f64_1d, _f64_1d, t=_f64_1d), onp.Array2D[np.float64])
 assert_type(geometric_slerp(_f64_1d, _f64_1d, t=_float_list), onp.Array2D[np.float64])


### PR DESCRIPTION
fixes #1772