### PR TITLE
🐛 `signal`: fix `lsim`/`step`/`impulse` shape-type

### DIFF
--- a/scipy-stubs/signal/_ltisys.pyi
+++ b/scipy-stubs/signal/_ltisys.pyi
@@ -149,7 +149,7 @@ class lti(LinearTimeInvariant[_ZerosT_co, _PolesT_co, None], Generic[_ZerosT_co,
         X0: onp.ToFloat1D | None = None,
         T: onp.ToFloat1D | None = None,
         N: int | None = None,
-    ) -> tuple[onp.Array1D[np.float64], onp.Array1D[np.float64]]: ...
+    ) -> tuple[onp.Array1D[np.float64], onp.ArrayND[np.float64]]: ...
     @overload
     def impulse(
         self: lti[np.complex64 | np.complex128],
@@ -157,7 +157,7 @@ class lti(LinearTimeInvariant[_ZerosT_co, _PolesT_co, None], Generic[_ZerosT_co,
         X0: onp.ToComplex1D | None = None,
         T: onp.ToFloat1D | None = None,
         N: int | None = None,
-    ) -> tuple[onp.Array1D[np.float64], onp.Array1D[np.complex128]]: ...
+    ) -> tuple[onp.Array1D[np.float64], onp.ArrayND[np.complex128]]: ...
 
     #
     @overload
@@ -167,7 +167,7 @@ class lti(LinearTimeInvariant[_ZerosT_co, _PolesT_co, None], Generic[_ZerosT_co,
         X0: onp.ToFloat1D | None = None,
         T: onp.ToFloat1D | None = None,
         N: int | None = None,
-    ) -> tuple[onp.Array1D[np.float64], onp.Array1D[np.float64]]: ...
+    ) -> tuple[onp.Array1D[np.float64], onp.ArrayND[np.float64]]: ...
     @overload
     def step(
         self: lti[np.complex64 | np.complex128],
@@ -175,7 +175,7 @@ class lti(LinearTimeInvariant[_ZerosT_co, _PolesT_co, None], Generic[_ZerosT_co,
         X0: onp.ToComplex1D | None = None,
         T: onp.ToFloat1D | None = None,
         N: int | None = None,
-    ) -> tuple[onp.Array1D[np.float64], onp.Array1D[np.complex128]]: ...
+    ) -> tuple[onp.Array1D[np.float64], onp.ArrayND[np.complex128]]: ...
 
     #
     @overload
@@ -185,7 +185,7 @@ class lti(LinearTimeInvariant[_ZerosT_co, _PolesT_co, None], Generic[_ZerosT_co,
         U: _ToFloat012D | None,
         T: onp.ToFloat | onp.ToFloat1D,
         X0: onp.ToComplex1D | None = None,
-    ) -> tuple[onp.Array1D[np.float64], onp.Array1D[np.float64], onp.ArrayND[np.float64]]: ...
+    ) -> tuple[onp.Array1D[np.float64], onp.ArrayND[np.float64], onp.ArrayND[np.float64]]: ...
     @overload
     def output(
         self: lti[np.complex64 | np.complex128],
@@ -193,7 +193,7 @@ class lti(LinearTimeInvariant[_ZerosT_co, _PolesT_co, None], Generic[_ZerosT_co,
         U: _ToFloat012D | None,
         T: onp.ToFloat | onp.ToFloat1D,
         X0: onp.ToComplex1D | None = None,
-    ) -> tuple[onp.Array1D[np.float64], onp.Array1D[np.complex128], onp.ArrayND[np.complex128]]: ...
+    ) -> tuple[onp.Array1D[np.float64], onp.ArrayND[np.complex128], onp.ArrayND[np.complex128]]: ...
 
     #
     @overload
@@ -823,7 +823,7 @@ def lsim(
     T: onp.ToFloat1D,
     X0: onp.ToFloat1D | None = None,
     interp: bool = True,
-) -> tuple[onp.Array1D[np.float64], onp.Array1D[np.float64], onp.ArrayND[np.float64]]: ...
+) -> tuple[onp.Array1D[np.float64], onp.ArrayND[np.float64], onp.ArrayND[np.float64]]: ...
 @overload
 def lsim(
     system: lti[np.complex64 | np.complex128],
@@ -831,11 +831,11 @@ def lsim(
     T: onp.ToFloat1D,
     X0: onp.ToComplex1D | None = None,
     interp: bool = True,
-) -> tuple[onp.Array1D[np.float64], onp.Array1D[np.complex128], onp.ArrayND[np.complex128]]: ...
+) -> tuple[onp.Array1D[np.float64], onp.ArrayND[np.complex128], onp.ArrayND[np.complex128]]: ...
 @overload
 def lsim(
     system: _ToLTIInexact, U: _ToFloat012D | None, T: onp.ToFloat1D, X0: onp.ToComplex1D | None = None, interp: bool = True
-) -> tuple[onp.Array1D[np.float64], onp.Array1D[np.complex128 | Any], onp.ArrayND[np.complex128 | Any]]: ...
+) -> tuple[onp.Array1D[np.float64], onp.ArrayND[np.complex128 | Any], onp.ArrayND[np.complex128 | Any]]: ...
 
 # keep in sync with lsim and step
 @overload
@@ -844,18 +844,18 @@ def impulse(
     X0: onp.ToFloat1D | None = None,
     T: onp.ToFloat1D | None = None,
     N: int | None = None,
-) -> tuple[onp.Array1D[np.float64], onp.Array1D[np.float64]]: ...
+) -> tuple[onp.Array1D[np.float64], onp.ArrayND[np.float64]]: ...
 @overload
 def impulse(
     system: lti[np.complex64 | np.complex128],
     X0: onp.ToComplex1D | None = None,
     T: onp.ToFloat1D | None = None,
     N: int | None = None,
-) -> tuple[onp.Array1D[np.float64], onp.Array1D[np.complex128]]: ...
+) -> tuple[onp.Array1D[np.float64], onp.ArrayND[np.complex128]]: ...
 @overload
 def impulse(
     system: _ToLTIInexact, X0: onp.ToComplex1D | None = None, T: onp.ToFloat1D | None = None, N: int | None = None
-) -> tuple[onp.Array1D[np.float64], onp.Array1D[np.complex128 | Any]]: ...
+) -> tuple[onp.Array1D[np.float64], onp.ArrayND[np.complex128 | Any]]: ...
 
 # keep in sync with lsim and impulse
 @overload
@@ -864,18 +864,18 @@ def step(
     X0: onp.ToFloat1D | None = None,
     T: onp.ToFloat1D | None = None,
     N: int | None = None,
-) -> tuple[onp.Array1D[np.float64], onp.Array1D[np.float64]]: ...
+) -> tuple[onp.Array1D[np.float64], onp.ArrayND[np.float64]]: ...
 @overload
 def step(
     system: lti[np.complex64 | np.complex128],
     X0: onp.ToComplex1D | None = None,
     T: onp.ToFloat1D | None = None,
     N: int | None = None,
-) -> tuple[onp.Array1D[np.float64], onp.Array1D[np.complex128]]: ...
+) -> tuple[onp.Array1D[np.float64], onp.ArrayND[np.complex128]]: ...
 @overload
 def step(
     system: _ToLTIInexact, X0: onp.ToComplex1D | None = None, T: onp.ToFloat1D | None = None, N: int | None = None
-) -> tuple[onp.Array1D[np.float64], onp.Array1D[np.complex128 | Any]]: ...
+) -> tuple[onp.Array1D[np.float64], onp.ArrayND[np.complex128 | Any]]: ...
 
 #
 @overload

--- a/tests/signal/test_ltisys.pyi
+++ b/tests/signal/test_ltisys.pyi
@@ -43,7 +43,6 @@ type _ArrF64 = onp.ArrayND[np.float64]
 type _VecC64 = onp.Array1D[np.complex64]
 type _VecC128 = onp.Array1D[np.complex128]
 type _ArrC128 = onp.ArrayND[np.complex128]
-type _VecC128ish = onp.Array1D[np.complex128 | Any]
 type _ArrC128ish = onp.ArrayND[np.complex128 | Any]
 
 ###
@@ -145,91 +144,91 @@ assert_type(StateSpace(_c128_2d, _c128_2d, _c128_2d, _c128_2d, dt=0.1), StateSpa
 # lsim (same as impulse and step)
 
 # f32
-assert_type(lsim(_lti_f32, None, _f64_1d), tuple[_VecF64, _VecF64, _ArrF64])
-assert_type(lsim(_to_tf_cont_f32, None, _f64_1d), tuple[_VecF64, _VecF64, _ArrF64])
-assert_type(lsim(_to_zpk_cont_f32, None, _f64_1d), tuple[_VecF64, _VecF64, _ArrF64])
-assert_type(lsim(_to_ss_cont_f32, None, _f64_1d), tuple[_VecF64, _VecF64, _ArrF64])
+assert_type(lsim(_lti_f32, None, _f64_1d), tuple[_VecF64, _ArrF64, _ArrF64])
+assert_type(lsim(_to_tf_cont_f32, None, _f64_1d), tuple[_VecF64, _ArrF64, _ArrF64])
+assert_type(lsim(_to_zpk_cont_f32, None, _f64_1d), tuple[_VecF64, _ArrF64, _ArrF64])
+assert_type(lsim(_to_ss_cont_f32, None, _f64_1d), tuple[_VecF64, _ArrF64, _ArrF64])
 # c64
-assert_type(lsim(_lti_c64, None, _f64_1d), tuple[_VecF64, _VecC128, _ArrC128])
-assert_type(lsim(_to_tf_cont_c64, None, _f64_1d), tuple[_VecF64, _VecC128ish, _ArrC128ish])
-assert_type(lsim(_to_zpk_cont_c64, None, _f64_1d), tuple[_VecF64, _VecC128ish, _ArrC128ish])
-assert_type(lsim(_to_ss_cont_c64, None, _f64_1d), tuple[_VecF64, _VecC128ish, _ArrC128ish])
+assert_type(lsim(_lti_c64, None, _f64_1d), tuple[_VecF64, _ArrC128, _ArrC128])
+assert_type(lsim(_to_tf_cont_c64, None, _f64_1d), tuple[_VecF64, _ArrC128ish, _ArrC128ish])
+assert_type(lsim(_to_zpk_cont_c64, None, _f64_1d), tuple[_VecF64, _ArrC128ish, _ArrC128ish])
+assert_type(lsim(_to_ss_cont_c64, None, _f64_1d), tuple[_VecF64, _ArrC128ish, _ArrC128ish])
 # f64
-assert_type(lsim(_lti_f64, None, _f64_1d), tuple[_VecF64, _VecF64, _ArrF64])
-assert_type(lsim(_to_tf_cont_f64, None, _f64_1d), tuple[_VecF64, _VecF64, _ArrF64])
-assert_type(lsim(_to_zpk_cont_f64, None, _f64_1d), tuple[_VecF64, _VecF64, _ArrF64])
-assert_type(lsim(_to_ss_cont_f64, None, _f64_1d), tuple[_VecF64, _VecF64, _ArrF64])
+assert_type(lsim(_lti_f64, None, _f64_1d), tuple[_VecF64, _ArrF64, _ArrF64])
+assert_type(lsim(_to_tf_cont_f64, None, _f64_1d), tuple[_VecF64, _ArrF64, _ArrF64])
+assert_type(lsim(_to_zpk_cont_f64, None, _f64_1d), tuple[_VecF64, _ArrF64, _ArrF64])
+assert_type(lsim(_to_ss_cont_f64, None, _f64_1d), tuple[_VecF64, _ArrF64, _ArrF64])
 # c128
-assert_type(lsim(_lti_c128, None, _f64_1d), tuple[_VecF64, _VecC128, _ArrC128])
-assert_type(lsim(_to_tf_cont_c128, None, _f64_1d), tuple[_VecF64, _VecC128ish, _ArrC128ish])
-assert_type(lsim(_to_zpk_cont_c128, None, _f64_1d), tuple[_VecF64, _VecC128ish, _ArrC128ish])
-assert_type(lsim(_to_ss_cont_c128, None, _f64_1d), tuple[_VecF64, _VecC128ish, _ArrC128ish])
+assert_type(lsim(_lti_c128, None, _f64_1d), tuple[_VecF64, _ArrC128, _ArrC128])
+assert_type(lsim(_to_tf_cont_c128, None, _f64_1d), tuple[_VecF64, _ArrC128ish, _ArrC128ish])
+assert_type(lsim(_to_zpk_cont_c128, None, _f64_1d), tuple[_VecF64, _ArrC128ish, _ArrC128ish])
+assert_type(lsim(_to_ss_cont_c128, None, _f64_1d), tuple[_VecF64, _ArrC128ish, _ArrC128ish])
 
 # lti.output method
-assert_type(_lti_f32.output(None, _f64_1d), tuple[_VecF64, _VecF64, _ArrF64])
-assert_type(_lti_c64.output(None, _f64_1d), tuple[_VecF64, _VecC128, _ArrC128])
-assert_type(_lti_f64.output(None, _f64_1d), tuple[_VecF64, _VecF64, _ArrF64])
-assert_type(_lti_c128.output(None, _f64_1d), tuple[_VecF64, _VecC128, _ArrC128])
+assert_type(_lti_f32.output(None, _f64_1d), tuple[_VecF64, _ArrF64, _ArrF64])
+assert_type(_lti_c64.output(None, _f64_1d), tuple[_VecF64, _ArrC128, _ArrC128])
+assert_type(_lti_f64.output(None, _f64_1d), tuple[_VecF64, _ArrF64, _ArrF64])
+assert_type(_lti_c128.output(None, _f64_1d), tuple[_VecF64, _ArrC128, _ArrC128])
 
 ###
 # impulse (same as lsim and step)
 
 # f32
-assert_type(impulse(_lti_f32), tuple[_VecF64, _VecF64])
-assert_type(impulse(_to_tf_cont_f32), tuple[_VecF64, _VecF64])
-assert_type(impulse(_to_zpk_cont_f32), tuple[_VecF64, _VecF64])
-assert_type(impulse(_to_ss_cont_f32), tuple[_VecF64, _VecF64])
+assert_type(impulse(_lti_f32), tuple[_VecF64, _ArrF64])
+assert_type(impulse(_to_tf_cont_f32), tuple[_VecF64, _ArrF64])
+assert_type(impulse(_to_zpk_cont_f32), tuple[_VecF64, _ArrF64])
+assert_type(impulse(_to_ss_cont_f32), tuple[_VecF64, _ArrF64])
 # c64
-assert_type(impulse(_lti_c64), tuple[_VecF64, _VecC128])
-assert_type(impulse(_to_tf_cont_c64), tuple[_VecF64, _VecC128ish])
-assert_type(impulse(_to_zpk_cont_c64), tuple[_VecF64, _VecC128ish])
-assert_type(impulse(_to_ss_cont_c64), tuple[_VecF64, _VecC128ish])
+assert_type(impulse(_lti_c64), tuple[_VecF64, _ArrC128])
+assert_type(impulse(_to_tf_cont_c64), tuple[_VecF64, _ArrC128ish])
+assert_type(impulse(_to_zpk_cont_c64), tuple[_VecF64, _ArrC128ish])
+assert_type(impulse(_to_ss_cont_c64), tuple[_VecF64, _ArrC128ish])
 # f64
-assert_type(impulse(_lti_f64), tuple[_VecF64, _VecF64])
-assert_type(impulse(_to_tf_cont_f64), tuple[_VecF64, _VecF64])
-assert_type(impulse(_to_zpk_cont_f64), tuple[_VecF64, _VecF64])
-assert_type(impulse(_to_ss_cont_f64), tuple[_VecF64, _VecF64])
+assert_type(impulse(_lti_f64), tuple[_VecF64, _ArrF64])
+assert_type(impulse(_to_tf_cont_f64), tuple[_VecF64, _ArrF64])
+assert_type(impulse(_to_zpk_cont_f64), tuple[_VecF64, _ArrF64])
+assert_type(impulse(_to_ss_cont_f64), tuple[_VecF64, _ArrF64])
 # c128
-assert_type(impulse(_lti_c128), tuple[_VecF64, _VecC128])
-assert_type(impulse(_to_tf_cont_c128), tuple[_VecF64, _VecC128ish])
-assert_type(impulse(_to_zpk_cont_c128), tuple[_VecF64, _VecC128ish])
-assert_type(impulse(_to_ss_cont_c128), tuple[_VecF64, _VecC128ish])
+assert_type(impulse(_lti_c128), tuple[_VecF64, _ArrC128])
+assert_type(impulse(_to_tf_cont_c128), tuple[_VecF64, _ArrC128ish])
+assert_type(impulse(_to_zpk_cont_c128), tuple[_VecF64, _ArrC128ish])
+assert_type(impulse(_to_ss_cont_c128), tuple[_VecF64, _ArrC128ish])
 
 # lti.impulse method
-assert_type(_lti_f32.impulse(), tuple[_VecF64, _VecF64])
-assert_type(_lti_c64.impulse(), tuple[_VecF64, _VecC128])
-assert_type(_lti_f64.impulse(), tuple[_VecF64, _VecF64])
-assert_type(_lti_c128.impulse(), tuple[_VecF64, _VecC128])
+assert_type(_lti_f32.impulse(), tuple[_VecF64, _ArrF64])
+assert_type(_lti_c64.impulse(), tuple[_VecF64, _ArrC128])
+assert_type(_lti_f64.impulse(), tuple[_VecF64, _ArrF64])
+assert_type(_lti_c128.impulse(), tuple[_VecF64, _ArrC128])
 
 ###
 # step (same as lsim and impulse)
 
 # f32
-assert_type(step(_lti_f32), tuple[_VecF64, _VecF64])
-assert_type(step(_to_tf_cont_f32), tuple[_VecF64, _VecF64])
-assert_type(step(_to_zpk_cont_f32), tuple[_VecF64, _VecF64])
-assert_type(step(_to_ss_cont_f32), tuple[_VecF64, _VecF64])
+assert_type(step(_lti_f32), tuple[_VecF64, _ArrF64])
+assert_type(step(_to_tf_cont_f32), tuple[_VecF64, _ArrF64])
+assert_type(step(_to_zpk_cont_f32), tuple[_VecF64, _ArrF64])
+assert_type(step(_to_ss_cont_f32), tuple[_VecF64, _ArrF64])
 # c64
-assert_type(step(_lti_c64), tuple[_VecF64, _VecC128])
-assert_type(step(_to_tf_cont_c64), tuple[_VecF64, _VecC128ish])
-assert_type(step(_to_zpk_cont_c64), tuple[_VecF64, _VecC128ish])
-assert_type(step(_to_ss_cont_c64), tuple[_VecF64, _VecC128ish])
+assert_type(step(_lti_c64), tuple[_VecF64, _ArrC128])
+assert_type(step(_to_tf_cont_c64), tuple[_VecF64, _ArrC128ish])
+assert_type(step(_to_zpk_cont_c64), tuple[_VecF64, _ArrC128ish])
+assert_type(step(_to_ss_cont_c64), tuple[_VecF64, _ArrC128ish])
 # f64
-assert_type(step(_lti_f64), tuple[_VecF64, _VecF64])
-assert_type(step(_to_tf_cont_f64), tuple[_VecF64, _VecF64])
-assert_type(step(_to_zpk_cont_f64), tuple[_VecF64, _VecF64])
-assert_type(step(_to_ss_cont_f64), tuple[_VecF64, _VecF64])
+assert_type(step(_lti_f64), tuple[_VecF64, _ArrF64])
+assert_type(step(_to_tf_cont_f64), tuple[_VecF64, _ArrF64])
+assert_type(step(_to_zpk_cont_f64), tuple[_VecF64, _ArrF64])
+assert_type(step(_to_ss_cont_f64), tuple[_VecF64, _ArrF64])
 # c128
-assert_type(step(_lti_c128), tuple[_VecF64, _VecC128])
-assert_type(step(_to_tf_cont_c128), tuple[_VecF64, _VecC128ish])
-assert_type(step(_to_zpk_cont_c128), tuple[_VecF64, _VecC128ish])
-assert_type(step(_to_ss_cont_c128), tuple[_VecF64, _VecC128ish])
+assert_type(step(_lti_c128), tuple[_VecF64, _ArrC128])
+assert_type(step(_to_tf_cont_c128), tuple[_VecF64, _ArrC128ish])
+assert_type(step(_to_zpk_cont_c128), tuple[_VecF64, _ArrC128ish])
+assert_type(step(_to_ss_cont_c128), tuple[_VecF64, _ArrC128ish])
 
 # lti.step method
-assert_type(_lti_f32.step(), tuple[_VecF64, _VecF64])
-assert_type(_lti_c64.step(), tuple[_VecF64, _VecC128])
-assert_type(_lti_f64.step(), tuple[_VecF64, _VecF64])
-assert_type(_lti_c128.step(), tuple[_VecF64, _VecC128])
+assert_type(_lti_f32.step(), tuple[_VecF64, _ArrF64])
+assert_type(_lti_c64.step(), tuple[_VecF64, _ArrC128])
+assert_type(_lti_f64.step(), tuple[_VecF64, _ArrF64])
+assert_type(_lti_c128.step(), tuple[_VecF64, _ArrC128])
 
 ###
 # bode


### PR DESCRIPTION
The second return array can be 0d, 1d, or 2d, depending on the input values (not overloadableso the previous `Array1D` was incorrect.

fixes #1822