### PR TITLE
🐛 `signal.place_poles`: fix return dtypes

### DIFF
--- a/scipy-stubs/signal/_ltisys.pyi
+++ b/scipy-stubs/signal/_ltisys.pyi
@@ -33,6 +33,7 @@ __all__ = [
 _ZerosT_co = TypeVar("_ZerosT_co", bound=npc.inexact32 | npc.inexact64, default=Any, covariant=True)
 _PolesT_co = TypeVar("_PolesT_co", bound=_Float, default=np.float64 | Any, covariant=True)
 _DTT_co = TypeVar("_DTT_co", bound=onp.ToComplex | None, default=Any, covariant=True)
+_RequestedPolesT_co = TypeVar("_RequestedPolesT_co", bound=npc.inexact64, default=np.float64 | np.complex128, covariant=True)
 
 type _Tuple3[T] = tuple[T, T, T]
 type _Tuple4[T] = tuple[T, T, T, T]
@@ -755,17 +756,54 @@ class StateSpaceDiscrete(
 
 # NOTE: Only used as return type of `place_poles`.
 @final
-class Bunch:
+class Bunch(Generic[_RequestedPolesT_co]):
     gain_matrix: _Float64_2D
-    computed_poles: _Float64_1D
-    requested_poles: _Float64_1D
-    X: onp.Array2D[np.complex128]
+    computed_poles: onp.Array1D[np.complex128]
+    requested_poles: onp.Array1D[_RequestedPolesT_co]
+    X: onp.Array2D[np.float64 | np.complex128]  # float64 iff `B` is square and full-rank
     rtol: float
-    nb_iter: int
+    nb_iter: float  # `nan` if `B` is square and full-rank, `int` otherwise
 
     def __init__(self, /) -> None: ...
 
 #
+@overload  # +f64
+def place_poles(
+    A: onp.ToFloat2D,
+    B: onp.ToFloat2D,
+    poles: onp.ToFloat64_1D,
+    method: Literal["YT", "KNV0"] = "YT",
+    rtol: float = 0.001,
+    maxiter: int = 30,
+) -> Bunch[np.float64]: ...
+@overload  # +floating
+def place_poles(
+    A: onp.ToFloat2D,
+    B: onp.ToFloat2D,
+    poles: onp.ToFloat1D,
+    method: Literal["YT", "KNV0"] = "YT",
+    rtol: float = 0.001,
+    maxiter: int = 30,
+) -> Bunch[np.float64 | Any]: ...
+@overload  # ~c128
+def place_poles(
+    A: onp.ToFloat2D,
+    B: onp.ToFloat2D,
+    poles: onp.ToJustComplex128_1D,
+    method: Literal["YT", "KNV0"] = "YT",
+    rtol: float = 0.001,
+    maxiter: int = 30,
+) -> Bunch[np.complex128]: ...
+@overload  # ~complexfloating
+def place_poles(
+    A: onp.ToFloat2D,
+    B: onp.ToFloat2D,
+    poles: onp.ToJustComplex1D,
+    method: Literal["YT", "KNV0"] = "YT",
+    rtol: float = 0.001,
+    maxiter: int = 30,
+) -> Bunch[np.complex128 | Any]: ...
+@overload  # +complexfloating
 def place_poles(
     A: onp.ToFloat2D,
     B: onp.ToFloat2D,
@@ -773,7 +811,7 @@ def place_poles(
     method: Literal["YT", "KNV0"] = "YT",
     rtol: float = 0.001,
     maxiter: int = 30,
-) -> Bunch: ...
+) -> Bunch[Any]: ...
 
 #
 

--- a/tests/signal/test_ltisys.pyi
+++ b/tests/signal/test_ltisys.pyi
@@ -4,6 +4,7 @@ from typing import Any, assert_type
 
 import numpy as np
 import optype.numpy as onp
+from optype.test import assert_subtype
 
 from scipy.signal import (
     StateSpace,
@@ -56,6 +57,7 @@ _c64_2d: onp.Array2D[np.complex64]
 _c128_1d: _VecC128
 _c128_2d: onp.Array2D[np.complex128]
 _i64_1d: onp.Array1D[np.int64]
+_f80_1d: onp.Array1D[np.longdouble]
 
 _lti_f32: lti[np.float32, np.float32]
 _lti_f64: lti[np.float64, np.float64]
@@ -294,14 +296,22 @@ assert_type(_lti_c128.freqresp(), tuple[_VecF64, _VecC128])
 ###
 # place_poles
 
-place_poles_result = place_poles(_f64_2d, _f64_2d, _i64_1d)
-assert_type(place_poles_result, Bunch)
+place_poles_result = place_poles(_f64_2d, _f64_2d, _f64_1d)
+assert_type(place_poles_result, Bunch[np.float64])
 assert_type(place_poles_result.gain_matrix, _MatF64)
-assert_type(place_poles_result.computed_poles, _VecF64)
+assert_type(place_poles_result.computed_poles, _VecC128)
 assert_type(place_poles_result.requested_poles, _VecF64)
-assert_type(place_poles_result.X, onp.Array2D[np.complex128])
+assert_type(place_poles_result.X, onp.Array2D[np.float64 | np.complex128])
 assert_type(place_poles_result.rtol, float)
-assert_type(place_poles_result.nb_iter, int)
+assert_type(place_poles_result.nb_iter, float)
+
+assert_type(place_poles(_f64_2d, _f64_2d, _i64_1d), Bunch[np.float64])
+assert_type(place_poles(_f64_2d, _f64_2d, _f32_1d), Bunch[np.float64])
+# on `numpy<2.2` this selects the `+f64` overload instead, returning `Bunch[np.float64]`
+assert_subtype[Bunch[np.float64 | Any]](place_poles(_f64_2d, _f64_2d, _f80_1d))
+assert_type(place_poles(_f64_2d, _f64_2d, _c128_1d), Bunch[np.complex128])
+assert_type(place_poles(_f64_2d, _f64_2d, _c128_1d).requested_poles, _VecC128)
+assert_type(place_poles(_f64_2d, _f64_2d, _c64_1d), Bunch[np.complex128 | Any])
 
 ###
 # dlsim


### PR DESCRIPTION
fixes #1821