### PR TITLE
🐛 `sparse.linalg`: fix `inv`/`expm`/`matrix_power` output formats and dtypes

### DIFF
--- a/scipy-stubs/sparse/linalg/_matfuncs.pyi
+++ b/scipy-stubs/sparse/linalg/_matfuncs.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Final, Generic, Literal, Self, SupportsIndex, override
+from typing import Any, Final, Generic, Literal, Self, SupportsIndex, overload, override
 from typing_extensions import TypeVar
 
 import numpy as np
@@ -6,6 +6,22 @@ import optype.numpy as onp
 import optype.numpy.compat as npc
 
 from ._interface import LinearOperator
+from scipy.sparse import (
+    bsr_array,
+    bsr_matrix,
+    coo_array,
+    coo_matrix,
+    csc_array,
+    csc_matrix,
+    csr_array,
+    csr_matrix,
+    dia_array,
+    dia_matrix,
+    dok_array,
+    dok_matrix,
+    lil_array,
+    lil_matrix,
+)
 from scipy.sparse._base import _spbase
 
 __all__ = ["expm", "inv", "matrix_power"]
@@ -13,6 +29,23 @@ __all__ = ["expm", "inv", "matrix_power"]
 ###
 
 type _Structure = Literal["upper_triangular"]
+
+type _CS[ScalarT: npc.number | np.bool] = csc_array[ScalarT] | csc_matrix[ScalarT] | csr_array[ScalarT] | csr_matrix[ScalarT]
+type _NonCS[ScalarT: npc.number | np.bool] = (
+    bsr_array[ScalarT]
+    | bsr_matrix[ScalarT]
+    | coo_array[ScalarT]
+    | coo_matrix[ScalarT]
+    | dok_array[ScalarT]
+    | dok_matrix[ScalarT]
+    | dia_array[ScalarT]
+    | dia_matrix[ScalarT]
+    | lil_array[ScalarT]
+    | lil_matrix[ScalarT]
+)
+
+type _SubF64 = npc.integer64 | npc.integer32
+type _SubF32 = npc.integer16 | npc.integer8 | np.bool
 
 _SCT_co = TypeVar("_SCT_co", bound=npc.number | np.bool, default=Any, covariant=True)
 
@@ -34,6 +67,30 @@ class ProductOperator(LinearOperator[_SCT_co], Generic[_SCT_co]):
     def T(self, /) -> Self: ...  # type: ignore[override]  # pyright: ignore[reportIncompatibleMethodOverride]
     def __init__(self, /, *args: onp.Array2D[_SCT_co] | _spbase, structure: _Structure | None = None) -> None: ...
 
-def inv[SparseT: _spbase](A: SparseT) -> SparseT: ...
+#
+@overload
+def inv[ScalarT: npc.inexact](A: _NonCS[ScalarT]) -> csc_array[ScalarT]: ...
+@overload
+def inv(A: _NonCS[_SubF64] | csc_array[_SubF64]) -> csc_array[np.float64]: ...  # type: ignore[overload-overlap]
+@overload
+def inv(A: _NonCS[_SubF32] | csc_array[_SubF32]) -> csc_array[np.float32]: ...
+@overload
+def inv[SparseT: _CS[npc.inexact]](A: SparseT) -> SparseT: ...
+@overload
+def inv(A: csr_array[_SubF64]) -> csr_array[np.float64]: ...  # type: ignore[overload-overlap]
+@overload
+def inv(A: csr_array[_SubF32]) -> csr_array[np.float32]: ...
+@overload
+def inv(A: csr_matrix[_SubF64]) -> csr_matrix[np.float64]: ...  # type: ignore[overload-overlap]
+@overload
+def inv(A: csr_matrix[_SubF32]) -> csr_matrix[np.float32]: ...
+@overload
+def inv(A: csc_matrix[_SubF64]) -> csc_matrix[np.float64]: ...  # type: ignore[overload-overlap]
+@overload
+def inv(A: csc_matrix[_SubF32]) -> csc_matrix[np.float32]: ...
+
+#
 def expm[SparseT: _spbase](A: SparseT) -> SparseT: ...
+
+#
 def matrix_power[SparseT: _spbase](A: SparseT, power: SupportsIndex) -> SparseT: ...

--- a/scipy-stubs/sparse/linalg/_matfuncs.pyi
+++ b/scipy-stubs/sparse/linalg/_matfuncs.pyi
@@ -46,6 +46,9 @@ type _NonCS[ST: npc.number | np.bool] = (
 type _ToCSCArray[ST: npc.number | np.bool] = bsr_array[ST] | bsr_matrix[ST] | csc_array[ST] | dia_array[ST] | dia_matrix[ST]
 type _ToCSRArray[ST: npc.number | np.bool] = coo_array[ST] | csr_array[ST] | dok_array[ST] | lil_array[ST]
 type _ToCSRMatrix[ST: npc.number | np.bool] = coo_matrix[ST] | csr_matrix[ST] | dok_matrix[ST] | lil_matrix[ST]
+type _ToSelf[ST: npc.number | np.bool] = (
+    bsr_array[ST] | bsr_matrix[ST] | csc_array[ST] | csc_matrix[ST] | dia_array[ST] | dia_matrix[ST]
+)
 
 type _SubF64 = npc.integer64 | npc.integer32
 type _SubF32 = npc.integer16 | npc.integer8 | np.bool
@@ -112,4 +115,9 @@ def expm[ScalarT: npc.inexact](A: csc_matrix[ScalarT]) -> csc_matrix[ScalarT]: .
 def expm(A: csc_matrix[_SubF]) -> csc_matrix[np.float64]: ...
 
 #
-def matrix_power[SparseT: _spbase](A: SparseT, power: SupportsIndex) -> SparseT: ...
+@overload
+def matrix_power[ScalarT: npc.number | np.bool](A: _ToCSRArray[ScalarT], power: SupportsIndex) -> csr_array[ScalarT]: ...
+@overload
+def matrix_power[ScalarT: npc.number | np.bool](A: _ToCSRMatrix[ScalarT], power: SupportsIndex) -> csr_matrix[ScalarT]: ...
+@overload
+def matrix_power[SparseT: _ToSelf[npc.number | np.bool]](A: SparseT, power: SupportsIndex) -> SparseT: ...

--- a/scipy-stubs/sparse/linalg/_matfuncs.pyi
+++ b/scipy-stubs/sparse/linalg/_matfuncs.pyi
@@ -30,22 +30,26 @@ __all__ = ["expm", "inv", "matrix_power"]
 
 type _Structure = Literal["upper_triangular"]
 
-type _CS[ScalarT: npc.number | np.bool] = csc_array[ScalarT] | csc_matrix[ScalarT] | csr_array[ScalarT] | csr_matrix[ScalarT]
-type _NonCS[ScalarT: npc.number | np.bool] = (
-    bsr_array[ScalarT]
-    | bsr_matrix[ScalarT]
-    | coo_array[ScalarT]
-    | coo_matrix[ScalarT]
-    | dok_array[ScalarT]
-    | dok_matrix[ScalarT]
-    | dia_array[ScalarT]
-    | dia_matrix[ScalarT]
-    | lil_array[ScalarT]
-    | lil_matrix[ScalarT]
+type _CS[ST: npc.number | np.bool] = csc_array[ST] | csc_matrix[ST] | csr_array[ST] | csr_matrix[ST]
+type _NonCS[ST: npc.number | np.bool] = (
+    bsr_array[ST]
+    | bsr_matrix[ST]
+    | coo_array[ST]
+    | coo_matrix[ST]
+    | dok_array[ST]
+    | dok_matrix[ST]
+    | dia_array[ST]
+    | dia_matrix[ST]
+    | lil_array[ST]
+    | lil_matrix[ST]
 )
+type _ToCSCArray[ST: npc.number | np.bool] = bsr_array[ST] | bsr_matrix[ST] | csc_array[ST] | dia_array[ST] | dia_matrix[ST]
+type _ToCSRArray[ST: npc.number | np.bool] = coo_array[ST] | csr_array[ST] | dok_array[ST] | lil_array[ST]
+type _ToCSRMatrix[ST: npc.number | np.bool] = coo_matrix[ST] | csr_matrix[ST] | dok_matrix[ST] | lil_matrix[ST]
 
 type _SubF64 = npc.integer64 | npc.integer32
 type _SubF32 = npc.integer16 | npc.integer8 | np.bool
+type _SubF = npc.integer | np.bool
 
 _SCT_co = TypeVar("_SCT_co", bound=npc.number | np.bool, default=Any, covariant=True)
 
@@ -90,7 +94,22 @@ def inv(A: csc_matrix[_SubF64]) -> csc_matrix[np.float64]: ...  # type: ignore[o
 def inv(A: csc_matrix[_SubF32]) -> csc_matrix[np.float32]: ...
 
 #
-def expm[SparseT: _spbase](A: SparseT) -> SparseT: ...
+@overload
+def expm[ScalarT: npc.inexact](A: _ToCSCArray[ScalarT]) -> csc_array[ScalarT]: ...
+@overload
+def expm(A: _ToCSCArray[_SubF]) -> csc_array[np.float64]: ...
+@overload
+def expm[ScalarT: npc.inexact](A: _ToCSRArray[ScalarT]) -> csr_array[ScalarT]: ...
+@overload
+def expm(A: _ToCSRArray[_SubF]) -> csr_array[np.float64]: ...
+@overload
+def expm[ScalarT: npc.inexact](A: _ToCSRMatrix[ScalarT]) -> csr_matrix[ScalarT]: ...
+@overload
+def expm(A: _ToCSRMatrix[_SubF]) -> csr_matrix[np.float64]: ...
+@overload
+def expm[ScalarT: npc.inexact](A: csc_matrix[ScalarT]) -> csc_matrix[ScalarT]: ...
+@overload
+def expm(A: csc_matrix[_SubF]) -> csc_matrix[np.float64]: ...
 
 #
 def matrix_power[SparseT: _spbase](A: SparseT, power: SupportsIndex) -> SparseT: ...

--- a/scipy-stubs/sparse/linalg/_matfuncs.pyi
+++ b/scipy-stubs/sparse/linalg/_matfuncs.pyi
@@ -78,11 +78,11 @@ class ProductOperator(LinearOperator[_SCT_co], Generic[_SCT_co]):
 @overload
 def inv[ScalarT: npc.inexact](A: _NonCS[ScalarT]) -> csc_array[ScalarT]: ...
 @overload
+def inv[SparseT: _CS[npc.inexact]](A: SparseT) -> SparseT: ...
+@overload
 def inv(A: _NonCS[_SubF64] | csc_array[_SubF64]) -> csc_array[np.float64]: ...  # type: ignore[overload-overlap]
 @overload
 def inv(A: _NonCS[_SubF32] | csc_array[_SubF32]) -> csc_array[np.float32]: ...
-@overload
-def inv[SparseT: _CS[npc.inexact]](A: SparseT) -> SparseT: ...
 @overload
 def inv(A: csr_array[_SubF64]) -> csr_array[np.float64]: ...  # type: ignore[overload-overlap]
 @overload

--- a/tests/sparse/linalg/test__matfuncs.pyi
+++ b/tests/sparse/linalg/test__matfuncs.pyi
@@ -1,19 +1,160 @@
 from typing import assert_type
 
-from scipy.sparse import csc_array, csr_array
+import numpy as np
+
+from scipy.sparse import (
+    bsr_array,
+    bsr_matrix,
+    coo_array,
+    coo_matrix,
+    csc_array,
+    csc_matrix,
+    csr_array,
+    csr_matrix,
+    dia_array,
+    dia_matrix,
+    dok_array,
+    dok_matrix,
+    lil_array,
+    lil_matrix,
+)
 from scipy.sparse.linalg import expm, inv, matrix_power
 
-a_csr: csr_array
-a_csc: csc_array
+###
 
+_a_bsr_i16: bsr_array[np.int16]
+_a_csc_i16: csc_array[np.int16]
+_a_csr_i16: csr_array[np.int16]
+_a_coo_i16: coo_array[np.int16]
+_a_dia_i16: dia_array[np.int16]
+_a_dok_i16: dok_array[np.int16]
+_a_lil_i16: lil_array[np.int16]
+
+_a_bsr_f32: bsr_array[np.float32]
+_a_csc_f32: csc_array[np.float32]
+_a_csr_f32: csr_array[np.float32]
+_a_coo_f32: coo_array[np.float32]
+_a_dia_f32: dia_array[np.float32]
+_a_dok_f32: dok_array[np.float32]
+_a_lil_f32: lil_array[np.float32]
+
+_m_bsr_i16: bsr_matrix[np.int16]
+_m_csc_i16: csc_matrix[np.int16]
+_m_csr_i16: csr_matrix[np.int16]
+_m_coo_i16: coo_matrix[np.int16]
+_m_dia_i16: dia_matrix[np.int16]
+_m_dok_i16: dok_matrix[np.int16]
+_m_lil_i16: lil_matrix[np.int16]
+
+_m_bsr_f32: bsr_matrix[np.float32]
+_m_csc_f32: csc_matrix[np.float32]
+_m_csr_f32: csr_matrix[np.float32]
+_m_coo_f32: coo_matrix[np.float32]
+_m_dia_f32: dia_matrix[np.float32]
+_m_dok_f32: dok_matrix[np.float32]
+_m_lil_f32: lil_matrix[np.float32]
+
+###
 # inv
-assert_type(inv(a_csr), csr_array)
-assert_type(inv(a_csc), csc_array)
 
+assert_type(inv(_a_bsr_i16), csc_array[np.float32])
+assert_type(inv(_a_csc_i16), csc_array[np.float32])
+assert_type(inv(_a_csr_i16), csr_array[np.float32])
+assert_type(inv(_a_coo_i16), csc_array[np.float32])
+assert_type(inv(_a_dia_i16), csc_array[np.float32])
+assert_type(inv(_a_dok_i16), csc_array[np.float32])
+assert_type(inv(_a_lil_i16), csc_array[np.float32])
+
+assert_type(inv(_a_bsr_f32), csc_array[np.float32])
+assert_type(inv(_a_csc_f32), csc_array[np.float32])
+assert_type(inv(_a_csr_f32), csr_array[np.float32])
+assert_type(inv(_a_coo_f32), csc_array[np.float32])
+assert_type(inv(_a_dia_f32), csc_array[np.float32])
+assert_type(inv(_a_dok_f32), csc_array[np.float32])
+assert_type(inv(_a_lil_f32), csc_array[np.float32])
+
+assert_type(inv(_m_bsr_i16), csc_array[np.float32])
+assert_type(inv(_m_csc_i16), csc_matrix[np.float32])
+assert_type(inv(_m_csr_i16), csr_matrix[np.float32])
+assert_type(inv(_m_coo_i16), csc_array[np.float32])
+assert_type(inv(_m_dia_i16), csc_array[np.float32])
+assert_type(inv(_m_dok_i16), csc_array[np.float32])
+assert_type(inv(_m_lil_i16), csc_array[np.float32])
+
+assert_type(inv(_m_bsr_f32), csc_array[np.float32])
+assert_type(inv(_m_csc_f32), csc_matrix[np.float32])
+assert_type(inv(_m_csr_f32), csr_matrix[np.float32])
+assert_type(inv(_m_coo_f32), csc_array[np.float32])
+assert_type(inv(_m_dia_f32), csc_array[np.float32])
+assert_type(inv(_m_dok_f32), csc_array[np.float32])
+assert_type(inv(_m_lil_f32), csc_array[np.float32])
+
+###
 # expm
-assert_type(expm(a_csr), csr_array)
-assert_type(expm(a_csc), csc_array)
 
+assert_type(expm(_a_bsr_i16), csc_array[np.float64])
+assert_type(expm(_a_csc_i16), csc_array[np.float64])
+assert_type(expm(_a_csr_i16), csr_array[np.float64])
+assert_type(expm(_a_coo_i16), csr_array[np.float64])
+assert_type(expm(_a_dia_i16), csc_array[np.float64])
+assert_type(expm(_a_dok_i16), csr_array[np.float64])
+assert_type(expm(_a_lil_i16), csr_array[np.float64])
+
+assert_type(expm(_a_bsr_f32), csc_array[np.float32])
+assert_type(expm(_a_csc_f32), csc_array[np.float32])
+assert_type(expm(_a_csr_f32), csr_array[np.float32])
+assert_type(expm(_a_coo_f32), csr_array[np.float32])
+assert_type(expm(_a_dia_f32), csc_array[np.float32])
+assert_type(expm(_a_dok_f32), csr_array[np.float32])
+assert_type(expm(_a_lil_f32), csr_array[np.float32])
+
+assert_type(expm(_m_bsr_i16), csc_array[np.float64])
+assert_type(expm(_m_csc_i16), csc_matrix[np.float64])
+assert_type(expm(_m_csr_i16), csr_matrix[np.float64])
+assert_type(expm(_m_coo_i16), csr_matrix[np.float64])
+assert_type(expm(_m_dia_i16), csc_array[np.float64])
+assert_type(expm(_m_dok_i16), csr_matrix[np.float64])
+assert_type(expm(_m_lil_i16), csr_matrix[np.float64])
+
+assert_type(expm(_m_bsr_f32), csc_array[np.float32])
+assert_type(expm(_m_csc_f32), csc_matrix[np.float32])
+assert_type(expm(_m_csr_f32), csr_matrix[np.float32])
+assert_type(expm(_m_coo_f32), csr_matrix[np.float32])
+assert_type(expm(_m_dia_f32), csc_array[np.float32])
+assert_type(expm(_m_dok_f32), csr_matrix[np.float32])
+assert_type(expm(_m_lil_f32), csr_matrix[np.float32])
+
+###
 # matrix_power
-assert_type(matrix_power(a_csr, 3), csr_array)
-assert_type(matrix_power(a_csc, 3), csc_array)
+
+assert_type(matrix_power(_a_bsr_i16, 3), bsr_array[np.int16])
+assert_type(matrix_power(_a_csc_i16, 3), csc_array[np.int16])
+assert_type(matrix_power(_a_csr_i16, 3), csr_array[np.int16])
+assert_type(matrix_power(_a_coo_i16, 3), csr_array[np.int16])
+assert_type(matrix_power(_a_dia_i16, 3), dia_array[np.int16])
+assert_type(matrix_power(_a_dok_i16, 3), csr_array[np.int16])
+assert_type(matrix_power(_a_lil_i16, 3), csr_array[np.int16])
+
+assert_type(matrix_power(_a_bsr_f32, 3), bsr_array[np.float32])
+assert_type(matrix_power(_a_csc_f32, 3), csc_array[np.float32])
+assert_type(matrix_power(_a_csr_f32, 3), csr_array[np.float32])
+assert_type(matrix_power(_a_coo_f32, 3), csr_array[np.float32])
+assert_type(matrix_power(_a_dia_f32, 3), dia_array[np.float32])
+assert_type(matrix_power(_a_dok_f32, 3), csr_array[np.float32])
+assert_type(matrix_power(_a_lil_f32, 3), csr_array[np.float32])
+
+assert_type(matrix_power(_m_bsr_i16, 3), bsr_matrix[np.int16])
+assert_type(matrix_power(_m_csc_i16, 3), csc_matrix[np.int16])
+assert_type(matrix_power(_m_csr_i16, 3), csr_matrix[np.int16])
+assert_type(matrix_power(_m_coo_i16, 3), csr_matrix[np.int16])
+assert_type(matrix_power(_m_dia_i16, 3), dia_matrix[np.int16])
+assert_type(matrix_power(_m_dok_i16, 3), csr_matrix[np.int16])
+assert_type(matrix_power(_m_lil_i16, 3), csr_matrix[np.int16])
+
+assert_type(matrix_power(_m_bsr_f32, 3), bsr_matrix[np.float32])
+assert_type(matrix_power(_m_csc_f32, 3), csc_matrix[np.float32])
+assert_type(matrix_power(_m_csr_f32, 3), csr_matrix[np.float32])
+assert_type(matrix_power(_m_coo_f32, 3), csr_matrix[np.float32])
+assert_type(matrix_power(_m_dia_f32, 3), dia_matrix[np.float32])
+assert_type(matrix_power(_m_dok_f32, 3), csr_matrix[np.float32])
+assert_type(matrix_power(_m_lil_f32, 3), csr_matrix[np.float32])


### PR DESCRIPTION
towards #1764 (5/6)