### PR TITLE
🚨 fix `ty` and `zuban` errors in `scripts/`

### DIFF
--- a/scripts/scipy_usage.py
+++ b/scripts/scipy_usage.py
@@ -373,7 +373,7 @@ class ScipyVisitor(ast.NodeVisitor):
             (call_name := self._get_call_name(node.func))
             and (scipy_call := self._resolve_scipy_call(call_name))
         ):  # fmt: skip
-            self.calls.add(scipy_call)  # ty:ignore[possibly-unresolved-reference]  # false positive
+            self.calls.add(scipy_call)
 
         self.generic_visit(node)
 

--- a/scripts/unstubbed_modules.py
+++ b/scripts/unstubbed_modules.py
@@ -57,7 +57,7 @@ def _check_stubs_path() -> None:
 def _path_to_module(parts: tuple[str, ...]) -> str | None:
     name_parts: Sequence[str] = []
     if parts and parts[0] == "scipy" and "tests" not in parts:
-        *parent, leaf = parts
+        *parent, leaf = parts  # zuban:ignore[misc]
         if leaf in _INIT_LEAVES:
             name_parts = parent
         elif leaf != "conftest.py" and leaf.endswith(_MODULE_SUFFIXES):


### PR DESCRIPTION
this was breaking `uvx tox p`