### PR TITLE
🐛 `stats.sobol_indices`: fix shape-type for single-output `func`

### DIFF
--- a/scipy-stubs/stats/_sensitivity_analysis.pyi
+++ b/scipy-stubs/stats/_sensitivity_analysis.pyi
@@ -1,6 +1,7 @@
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
-from typing import Literal, Protocol, type_check_only
+from typing import Any, Generic, Literal, Never, Protocol, overload, type_check_only
+from typing_extensions import TypeVar
 
 import numpy as np
 import optype.numpy as onp
@@ -12,11 +13,19 @@ __all__ = ["sobol_indices"]
 
 ###
 
+_ShapeT_co = TypeVar("_ShapeT_co", bound=tuple[int, ...], default=tuple[Any, ...], covariant=True)
+
+type _SobolFunc[T] = Callable[[onp.Array2D[np.float64]], T]
+
+# workaround for mypy & pyright's failure to conform to the overload typing specification
+type _JustAnyShape = tuple[Never, Never, Never]
+
 type _SobolKey = Literal["f_A", "f_B", "f_AB"]
 type _SobolMethod = Callable[
     [onp.Array2D[np.float64], onp.Array2D[np.float64], onp.Array3D[np.float64]],
     tuple[onp.ToFloat | onp.ToFloatND, onp.ToFloat | onp.ToFloatND],
 ]
+type _ToSobolMethod = _SobolMethod | Literal["saltelli_2010"]
 
 @type_check_only
 class _HasPPF(Protocol):
@@ -31,9 +40,9 @@ class BootstrapSobolResult:
     total_order: BootstrapResult
 
 @dataclass
-class SobolResult:
-    first_order: onp.Array2D[np.float64]
-    total_order: onp.Array2D[np.float64]
+class SobolResult(Generic[_ShapeT_co]):
+    first_order: onp.ArrayND[np.float64, _ShapeT_co]
+    total_order: onp.ArrayND[np.float64, _ShapeT_co]
 
     _indices_method: _SobolMethod
     _f_A: onp.Array2D[np.float64]
@@ -61,12 +70,43 @@ def saltelli_2010(
 ) -> tuple[onp.Array2D[np.float64], onp.Array2D[np.float64]]: ...  # undocumented
 
 #
+@overload  # (2d f64) -> ?d +complex  (mypy & pyright workaround)
 def sobol_indices(
     *,
-    func: Callable[[onp.Array2D[np.float64]], onp.ToComplex2D] | Mapping[_SobolKey, onp.ArrayND[npc.number]],
+    func: _SobolFunc[onp.ArrayND[npc.number | np.bool, _JustAnyShape]],
     n: onp.ToJustInt,
     dists: Sequence[_HasPPF] | None = None,
-    method: _SobolMethod | Literal["saltelli_2010"] = "saltelli_2010",
+    method: _ToSobolMethod = "saltelli_2010",
+    rng: onp.random.ToRNG | None = None,
+    random_state: onp.random.ToRNG | None = None,
+) -> SobolResult: ...
+@overload  # (2d f64) -> 1d +complex  (single output)
+def sobol_indices(
+    *,
+    func: _SobolFunc[onp.ToComplexStrict1D],
+    n: onp.ToJustInt,
+    dists: Sequence[_HasPPF] | None = None,
+    method: _ToSobolMethod = "saltelli_2010",
+    rng: onp.random.ToRNG | None = None,
+    random_state: onp.random.ToRNG | None = None,
+) -> SobolResult[tuple[int]]: ...
+@overload  # (2d f64) -> 2d +complex  (multiple outputs)
+def sobol_indices(
+    *,
+    func: _SobolFunc[onp.ToComplexStrict2D],
+    n: onp.ToJustInt,
+    dists: Sequence[_HasPPF] | None = None,
+    method: _ToSobolMethod = "saltelli_2010",
+    rng: onp.random.ToRNG | None = None,
+    random_state: onp.random.ToRNG | None = None,
+) -> SobolResult[tuple[int, int]]: ...
+@overload  # fallback
+def sobol_indices(
+    *,
+    func: _SobolFunc[onp.ToComplex2D] | Mapping[_SobolKey, onp.ArrayND[npc.number]],
+    n: onp.ToJustInt,
+    dists: Sequence[_HasPPF] | None = None,
+    method: _ToSobolMethod = "saltelli_2010",
     rng: onp.random.ToRNG | None = None,
     random_state: onp.random.ToRNG | None = None,
 ) -> SobolResult: ...

--- a/tests/stats/test__sensitivity_analysis.pyi
+++ b/tests/stats/test__sensitivity_analysis.pyi
@@ -1,25 +1,46 @@
 # type-tests for `stats/_sensitivity_analysis.pyi`
 
-from typing import assert_type
+from typing import Any, assert_type
 
 import numpy as np
+import numpy.typing as npt
 import optype.numpy as onp
 
 from scipy.stats import sobol_indices
 from scipy.stats._resampling import BootstrapResult
 from scipy.stats._sensitivity_analysis import BootstrapSobolResult, SobolResult
 
+_f_A: onp.Array2D[np.float64]
+_f_AB: onp.Array3D[np.float64]
+
 ###
 # sobol_indices
 
-def _func(x: onp.Array2D[np.float64]) -> onp.Array2D[np.float64]: ...
+def _func_1d(x: onp.Array2D[np.float64]) -> onp.Array1D[np.float64]: ...
+def _func_2d(x: onp.Array2D[np.float64]) -> onp.Array2D[np.float64]: ...
+def _func_nd(x: onp.Array2D[np.float64]) -> npt.NDArray[np.float64]: ...
 
-_si = sobol_indices(func=_func, n=1024, dists=[])
-assert_type(_si, SobolResult)
-assert_type(_si.first_order, onp.Array2D[np.float64])
-assert_type(_si.total_order, onp.Array2D[np.float64])
+_si_1d = sobol_indices(func=_func_1d, n=1024, dists=[])
+assert_type(_si_1d, SobolResult[tuple[int]])
+assert_type(_si_1d.first_order, onp.Array1D[np.float64])
+assert_type(_si_1d.total_order, onp.Array1D[np.float64])
 
-_bs = _si.bootstrap(confidence_level=0.95, n_resamples=100)
+_si_2d = sobol_indices(func=_func_2d, n=1024, dists=[])
+assert_type(_si_2d, SobolResult[tuple[int, int]])
+assert_type(_si_2d.first_order, onp.Array2D[np.float64])
+assert_type(_si_2d.total_order, onp.Array2D[np.float64])
+
+_si_nd = sobol_indices(func=_func_nd, n=1024, dists=[])
+assert_type(_si_nd, SobolResult[tuple[Any, ...]])
+assert_type(_si_nd.first_order, onp.ArrayND[np.float64])
+assert_type(_si_nd.total_order, onp.ArrayND[np.float64])
+
+_si_dict = sobol_indices(func={"f_A": _f_A, "f_B": _f_A, "f_AB": _f_AB}, n=1024)
+assert_type(_si_dict, SobolResult[tuple[Any, ...]])
+assert_type(_si_dict.first_order, onp.ArrayND[np.float64])
+assert_type(_si_dict.total_order, onp.ArrayND[np.float64])
+
+_bs = _si_2d.bootstrap(confidence_level=0.95, n_resamples=100)
 assert_type(_bs, BootstrapSobolResult)
 assert_type(_bs.first_order, BootstrapResult)
 assert_type(_bs.total_order, BootstrapResult)


### PR DESCRIPTION
fixes #1786