### PR TITLE
🐛 `sparse.csgraph.shortest_path`: fix return shape-type

### DIFF
--- a/scipy-stubs/sparse/csgraph/_shortest_path.pyi
+++ b/scipy-stubs/sparse/csgraph/_shortest_path.pyi
@@ -33,7 +33,18 @@ def shortest_path(
     return_predecessors: onp.ToFalse = False,
     unweighted: bool = False,
     overwrite: bool = False,
-    indices: onp.ToInt | onp.ToIntND | None = None,
+    *,
+    indices: onp.ToInt,
+) -> _Float1D: ...
+@overload
+def shortest_path(
+    csgraph: _ToGraphArray,
+    method: _ShortestPathMethod = "auto",
+    directed: bool = True,
+    return_predecessors: onp.ToFalse = False,
+    unweighted: bool = False,
+    overwrite: bool = False,
+    indices: onp.ToIntND | None = None,
 ) -> _Float2D: ...
 @overload
 def shortest_path(
@@ -43,7 +54,18 @@ def shortest_path(
     return_predecessors: onp.ToTrue,
     unweighted: bool = False,
     overwrite: bool = False,
-    indices: onp.ToInt | onp.ToIntND | None = None,
+    *,
+    indices: onp.ToInt,
+) -> tuple[_Float1D, _Int1D]: ...
+@overload
+def shortest_path(
+    csgraph: _ToGraphArray,
+    method: _ShortestPathMethod,
+    directed: bool,
+    return_predecessors: onp.ToTrue,
+    unweighted: bool = False,
+    overwrite: bool = False,
+    indices: onp.ToIntND | None = None,
 ) -> tuple[_Float2D, _Int2D]: ...
 @overload
 def shortest_path(
@@ -54,7 +76,18 @@ def shortest_path(
     return_predecessors: onp.ToTrue,
     unweighted: bool = False,
     overwrite: bool = False,
-    indices: onp.ToInt | onp.ToIntND | None = None,
+    indices: onp.ToInt,
+) -> tuple[_Float1D, _Int1D]: ...
+@overload
+def shortest_path(
+    csgraph: _ToGraphArray,
+    method: _ShortestPathMethod = "auto",
+    directed: bool = True,
+    *,
+    return_predecessors: onp.ToTrue,
+    unweighted: bool = False,
+    overwrite: bool = False,
+    indices: onp.ToIntND | None = None,
 ) -> tuple[_Float2D, _Int2D]: ...
 
 #

--- a/tests/sparse/csgraph/test_shortest_path.pyi
+++ b/tests/sparse/csgraph/test_shortest_path.pyi
@@ -28,6 +28,10 @@ assert_type(minimum_spanning_tree(_csr_arr), sparse.csr_array[_ScalarType, tuple
 
 assert_type(shortest_path(_csr_arr), onp.Array2D[np.float64])
 assert_type(shortest_path(_csr_arr, return_predecessors=True), tuple[onp.Array2D[np.float64], onp.Array2D[np.int32]])
+assert_type(shortest_path(_csr_arr, indices=0), onp.Array1D[np.float64])
+assert_type(shortest_path(_csr_arr, indices=[0]), onp.Array2D[np.float64])
+assert_type(shortest_path(_csr_arr, return_predecessors=True, indices=0), tuple[onp.Array1D[np.float64], onp.Array1D[np.int32]])
+assert_type(shortest_path(_csr_arr, return_predecessors=True, indices=[0]), tuple[onp.Array2D[np.float64], onp.Array2D[np.int32]])
 
 # floyd_warshall
 


### PR DESCRIPTION
fixes #1815