### PR TITLE
🐛 `special.lqmn`: scalar `z` should return 2d arrays

### DIFF
--- a/scipy-stubs/special/_basic.pyi
+++ b/scipy-stubs/special/_basic.pyi
@@ -98,8 +98,10 @@ type _c = _c4 | _c8
 type _fc = _f | _c
 
 type _f8_1d = onp.Array1D[_f8]
+type _f8_2d = onp.Array2D[_f8]
 type _f8_nd = onp.ArrayND[_f8]
 type _c8_1d = onp.Array1D[_c8]
+type _c8_2d = onp.Array2D[_c8]
 type _c8_nd = onp.ArrayND[_c8]
 type _fc8_nd = onp.ArrayND[_fc8]
 
@@ -308,11 +310,11 @@ def lqn(n: onp.ToInt, z: _ToComplexOrND) -> _tuple2[_f8_nd] | _tuple2[_c8_nd]: .
 
 #
 @overload
-def lqmn(m: onp.ToFloat, n: onp.ToFloat, z: onp.ToFloat) -> _tuple2[_f8_1d]: ...
+def lqmn(m: onp.ToFloat, n: onp.ToFloat, z: onp.ToFloat) -> _tuple2[_f8_2d]: ...
 @overload
 def lqmn(m: onp.ToFloat, n: onp.ToFloat, z: _ToFloatOrND) -> _tuple2[_f8_nd]: ...
 @overload
-def lqmn(m: onp.ToFloat, n: onp.ToFloat, z: onp.ToJustComplex) -> _tuple2[_c8_1d]: ...
+def lqmn(m: onp.ToFloat, n: onp.ToFloat, z: onp.ToJustComplex) -> _tuple2[_c8_2d]: ...
 @overload
 def lqmn(m: onp.ToFloat, n: onp.ToFloat, z: _ToJustComplexOrND) -> _tuple2[_c8_nd]: ...
 @overload

--- a/tests/special/test_basic.pyi
+++ b/tests/special/test_basic.pyi
@@ -205,9 +205,9 @@ assert_type(lqn(2, 1j), tuple[onp.Array1D[np.complex128], onp.Array1D[np.complex
 assert_type(lqn(2, c_arr), tuple[onp.ArrayND[np.complex128], onp.ArrayND[np.complex128]])
 
 # lqmn
-assert_type(lqmn(1, 2, 1.0), tuple[onp.Array1D[np.float64], onp.Array1D[np.float64]])
+assert_type(lqmn(1, 2, 1.0), tuple[onp.Array2D[np.float64], onp.Array2D[np.float64]])
 assert_type(lqmn(1, 2, f_arr), tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64]])
-assert_type(lqmn(1, 2, 1j), tuple[onp.Array1D[np.complex128], onp.Array1D[np.complex128]])
+assert_type(lqmn(1, 2, 1j), tuple[onp.Array2D[np.complex128], onp.Array2D[np.complex128]])
 assert_type(lqmn(1, 2, c_arr), tuple[onp.ArrayND[np.complex128], onp.ArrayND[np.complex128]])
 
 # bernoulli


### PR DESCRIPTION
```
In [1]: from scipy.special import lqmn

In [2]: lqmn(1, 1, .5)
Out[2]: 
(array([[ 0.54930614, -0.72534693],
        [-1.15470054, -1.05306334]]),
 array([[ 1.33333333,  1.21597281],
        [-0.76980036, -2.37715921]]))
```

fixes #1826