### PR TITLE
🐛 `signal.detrend`: fix output dtypes for `float16` and `complex64` input

### DIFF
--- a/scipy-stubs/signal/_signaltools.pyi
+++ b/scipy-stubs/signal/_signaltools.pyi
@@ -1045,22 +1045,14 @@ def hilbert2(
 ###
 
 #
-@overload  # f64
+@overload  # +f64
 def detrend(
-    data: onp.ToIntND | onp.ToJustFloat64_ND,
+    data: onp.ToIntND | onp.ToJustFloat64_ND | onp.ToJustFloat16_ND,
     axis: int = -1,
     type: _TrendType = "linear",
     bp: int | onp.ToJustIntND = 0,
     overwrite_data: bool = False,
 ) -> onp.ArrayND[np.float64]: ...
-@overload  # f16
-def detrend(
-    data: onp.ToJustFloat16_ND,
-    axis: int = -1,
-    type: _TrendType = "linear",
-    bp: int | onp.ToJustIntND = 0,
-    overwrite_data: bool = False,
-) -> onp.ArrayND[np.float16]: ...
 @overload  # f32
 def detrend(
     data: onp.ToJustFloat32_ND,
@@ -1076,7 +1068,7 @@ def detrend(
     type: _TrendType = "linear",
     bp: int | onp.ToJustIntND = 0,
     overwrite_data: bool = False,
-) -> onp.ArrayND[np.complex128]: ...
+) -> onp.ArrayND[np.complex64]: ...
 @overload  # c128
 def detrend(
     data: onp.ToJustComplex128_ND,

--- a/tests/signal/test_signaltools.pyi
+++ b/tests/signal/test_signaltools.pyi
@@ -360,9 +360,9 @@ assert_type(hilbert2(_f80_2d), onp.Array2D[npc.complexfloating160])
 
 assert_type(detrend(_py_i_1d), onp.ArrayND[np.float64])
 assert_type(detrend(_f64_1d), onp.ArrayND[np.float64])
-assert_type(detrend(_f16_1d), onp.ArrayND[np.float16])
+assert_type(detrend(_f16_1d), onp.ArrayND[np.float64])
 assert_type(detrend(_f32_1d), onp.ArrayND[np.float32])
-assert_type(detrend(_c64_1d), onp.ArrayND[np.complex128])
+assert_type(detrend(_c64_1d), onp.ArrayND[np.complex64])
 assert_type(detrend(_c128_1d), onp.ArrayND[np.complex128])
 
 # unique_roots


### PR DESCRIPTION
fixes #1816