### PR TITLE
🐛 `stats`: fix `ttest_{1samp,rel}` result `.df` dtype

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ See the `scipy` columns below for which classes are subscriptable at runtime.
 | `FitResult[F: (float, *) -> f64]`                                              | `>=1.15.0.0`  |          | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats._result_classes.FitResult.html)      |
 | `DunnettResult[T: f64 \| ld]`                                                  | `>=1.17.1.4`  | `>=1.18` | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats._result_classes.DunnettResult.html)  |
 | `PearsonRResult[T: floating scalar/array, P: f64 scalar/array]`                | `>=1.14.1.0`  |          | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats._result_classes.PearsonRResult.html) |
-| `TtestResult[T: floating scalar/array]`                                        | `>=1.14.1.0`  |          | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats._result_classes.TtestResult.html)    |
+| `TtestResult[T: floating scalar/array, D: real scalar/array = T]`              | `>=1.14.1.0`  |          | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats._result_classes.TtestResult.html)    |
 
 #### `scipy.stats.contingency`
 

--- a/scipy-stubs/stats/_stats_py.pyi
+++ b/scipy-stubs/stats/_stats_py.pyi
@@ -95,6 +95,12 @@ _FloatOrArrayT_co = TypeVar(
     default=float | onp.ArrayND[np.float64],
     covariant=True,
 )
+_IntFloatOrArrayT_co = TypeVar(
+    "_IntFloatOrArrayT_co",
+    bound=float | npc.integer | npc.floating | onp.ArrayND[npc.integer | npc.floating, Any],
+    default=_FloatOrArrayT_co,
+    covariant=True,
+)
 _SignOrArrayT_co = TypeVar(
     "_SignOrArrayT_co", bound=np.int8 | onp.ArrayND[np.int8], default=np.int8 | onp.ArrayND[np.int8], covariant=True
 )
@@ -289,9 +295,9 @@ class PearsonRResult(PearsonRResultBase[_FloatOrArrayT_co, _F64OrArrayT_co], Gen
         self, /, confidence_level: float = 0.95, method: BootstrapMethod | None = None
     ) -> ConfidenceInterval[_FloatOrArrayT_co]: ...
 
-class TtestResultBase(_TestResultBunch[_FloatOrArrayT_co, _FloatOrArrayT_co], Generic[_FloatOrArrayT_co]):
+class TtestResultBase(_TestResultBunch[_FloatOrArrayT_co, _FloatOrArrayT_co], Generic[_FloatOrArrayT_co, _IntFloatOrArrayT_co]):
     @property
-    def df(self, /) -> _FloatOrArrayT_co: ...
+    def df(self, /) -> _IntFloatOrArrayT_co: ...
 
     #
     @override
@@ -299,7 +305,7 @@ class TtestResultBase(_TestResultBunch[_FloatOrArrayT_co, _FloatOrArrayT_co], Ge
     @override
     def __init__(self, /, statistic: _FloatOrArrayT_co, pvalue: _FloatOrArrayT_co, *, df: _FloatOrArrayT_co) -> None: ...  # pyrefly:ignore[bad-override]
 
-class TtestResult(TtestResultBase[_FloatOrArrayT_co], Generic[_FloatOrArrayT_co,]):
+class TtestResult(TtestResultBase[_FloatOrArrayT_co, _IntFloatOrArrayT_co], Generic[_FloatOrArrayT_co, _IntFloatOrArrayT_co]):
     _alternative: Alternative
     _standard_error: _FloatOrArrayT_co
     _estimate: _FloatOrArrayT_co
@@ -313,7 +319,7 @@ class TtestResult(TtestResultBase[_FloatOrArrayT_co], Generic[_FloatOrArrayT_co,
         /,
         statistic: _FloatOrArrayT_co,
         pvalue: _FloatOrArrayT_co,
-        df: _FloatOrArrayT_co,
+        df: _IntFloatOrArrayT_co,
         alternative: Alternative,
         standard_error: _FloatOrArrayT_co,
         estimate: _FloatOrArrayT_co,
@@ -4054,7 +4060,7 @@ def ttest_1samp(
     alternative: Alternative = "two-sided",
     *,
     keepdims: bool = False,
-) -> TtestResult: ...
+) -> TtestResult[np.float64, np.int_] | TtestResult[onp.ArrayND[np.float64], onp.ArrayND[np.int_]]: ...
 
 # TODO(jorenham): improve
 def ttest_ind_from_stats(
@@ -4314,7 +4320,7 @@ def ttest_rel(
     alternative: Alternative = "two-sided",
     *,
     keepdims: L[False] = False,
-) -> TtestResult[np.float64 | Any]: ...
+) -> TtestResult[np.float64 | Any, np.int_ | Any]: ...
 @overload  # ?d ~T
 def ttest_rel[FloatT: np.float32 | np.float16](
     a: onp.ArrayND[FloatT, _JustAnyShape],
@@ -4324,7 +4330,7 @@ def ttest_rel[FloatT: np.float32 | np.float16](
     alternative: Alternative = "two-sided",
     *,
     keepdims: L[False] = False,
-) -> TtestResult[FloatT | Any]: ...
+) -> TtestResult[FloatT | Any, np.int_ | Any]: ...
 @overload  # 1d ~f64
 def ttest_rel(
     a: onp.ToArrayStrict1D[float, npc.floating64 | npc.integer | np.bool],
@@ -4334,7 +4340,7 @@ def ttest_rel(
     alternative: Alternative = "two-sided",
     *,
     keepdims: L[False] = False,
-) -> TtestResult[np.float64]: ...
+) -> TtestResult[np.float64, np.int_]: ...
 @overload  # 1d ~T
 def ttest_rel[FloatT: np.float32 | np.float16](
     a: onp.ToArrayStrict1D[FloatT, FloatT],
@@ -4344,7 +4350,7 @@ def ttest_rel[FloatT: np.float32 | np.float16](
     alternative: Alternative = "two-sided",
     *,
     keepdims: L[False] = False,
-) -> TtestResult[FloatT]: ...
+) -> TtestResult[FloatT, np.int_]: ...
 @overload  # 1d +floating
 def ttest_rel(
     a: onp.ToFloatStrict1D,
@@ -4354,7 +4360,7 @@ def ttest_rel(
     alternative: Alternative = "two-sided",
     *,
     keepdims: L[False] = False,
-) -> TtestResult[np.float64 | Any]: ...
+) -> TtestResult[np.float64 | Any, np.int_]: ...
 @overload  # 2d ~f64
 def ttest_rel(
     a: onp.ToArrayStrict2D[float, npc.floating64 | npc.integer | np.bool],
@@ -4364,7 +4370,7 @@ def ttest_rel(
     alternative: Alternative = "two-sided",
     *,
     keepdims: L[False] = False,
-) -> TtestResult[onp.Array1D[np.float64]]: ...
+) -> TtestResult[onp.Array1D[np.float64], onp.Array1D[np.int_]]: ...
 @overload  # 2d ~T
 def ttest_rel[FloatT: np.float32 | np.float16](
     a: onp.ToArrayStrict2D[FloatT, FloatT],
@@ -4374,7 +4380,7 @@ def ttest_rel[FloatT: np.float32 | np.float16](
     alternative: Alternative = "two-sided",
     *,
     keepdims: L[False] = False,
-) -> TtestResult[onp.Array1D[FloatT]]: ...
+) -> TtestResult[onp.Array1D[FloatT], onp.Array1D[np.int_]]: ...
 @overload  # 2d +floating
 def ttest_rel(
     a: onp.ToFloatStrict2D,
@@ -4384,7 +4390,7 @@ def ttest_rel(
     alternative: Alternative = "two-sided",
     *,
     keepdims: L[False] = False,
-) -> TtestResult[onp.Array1D[np.float64 | Any]]: ...
+) -> TtestResult[onp.Array1D[np.float64 | Any], onp.Array1D[np.int_]]: ...
 @overload  # 3d ~f64
 def ttest_rel(
     a: onp.ToArrayStrict3D[float, npc.floating64 | npc.integer | np.bool],
@@ -4394,7 +4400,7 @@ def ttest_rel(
     alternative: Alternative = "two-sided",
     *,
     keepdims: L[False] = False,
-) -> TtestResult[onp.Array2D[np.float64]]: ...
+) -> TtestResult[onp.Array2D[np.float64], onp.Array2D[np.int_]]: ...
 @overload  # 3d ~T
 def ttest_rel[FloatT: np.float32 | np.float16](
     a: onp.ToArrayStrict3D[FloatT, FloatT],
@@ -4404,7 +4410,7 @@ def ttest_rel[FloatT: np.float32 | np.float16](
     alternative: Alternative = "two-sided",
     *,
     keepdims: L[False] = False,
-) -> TtestResult[onp.Array2D[FloatT]]: ...
+) -> TtestResult[onp.Array2D[FloatT], onp.Array1D[np.int_]]: ...
 @overload  # 3d +floating
 def ttest_rel(
     a: onp.ToFloatStrict3D,
@@ -4414,7 +4420,7 @@ def ttest_rel(
     alternative: Alternative = "two-sided",
     *,
     keepdims: L[False] = False,
-) -> TtestResult[onp.Array2D[np.float64 | Any]]: ...
+) -> TtestResult[onp.Array2D[np.float64 | Any], onp.Array2D[np.int_]]: ...
 @overload  # nd ~f64, axis=None
 def ttest_rel(  # type: ignore[overload-overlap]
     a: onp.ToArrayND[float, npc.floating64 | npc.integer | np.bool],
@@ -4424,7 +4430,7 @@ def ttest_rel(  # type: ignore[overload-overlap]
     alternative: Alternative = "two-sided",
     *,
     keepdims: L[False] = False,
-) -> TtestResult[np.float64]: ...
+) -> TtestResult[np.float64, np.int_]: ...
 @overload  # nd ~f64, keepdims=True
 def ttest_rel(  # type: ignore[overload-overlap]
     a: onp.ToArrayND[float, npc.floating64 | npc.integer | np.bool],
@@ -4434,7 +4440,7 @@ def ttest_rel(  # type: ignore[overload-overlap]
     alternative: Alternative = "two-sided",
     *,
     keepdims: L[True],
-) -> TtestResult[onp.ArrayND[np.float64]]: ...
+) -> TtestResult[onp.ArrayND[np.float64], onp.ArrayND[np.int_]]: ...
 @overload  # nd ~T, axis=None
 def ttest_rel[FloatT: np.float32 | np.float16](
     a: onp.ToArrayND[FloatT, FloatT],
@@ -4444,7 +4450,7 @@ def ttest_rel[FloatT: np.float32 | np.float16](
     alternative: Alternative = "two-sided",
     *,
     keepdims: L[False] = False,
-) -> TtestResult[FloatT]: ...
+) -> TtestResult[FloatT, np.int_]: ...
 @overload  # nd ~T, keepdims=True
 def ttest_rel[FloatT: np.float32 | np.float16](
     a: onp.ToArrayND[FloatT, FloatT],
@@ -4454,7 +4460,7 @@ def ttest_rel[FloatT: np.float32 | np.float16](
     alternative: Alternative = "two-sided",
     *,
     keepdims: L[True],
-) -> TtestResult[onp.ArrayND[FloatT]]: ...
+) -> TtestResult[onp.ArrayND[FloatT], onp.ArrayND[np.int_]]: ...
 @overload  # nd +floating, axis=None
 def ttest_rel(
     a: onp.ToFloatND,
@@ -4464,7 +4470,7 @@ def ttest_rel(
     alternative: Alternative = "two-sided",
     *,
     keepdims: L[False] = False,
-) -> TtestResult[np.float64 | Any]: ...
+) -> TtestResult[np.float64 | Any, np.int64]: ...
 @overload  # nd +floating, keepdims=True
 def ttest_rel(
     a: onp.ToFloatND,
@@ -4474,7 +4480,7 @@ def ttest_rel(
     alternative: Alternative = "two-sided",
     *,
     keepdims: L[True],
-) -> TtestResult[onp.ArrayND[np.float64 | Any]]: ...
+) -> TtestResult[onp.ArrayND[np.float64 | Any], onp.ArrayND[np.int_]]: ...
 @overload  # nd +floating
 def ttest_rel(
     a: onp.ToFloatND,
@@ -4484,7 +4490,7 @@ def ttest_rel(
     alternative: Alternative = "two-sided",
     *,
     keepdims: L[False] = False,
-) -> TtestResult[onp.ArrayND[np.float64 | Any] | np.float64 | Any]: ...
+) -> TtestResult[onp.ArrayND[np.float64 | Any], onp.ArrayND[np.int_]] | TtestResult[np.float64 | Any, np.int_]: ...
 
 #
 @overload

--- a/tests/stats/test__stats_py.pyi
+++ b/tests/stats/test__stats_py.pyi
@@ -1044,7 +1044,9 @@ assert_type(weightedtau(_f64_nd, _f64_nd, keepdims=True), SignificanceResult[onp
 
 # ttest_1samp
 
-assert_type(ttest_1samp(_f64_1d, 0.0), TtestResult)
+assert_type(
+    ttest_1samp(_f64_1d, 0.0), TtestResult[np.float64, np.int_] | TtestResult[onp.ArrayND[np.float64], onp.ArrayND[np.int_]]
+)
 
 # ttest_ind_from_stats
 

--- a/tests/stats/test_ttest.pyi
+++ b/tests/stats/test_ttest.pyi
@@ -62,7 +62,6 @@ assert_type(ttest_ind(_f16_3d, _f16_3d).statistic, onp.Array2D[np.float16])
 assert_type(ttest_ind(_f32_3d, _f32_3d).statistic, onp.Array2D[np.float32])
 assert_type(ttest_ind(_f64_3d, _f64_3d).statistic, onp.Array2D[np.float64])
 
-# NOTE: Pyrefly doesn't seem to be able to intersect the return types in case of multiple matching overloads.
 assert_type(ttest_ind(_i8_nd, _i8_nd).statistic, np.float64 | Any)
 assert_type(ttest_ind(_f16_nd, _f16_nd).statistic, np.float16 | Any)
 assert_type(ttest_ind(_f32_nd, _f32_nd).statistic, np.float32 | Any)
@@ -91,8 +90,8 @@ assert_type(ttest_rel(_f16_3d, _f16_3d).statistic, onp.Array2D[np.float16])
 assert_type(ttest_rel(_f32_3d, _f32_3d).statistic, onp.Array2D[np.float32])
 assert_type(ttest_rel(_f64_3d, _f64_3d).statistic, onp.Array2D[np.float64])
 
-# NOTE: Pyrefly doesn't seem to be able to intersect the return types in case of multiple matching overloads.
-assert_type(ttest_rel(_i8_nd, _i8_nd).statistic, np.float64 | Any)
-assert_type(ttest_rel(_f16_nd, _f16_nd).statistic, np.float16 | Any)
-assert_type(ttest_rel(_f32_nd, _f32_nd).statistic, np.float32 | Any)
-assert_type(ttest_rel(_f64_nd, _f64_nd).statistic, np.float64 | Any)
+assert_type(ttest_rel(_i8_nd, _i8_nd).df, np.int_ | Any)
+assert_type(ttest_rel(_py_i_1d, _py_i_1d).df, np.int_)
+assert_type(ttest_rel(_py_i_2d, _py_i_2d).df, onp.Array1D[np.int_])
+assert_type(ttest_rel(_py_i_3d, _py_i_3d).df, onp.Array2D[np.int_])
+assert_type(ttest_rel(_i8_nd, _i8_nd).df, np.int_ | Any)


### PR DESCRIPTION
fixes #1778

This required adding an additional type param to `stats.TtestResult` that defaults to the first one but also accepts integer scalars or arrays.