### PR TITLE
🐛 `sparse.linalg`: fix `spsolve` sparse format propagation source

### DIFF
--- a/scipy-stubs/sparse/linalg/_dsolve/linsolve.pyi
+++ b/scipy-stubs/sparse/linalg/_dsolve/linsolve.pyi
@@ -76,7 +76,7 @@ def factorized(A: _ToC64Mat) -> _SuperLU_solve[_AsC64, np.complex64]: ...
 #
 @overload  # 2d float, sparse 2d
 def spsolve[SparseT: _spbase](
-    A: _ToInexactMat, b: SparseT, permc_spec: _PermcSpec | None = None, use_umfpack: bool = True
+    A: SparseT, b: _Sparse2D[Any], permc_spec: _PermcSpec | None = None, use_umfpack: bool = True
 ) -> SparseT: ...
 @overload  # 2d float, 1d float
 def spsolve(

--- a/tests/sparse/linalg/test__dsolve.pyi
+++ b/tests/sparse/linalg/test__dsolve.pyi
@@ -60,7 +60,7 @@ assert_type(solve_c64(b_c64), onp.Array1D[np.complex64])
 assert_type(solve_c64(b_c64_2d), onp.Array2D[np.complex64])
 
 # spsolve
-assert_type(spsolve(f64_mat, b_sparse), csc_array[np.float64])
+assert_type(spsolve(b_sparse, bsr_), csc_array[np.float64])
 assert_type(spsolve(f64_mat, b_f), onp.Array1D[np.float64])
 assert_type(spsolve(f64_mat, b_f2d), onp.Array2D[np.float64])
 assert_type(spsolve(c128_mat, b_c), onp.Array1D[np.complex128])


### PR DESCRIPTION
closes #1764 (6/6)