### PR TITLE
🐛 `stats`: fix `bootstrap`/`permutation_test` off-by-one rank

### DIFF
--- a/scipy-stubs/stats/_resampling.pyi
+++ b/scipy-stubs/stats/_resampling.pyi
@@ -1,4 +1,4 @@
-from collections.abc import Callable, Iterable, Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, ClassVar, Generic, Literal, Never, Protocol, TypeVar, overload, type_check_only
 from typing_extensions import deprecated
@@ -189,24 +189,24 @@ def power(
 #
 @overload
 def bootstrap(
-    data: Iterable[onp.ArrayND[npc.floating | npc.integer, _JustAnyShape]],
+    data: Sequence[onp.ArrayND[npc.floating | npc.integer, _JustAnyShape]],
     statistic: _Statistic,
     *,
     n_resamples: int = 9_999,
     batch: int | None = None,
     vectorized: bool | None = None,
     paired: bool = False,
-    axis: Literal[0, -1] = 0,
+    axis: int = 0,
     confidence_level: float = 0.95,
     alternative: Alternative = "two-sided",
     method: _BootstrapMethod = "BCa",
     bootstrap_result: BootstrapResult | None = None,
     rng: onp.random.ToRNG | None = None,
     random_state: onp.random.ToRNG | None = None,
-) -> BootstrapResult[onp.ArrayND[np.float64] | np.float64, onp.Array1D[np.float64]]: ...
+) -> BootstrapResult[onp.ArrayND[np.float64] | np.float64, onp.ArrayND[np.float64]]: ...
 @overload
 def bootstrap(
-    data: Iterable[onp.ToFloatStrict1D],
+    data: Sequence[onp.ToFloatStrict1D],
     statistic: _Statistic,
     *,
     n_resamples: int = 9_999,
@@ -223,7 +223,7 @@ def bootstrap(
 ) -> BootstrapResult[np.float64, onp.Array1D[np.float64]]: ...
 @overload
 def bootstrap(
-    data: Iterable[onp.ToFloatStrict2D],
+    data: Sequence[onp.ToFloatStrict2D],
     statistic: _Statistic,
     *,
     n_resamples: int = 9_999,
@@ -240,7 +240,7 @@ def bootstrap(
 ) -> BootstrapResult[onp.Array1D[np.float64], onp.Array2D[np.float64]]: ...
 @overload
 def bootstrap(
-    data: Iterable[onp.ToFloatStrict3D],
+    data: Sequence[onp.ToFloatStrict3D],
     statistic: _Statistic,
     *,
     n_resamples: int = 9_999,
@@ -257,7 +257,7 @@ def bootstrap(
 ) -> BootstrapResult[onp.Array2D[np.float64], onp.Array3D[np.float64]]: ...
 @overload
 def bootstrap(
-    data: Iterable[onp.ToFloatND],
+    data: Sequence[onp.ToFloatND],
     statistic: _Statistic,
     *,
     n_resamples: int = 9_999,
@@ -276,7 +276,21 @@ def bootstrap(
 #
 @overload
 def permutation_test(
-    data: onp.ToFloatStrict1D,
+    data: Sequence[onp.ArrayND[npc.floating | npc.integer, _JustAnyShape]],
+    statistic: _Statistic,
+    *,
+    permutation_type: _PermutationType = "independent",
+    vectorized: bool | None = None,
+    n_resamples: int = 9_999,
+    batch: int | None = None,
+    alternative: Alternative = "two-sided",
+    axis: int = 0,
+    rng: onp.random.ToRNG | None = None,
+    random_state: onp.random.ToRNG | None = None,
+) -> PermutationTestResult[onp.ArrayND[np.float64] | np.float64, onp.ArrayND[np.float64]]: ...
+@overload
+def permutation_test(
+    data: Sequence[onp.ToFloatStrict1D],
     statistic: _Statistic,
     *,
     permutation_type: _PermutationType = "independent",
@@ -287,10 +301,10 @@ def permutation_test(
     axis: Literal[0, -1] = 0,
     rng: onp.random.ToRNG | None = None,
     random_state: onp.random.ToRNG | None = None,
-) -> PermutationTestResult[float | np.float64, onp.Array1D[np.float64]]: ...
+) -> PermutationTestResult[np.float64, onp.Array1D[np.float64]]: ...
 @overload
 def permutation_test(
-    data: onp.ToFloatStrict2D,
+    data: Sequence[onp.ToFloatStrict2D],
     statistic: _Statistic,
     *,
     permutation_type: _PermutationType = "independent",
@@ -304,7 +318,7 @@ def permutation_test(
 ) -> PermutationTestResult[onp.Array1D[np.float64], onp.Array2D[np.float64]]: ...
 @overload
 def permutation_test(
-    data: onp.ToFloatStrict3D,
+    data: Sequence[onp.ToFloatStrict3D],
     statistic: _Statistic,
     *,
     permutation_type: _PermutationType = "independent",
@@ -318,7 +332,7 @@ def permutation_test(
 ) -> PermutationTestResult[onp.Array2D[np.float64], onp.Array3D[np.float64]]: ...
 @overload
 def permutation_test(
-    data: onp.ToFloatND,
+    data: Sequence[onp.ToFloatND],
     statistic: _Statistic,
     *,
     permutation_type: _PermutationType = "independent",
@@ -329,9 +343,21 @@ def permutation_test(
     axis: int = 0,
     rng: onp.random.ToRNG | None = None,
     random_state: onp.random.ToRNG | None = None,
-) -> PermutationTestResult: ...
+) -> PermutationTestResult[onp.ArrayND[np.float64] | Any, onp.ArrayND[np.float64]]: ...
 
 #
+@overload
+def monte_carlo_test(
+    data: onp.ArrayND[npc.floating | npc.integer, _JustAnyShape],
+    rvs: _RVSCallable,
+    statistic: _Statistic,
+    *,
+    vectorized: bool | None = None,
+    n_resamples: int = 9_999,
+    batch: int | None = None,
+    alternative: Alternative = "two-sided",
+    axis: int = 0,
+) -> MonteCarloTestResult[onp.ArrayND[np.float64] | np.float64, onp.ArrayND[np.float64]]: ...
 @overload
 def monte_carlo_test(
     data: onp.ToFloatStrict1D,
@@ -343,7 +369,7 @@ def monte_carlo_test(
     batch: int | None = None,
     alternative: Alternative = "two-sided",
     axis: Literal[0, -1] = 0,
-) -> MonteCarloTestResult[float | np.float64, onp.Array1D[np.float64]]: ...
+) -> MonteCarloTestResult[np.float64, onp.Array1D[np.float64]]: ...
 @overload
 def monte_carlo_test(
     data: onp.ToFloatStrict2D,
@@ -379,4 +405,4 @@ def monte_carlo_test(
     batch: int | None = None,
     alternative: Alternative = "two-sided",
     axis: int = 0,
-) -> MonteCarloTestResult: ...
+) -> MonteCarloTestResult[onp.ArrayND[np.float64] | Any, onp.ArrayND[np.float64]]: ...

--- a/scipy-stubs/stats/_resampling.pyi
+++ b/scipy-stubs/stats/_resampling.pyi
@@ -1,6 +1,6 @@
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass
-from typing import Any, ClassVar, Generic, Literal, Protocol, TypeVar, overload, type_check_only
+from typing import Any, ClassVar, Generic, Literal, Never, Protocol, TypeVar, overload, type_check_only
 from typing_extensions import deprecated
 
 import numpy as np
@@ -14,11 +14,13 @@ __all__ = ["bootstrap", "monte_carlo_test", "permutation_test"]
 
 ###
 
-type _FloatND = float | np.float64 | onp.Array[Any, np.float64]
+type _FloatND = float | np.float64 | onp.ArrayND[np.float64]
 type _BootstrapMethod = Literal["percentile", "basic", "bca", "BCa"]
 type _PermutationType = Literal["independent", "samples", "pairings"]
 
 type _Statistic = Callable[..., onp.ToFloat] | Callable[..., onp.ToFloatND]
+
+type _JustAnyShape = tuple[Never, Never, Never, Never]
 
 _FloatNDT = TypeVar("_FloatNDT", bound=_FloatND, default=Any)
 _DistT = TypeVar("_DistT", bound=onp.ArrayND[np.float64], default=onp.ArrayND[np.float64])
@@ -36,7 +38,7 @@ class PowerResult(Generic[_FloatNDT]):
 
 @dataclass
 class BootstrapResult(Generic[_FloatNDT, _DistT]):
-    confidence_interval: ConfidenceInterval
+    confidence_interval: ConfidenceInterval[_FloatNDT]
     bootstrap_distribution: _DistT
     standard_error: _FloatNDT
 
@@ -187,7 +189,7 @@ def power(
 #
 @overload
 def bootstrap(
-    data: onp.ToFloatStrict1D,
+    data: Iterable[onp.ArrayND[npc.floating | npc.integer, _JustAnyShape]],
     statistic: _Statistic,
     *,
     n_resamples: int = 9_999,
@@ -201,10 +203,27 @@ def bootstrap(
     bootstrap_result: BootstrapResult | None = None,
     rng: onp.random.ToRNG | None = None,
     random_state: onp.random.ToRNG | None = None,
-) -> BootstrapResult[float | np.float64, onp.Array1D[np.float64]]: ...
+) -> BootstrapResult[onp.ArrayND[np.float64] | np.float64, onp.Array1D[np.float64]]: ...
 @overload
 def bootstrap(
-    data: onp.ToFloatStrict2D,
+    data: Iterable[onp.ToFloatStrict1D],
+    statistic: _Statistic,
+    *,
+    n_resamples: int = 9_999,
+    batch: int | None = None,
+    vectorized: bool | None = None,
+    paired: bool = False,
+    axis: Literal[0, -1] = 0,
+    confidence_level: float = 0.95,
+    alternative: Alternative = "two-sided",
+    method: _BootstrapMethod = "BCa",
+    bootstrap_result: BootstrapResult | None = None,
+    rng: onp.random.ToRNG | None = None,
+    random_state: onp.random.ToRNG | None = None,
+) -> BootstrapResult[np.float64, onp.Array1D[np.float64]]: ...
+@overload
+def bootstrap(
+    data: Iterable[onp.ToFloatStrict2D],
     statistic: _Statistic,
     *,
     n_resamples: int = 9_999,
@@ -221,7 +240,7 @@ def bootstrap(
 ) -> BootstrapResult[onp.Array1D[np.float64], onp.Array2D[np.float64]]: ...
 @overload
 def bootstrap(
-    data: onp.ToFloatStrict3D,
+    data: Iterable[onp.ToFloatStrict3D],
     statistic: _Statistic,
     *,
     n_resamples: int = 9_999,
@@ -238,7 +257,7 @@ def bootstrap(
 ) -> BootstrapResult[onp.Array2D[np.float64], onp.Array3D[np.float64]]: ...
 @overload
 def bootstrap(
-    data: onp.ToFloatND,
+    data: Iterable[onp.ToFloatND],
     statistic: _Statistic,
     *,
     n_resamples: int = 9_999,
@@ -252,7 +271,7 @@ def bootstrap(
     bootstrap_result: BootstrapResult | None = None,
     rng: onp.random.ToRNG | None = None,
     random_state: onp.random.ToRNG | None = None,
-) -> BootstrapResult: ...
+) -> BootstrapResult[onp.ArrayND[np.float64] | Any, onp.ArrayND[np.float64]]: ...
 
 #
 @overload

--- a/tests/stats/test_resampling.pyi
+++ b/tests/stats/test_resampling.pyi
@@ -27,36 +27,36 @@ def _statistic_nd(x: onp.ArrayND[np.float64], y: onp.ArrayND[np.float64]) -> onp
 ###
 
 # bootstrap
-assert_type(bootstrap([_py_f_1d], np.mean), BootstrapResult[np.float64, onp.Array1D[np.float64]])
-assert_type(bootstrap([_f64_1d], np.mean), BootstrapResult[np.float64, onp.Array1D[np.float64]])
-assert_type(bootstrap([_f64_2d], np.mean), BootstrapResult[onp.Array1D[np.float64], onp.Array2D[np.float64]])
-assert_type(bootstrap([_f64_3d], np.mean), BootstrapResult[onp.Array2D[np.float64], onp.Array3D[np.float64]])
+assert_type(bootstrap((_py_f_1d, _py_f_1d), np.mean), BootstrapResult[np.float64, onp.Array1D[np.float64]])
+assert_type(bootstrap((_f64_1d, _f64_1d), np.mean), BootstrapResult[np.float64, onp.Array1D[np.float64]])
+assert_type(bootstrap((_f64_2d, _f64_2d), np.mean), BootstrapResult[onp.Array1D[np.float64], onp.Array2D[np.float64]])
+assert_type(bootstrap((_f64_3d, _f64_3d), np.mean), BootstrapResult[onp.Array2D[np.float64], onp.Array3D[np.float64]])
 # pyrefly:ignore[assert-type]
-assert_type(bootstrap([_f64_nd], np.mean), BootstrapResult[onp.ArrayND[np.float64] | np.float64, onp.Array1D[np.float64]])
+assert_type(
+    bootstrap((_f64_nd, _f64_nd), np.mean), BootstrapResult[onp.ArrayND[np.float64] | np.float64, onp.ArrayND[np.float64]]
+)
 
 # permutation_test
+assert_type(permutation_test((_py_f_1d, _py_f_1d), _statistic_1d), PermutationTestResult[np.float64, onp.Array1D[np.float64]])
+assert_type(permutation_test((_f64_1d, _f64_1d), _statistic_1d), PermutationTestResult[np.float64, onp.Array1D[np.float64]])
 assert_type(
-    permutation_test((_py_f_1d, _py_f_1d), _statistic_1d), PermutationTestResult[onp.Array1D[np.float64], onp.Array2D[np.float64]]
+    permutation_test((_f64_2d, _f64_2d), _statistic_2d), PermutationTestResult[onp.Array1D[np.float64], onp.Array2D[np.float64]]
 )
 assert_type(
-    permutation_test((_f64_1d, _f64_1d), _statistic_1d), PermutationTestResult[onp.Array1D[np.float64], onp.Array2D[np.float64]]
+    permutation_test((_f64_3d, _f64_3d), _statistic_3d), PermutationTestResult[onp.Array2D[np.float64], onp.Array3D[np.float64]]
 )
+# pyrefly:ignore[assert-type]
 assert_type(
-    permutation_test((_f64_2d, _f64_2d), _statistic_2d), PermutationTestResult[onp.Array2D[np.float64], onp.Array3D[np.float64]]
-)
-assert_type(permutation_test((_f64_3d, _f64_3d), _statistic_3d), PermutationTestResult[Any, onp.ArrayND[np.float64]])
-assert_type(  # pyrefly:ignore[assert-type]
-    permutation_test((_f64_nd, _f64_nd), _statistic_nd), PermutationTestResult[onp.Array1D[np.float64], onp.Array2D[np.float64]]
+    permutation_test((_f64_nd, _f64_nd), _statistic_nd),
+    PermutationTestResult[onp.ArrayND[np.float64] | np.float64, onp.ArrayND[np.float64]],
 )
 
 # monte_carlo_test
 assert_type(
-    monte_carlo_test(_py_f_1d, np.random.standard_normal, np.mean),
-    MonteCarloTestResult[float | np.float64, onp.Array1D[np.float64]],
+    monte_carlo_test(_py_f_1d, np.random.standard_normal, np.mean), MonteCarloTestResult[np.float64, onp.Array1D[np.float64]]
 )
 assert_type(
-    monte_carlo_test(_f64_1d, np.random.standard_normal, np.mean),
-    MonteCarloTestResult[float | np.float64, onp.Array1D[np.float64]],
+    monte_carlo_test(_f64_1d, np.random.standard_normal, np.mean), MonteCarloTestResult[np.float64, onp.Array1D[np.float64]]
 )
 assert_type(
     monte_carlo_test(_f64_2d, np.random.standard_normal, np.mean),
@@ -66,9 +66,10 @@ assert_type(
     monte_carlo_test(_f64_3d, np.random.standard_normal, np.mean),
     MonteCarloTestResult[onp.Array2D[np.float64], onp.Array3D[np.float64]],
 )
-assert_type(  # pyrefly:ignore[assert-type]
+# pyrefly:ignore[assert-type]
+assert_type(
     monte_carlo_test(_f64_nd, np.random.standard_normal, np.mean),
-    MonteCarloTestResult[float | np.float64, onp.Array1D[np.float64]],
+    MonteCarloTestResult[onp.ArrayND[np.float64] | np.float64, onp.ArrayND[np.float64]],
 )
 
 # BootstrapMethod

--- a/tests/stats/test_resampling.pyi
+++ b/tests/stats/test_resampling.pyi
@@ -27,13 +27,12 @@ def _statistic_nd(x: onp.ArrayND[np.float64], y: onp.ArrayND[np.float64]) -> onp
 ###
 
 # bootstrap
-assert_type(bootstrap(_py_f_1d, np.mean), BootstrapResult[float | np.float64, onp.Array1D[np.float64]])
-assert_type(bootstrap(_f64_1d, np.mean), BootstrapResult[float | np.float64, onp.Array1D[np.float64]])
-assert_type(bootstrap(_f64_2d, np.mean), BootstrapResult[onp.Array1D[np.float64], onp.Array2D[np.float64]])
-assert_type(bootstrap(_f64_3d, np.mean), BootstrapResult[onp.Array2D[np.float64], onp.Array3D[np.float64]])
-assert_type(  # pyrefly:ignore[assert-type]
-    bootstrap(_f64_nd, np.mean), BootstrapResult[float | np.float64, onp.Array1D[np.float64]]
-)
+assert_type(bootstrap([_py_f_1d], np.mean), BootstrapResult[np.float64, onp.Array1D[np.float64]])
+assert_type(bootstrap([_f64_1d], np.mean), BootstrapResult[np.float64, onp.Array1D[np.float64]])
+assert_type(bootstrap([_f64_2d], np.mean), BootstrapResult[onp.Array1D[np.float64], onp.Array2D[np.float64]])
+assert_type(bootstrap([_f64_3d], np.mean), BootstrapResult[onp.Array2D[np.float64], onp.Array3D[np.float64]])
+# pyrefly:ignore[assert-type]
+assert_type(bootstrap([_f64_nd], np.mean), BootstrapResult[onp.ArrayND[np.float64] | np.float64, onp.Array1D[np.float64]])
 
 # permutation_test
 assert_type(


### PR DESCRIPTION
fixes #1760

This also adds the pyrefly/mypy workaround overloads for `Any`-D input shape-types, and fixes the `confidence_interval` field type of the `bootstrap` result class.
