### PR TITLE
🐛 `linalg.pinv`: fix returned rank type (`int` -> `np.int_`)

### DIFF
--- a/scipy-stubs/linalg/_basic.pyi
+++ b/scipy-stubs/linalg/_basic.pyi
@@ -1340,7 +1340,7 @@ def pinv(
     rtol: onp.ToFloat | None = None,
     return_rank: Literal[True],
     check_finite: bool = True,
-) -> tuple[_FloatND, int]: ...
+) -> tuple[_FloatND, np.int_]: ...
 @overload  # (complex[:, :], return_rank=False) -> complex[:, :]
 def pinv(
     a: onp.ToComplexND,
@@ -1358,7 +1358,7 @@ def pinv(
     rtol: onp.ToFloat | None = None,
     return_rank: Literal[True],
     check_finite: bool = True,
-) -> tuple[_InexactND, int]: ...
+) -> tuple[_InexactND, np.int_]: ...
 
 # TODO(jorenham): improve this
 @overload  # (float[:, :], return_rank=False) -> float[:, :]

--- a/tests/linalg/test__basic.pyi
+++ b/tests/linalg/test__basic.pyi
@@ -494,9 +494,9 @@ assert_type(solveh_banded(py_c_3d, py_c_1d), onp.ArrayND[np.complex128])
 # pinv
 
 assert_type(pinv(f64_nd), onp.ArrayND[npc.floating])
-assert_type(pinv(f64_nd, return_rank=True), tuple[onp.ArrayND[npc.floating], int])
+assert_type(pinv(f64_nd, return_rank=True), tuple[onp.ArrayND[npc.floating], np.int_])
 assert_type(pinv(c128_nd), onp.ArrayND[npc.inexact])
-assert_type(pinv(c128_nd, return_rank=True), tuple[onp.ArrayND[npc.inexact], int])
+assert_type(pinv(c128_nd, return_rank=True), tuple[onp.ArrayND[npc.inexact], np.int_])
 
 ###
 # pinvh


### PR DESCRIPTION
closes #1856