### PR TITLE
🐛 `linalg.lstsq`: fix `residues` shape-types and `rank` dtype

### DIFF
--- a/scipy-stubs/linalg/_basic.pyi
+++ b/scipy-stubs/linalg/_basic.pyi
@@ -70,7 +70,32 @@ type _LapackDriver = Literal["gelsd", "gelsy", "gelss"]
 type _LapackDriverDS = Literal["gelsd", "gelss"]
 type _LapackDriverY = Literal["gelsy"]
 
-type _LstSqResultND[ScalarT: np.generic, T] = tuple[onp.ArrayND[ScalarT], onp.Array1D[ScalarT], int, T]
+# `lstsq` inputs, named after the scalar-type of the result they produce
+type _CoFloat64 = np.float64 | npc.floating80 | npc.integer | np.bool
+
+type _AsFloat64Strict1D = onp.ToArrayStrict1D[float, _CoFloat64]
+type _AsFloat64Strict2D = onp.ToArrayStrict2D[float, _CoFloat64]
+type _AsFloat64_2D = onp.ToArray2D[float, _CoFloat64]
+type _AsFloat64_ND = onp.ToArrayND[float, _CoFloat64]
+
+type _AsFloat32Strict1D = onp.ToJustFloat32Strict1D | onp.ToJustFloat16Strict1D
+type _AsFloat32Strict2D = onp.ToJustFloat32Strict2D | onp.ToJustFloat16Strict2D
+type _AsFloat32_2D = onp.ToJustFloat32_2D | onp.ToJustFloat16_2D
+type _AsFloat32_ND = onp.ToJustFloat32_ND | onp.ToJustFloat16_ND
+
+type _AsComplex128Strict1D = onp.ToJustComplex128Strict1D | onp.ToJustCLongDoubleStrict1D
+type _AsComplex128Strict2D = onp.ToJustComplex128Strict2D | onp.ToJustCLongDoubleStrict2D
+type _AsComplex128_2D = onp.ToJustComplex128_2D | onp.ToJustCLongDouble2D
+type _AsComplex128_ND = onp.ToJustComplex128_ND | onp.ToJustCLongDoubleND
+
+type _AsComplex64Strict1D = onp.ToJustComplex64Strict1D | _AsFloat32Strict1D
+type _AsComplex64Strict2D = onp.ToJustComplex64Strict2D | _AsFloat32Strict2D
+type _AsComplex64_ND = onp.ToJustComplex64_ND | _AsFloat32_ND
+
+type _LstSqResult11[ScalarT: np.generic] = tuple[onp.Array1D[ScalarT], onp.Array1D[ScalarT], np.int64, None]  # gelsy
+type _LstSqResult1N[ScalarT: np.generic, T] = tuple[onp.Array1D[ScalarT], onp.ArrayND[ScalarT], np.int64, T]
+type _LstSqResult21[ScalarT: np.generic, T] = tuple[onp.Array2D[ScalarT], onp.Array1D[ScalarT], np.int64, T]
+type _LstSqResultND[ScalarT: np.generic, T] = tuple[onp.ArrayND[ScalarT], onp.ArrayND[ScalarT], np.int64 | Any, T]
 
 ###
 
@@ -1184,20 +1209,62 @@ def det(
     a: onp.ToComplex128_ND, overwrite_a: bool = False, check_finite: bool = True
 ) -> np.float64 | np.complex128 | onp.ArrayND[np.float64 | np.complex128]: ...
 
-# TODO(@jorenham): shape-typing for `b`
-@overload  # ~f64, +f64
+#
+@overload  # ~f64, +f64 1d
 def lstsq(
-    a: onp.ToArray2D[float, np.float64 | npc.inexact80 | npc.integer | np.bool],
+    a: _AsFloat64Strict2D,
+    b: onp.ToFloatStrict1D,
+    cond: float | None = None,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    lapack_driver: _LapackDriverDS | None = None,
+) -> _LstSqResult1N[np.float64, onp.Array1D[np.float64]]: ...
+@overload  # ~f64, +f64 1d, lapack_driver='gelsy' (keyword)
+def lstsq(
+    a: _AsFloat64Strict2D,
+    b: onp.ToFloatStrict1D,
+    cond: float | None = None,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    *,
+    lapack_driver: _LapackDriverY,
+) -> _LstSqResult11[np.float64]: ...
+@overload  # ~f64, +f64 2d
+def lstsq(
+    a: _AsFloat64Strict2D,
+    b: onp.ToFloatStrict2D,
+    cond: float | None = None,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    lapack_driver: _LapackDriverDS | None = None,
+) -> _LstSqResult21[np.float64, onp.Array1D[np.float64]]: ...
+@overload  # ~f64, +f64 2d, lapack_driver='gelsy' (keyword)
+def lstsq(
+    a: _AsFloat64Strict2D,
+    b: onp.ToFloatStrict2D,
+    cond: float | None = None,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    *,
+    lapack_driver: _LapackDriverY,
+) -> _LstSqResult21[np.float64, None]: ...
+@overload  # ~f64, +f64 Nd
+def lstsq(
+    a: _AsFloat64_2D,
     b: onp.ToFloatND,
     cond: float | None = None,
     overwrite_a: bool = False,
     overwrite_b: bool = False,
     check_finite: bool = True,
     lapack_driver: _LapackDriverDS | None = None,
-) -> _LstSqResultND[np.float64, onp.Array1D[np.float64]]: ...
-@overload  # ~f64, +f64, lapack_driver='gelsy' (keyword)
+) -> _LstSqResultND[np.float64, onp.ArrayND[np.float64]]: ...
+@overload  # ~f64, +f64 Nd, lapack_driver='gelsy' (keyword)
 def lstsq(
-    a: onp.ToArray2D[float, np.float64 | npc.inexact80 | npc.integer | np.bool],
+    a: _AsFloat64_2D,
     b: onp.ToFloatND,
     cond: float | None = None,
     overwrite_a: bool = False,
@@ -1206,20 +1273,62 @@ def lstsq(
     *,
     lapack_driver: _LapackDriverY,
 ) -> _LstSqResultND[np.float64, None]: ...
-@overload  # +f64, -f64
+@overload  # +f64, ~f64 1d
 def lstsq(
-    a: onp.ToFloat2D,
-    b: onp.ToArrayND[float, np.float64 | npc.inexact80 | npc.integer | np.bool],
+    a: onp.ToFloatStrict2D,
+    b: _AsFloat64Strict1D,
     cond: float | None = None,
     overwrite_a: bool = False,
     overwrite_b: bool = False,
     check_finite: bool = True,
     lapack_driver: _LapackDriverDS | None = None,
-) -> _LstSqResultND[np.float64, onp.Array1D[np.float64]]: ...
-@overload  # +f64, -f64, lapack_driver='gelsy' (keyword)
+) -> _LstSqResult1N[np.float64, onp.Array1D[np.float64]]: ...
+@overload  # +f64, ~f64 1d, lapack_driver='gelsy' (keyword)
+def lstsq(
+    a: onp.ToFloatStrict2D,
+    b: _AsFloat64Strict1D,
+    cond: float | None = None,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    *,
+    lapack_driver: _LapackDriverY,
+) -> _LstSqResult11[np.float64]: ...
+@overload  # +f64, ~f64 2d
+def lstsq(
+    a: onp.ToFloatStrict2D,
+    b: _AsFloat64Strict2D,
+    cond: float | None = None,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    lapack_driver: _LapackDriverDS | None = None,
+) -> _LstSqResult21[np.float64, onp.Array1D[np.float64]]: ...
+@overload  # +f64, ~f64 2d, lapack_driver='gelsy' (keyword)
+def lstsq(
+    a: onp.ToFloatStrict2D,
+    b: _AsFloat64Strict2D,
+    cond: float | None = None,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    *,
+    lapack_driver: _LapackDriverY,
+) -> _LstSqResult21[np.float64, None]: ...
+@overload  # +f64, ~f64 Nd
 def lstsq(
     a: onp.ToFloat2D,
-    b: onp.ToArrayND[float, np.float64 | npc.inexact80 | npc.integer | np.bool],
+    b: _AsFloat64_ND,
+    cond: float | None = None,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    lapack_driver: _LapackDriverDS | None = None,
+) -> _LstSqResultND[np.float64, onp.ArrayND[np.float64]]: ...
+@overload  # +f64, ~f64 Nd, lapack_driver='gelsy' (keyword)
+def lstsq(
+    a: onp.ToFloat2D,
+    b: _AsFloat64_ND,
     cond: float | None = None,
     overwrite_a: bool = False,
     overwrite_b: bool = False,
@@ -1227,20 +1336,62 @@ def lstsq(
     *,
     lapack_driver: _LapackDriverY,
 ) -> _LstSqResultND[np.float64, None]: ...
-@overload  # ~f32, ~f32
+@overload  # ~f32 1d
 def lstsq(
-    a: onp.ToJustFloat32_2D | onp.ToJustFloat16_2D,
-    b: onp.ToJustFloat32_ND | onp.ToJustFloat16_ND,
+    a: _AsFloat32Strict2D,
+    b: _AsFloat32Strict1D,
     cond: float | None = None,
     overwrite_a: bool = False,
     overwrite_b: bool = False,
     check_finite: bool = True,
     lapack_driver: _LapackDriverDS | None = None,
-) -> _LstSqResultND[np.float32, onp.Array1D[np.float32]]: ...
-@overload  # ~f32, -f32, lapack_driver='gelsy' (keyword)
+) -> _LstSqResult1N[np.float32, onp.Array1D[np.float32]]: ...
+@overload  # ~f32 1d, lapack_driver='gelsy' (keyword)
 def lstsq(
-    a: onp.ToJustFloat32_2D | onp.ToJustFloat16_2D,
-    b: onp.ToJustFloat32_ND | onp.ToJustFloat16_ND,
+    a: _AsFloat32Strict2D,
+    b: _AsFloat32Strict1D,
+    cond: float | None = None,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    *,
+    lapack_driver: _LapackDriverY,
+) -> _LstSqResult11[np.float32]: ...
+@overload  # ~f32 2d
+def lstsq(
+    a: _AsFloat32Strict2D,
+    b: _AsFloat32Strict2D,
+    cond: float | None = None,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    lapack_driver: _LapackDriverDS | None = None,
+) -> _LstSqResult21[np.float32, onp.Array1D[np.float32]]: ...
+@overload  # ~f32 2d, lapack_driver='gelsy' (keyword)
+def lstsq(
+    a: _AsFloat32Strict2D,
+    b: _AsFloat32Strict2D,
+    cond: float | None = None,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    *,
+    lapack_driver: _LapackDriverY,
+) -> _LstSqResult21[np.float32, None]: ...
+@overload  # ~f32 Nd
+def lstsq(
+    a: _AsFloat32_2D,
+    b: _AsFloat32_ND,
+    cond: float | None = None,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    lapack_driver: _LapackDriverDS | None = None,
+) -> _LstSqResultND[np.float32, onp.ArrayND[np.float32]]: ...
+@overload  # ~f32 Nd, lapack_driver='gelsy' (keyword)
+def lstsq(
+    a: _AsFloat32_2D,
+    b: _AsFloat32_ND,
     cond: float | None = None,
     overwrite_a: bool = False,
     overwrite_b: bool = False,
@@ -1248,19 +1399,61 @@ def lstsq(
     *,
     lapack_driver: _LapackDriverY,
 ) -> _LstSqResultND[np.float32, None]: ...
-@overload  # ~c128, +c128
+@overload  # ~c128, +c128 1d
 def lstsq(
-    a: onp.ToJustComplex128_2D | onp.ToJustCLongDoubleND,
+    a: _AsComplex128Strict2D,
+    b: onp.ToComplexStrict1D,
+    cond: float | None = None,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    lapack_driver: _LapackDriverDS | None = None,
+) -> _LstSqResult1N[np.complex128, onp.Array1D[np.float64]]: ...
+@overload  # ~c128, +c128 1d, lapack_driver='gelsy' (keyword)
+def lstsq(
+    a: _AsComplex128Strict2D,
+    b: onp.ToComplexStrict1D,
+    cond: float | None = None,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    *,
+    lapack_driver: _LapackDriverY,
+) -> _LstSqResult11[np.complex128]: ...
+@overload  # ~c128, +c128 2d
+def lstsq(
+    a: _AsComplex128Strict2D,
+    b: onp.ToComplexStrict2D,
+    cond: float | None = None,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    lapack_driver: _LapackDriverDS | None = None,
+) -> _LstSqResult21[np.complex128, onp.Array1D[np.float64]]: ...
+@overload  # ~c128, +c128 2d, lapack_driver='gelsy' (keyword)
+def lstsq(
+    a: _AsComplex128Strict2D,
+    b: onp.ToComplexStrict2D,
+    cond: float | None = None,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    *,
+    lapack_driver: _LapackDriverY,
+) -> _LstSqResult21[np.complex128, None]: ...
+@overload  # ~c128, +c128 Nd
+def lstsq(
+    a: _AsComplex128_2D,
     b: onp.ToComplexND,
     cond: float | None = None,
     overwrite_a: bool = False,
     overwrite_b: bool = False,
     check_finite: bool = True,
     lapack_driver: _LapackDriverDS | None = None,
-) -> _LstSqResultND[np.complex128, onp.Array1D[np.float64]]: ...
-@overload  # ~c128, +c128, lapack_driver='gelsy' (keyword)
+) -> _LstSqResultND[np.complex128, onp.ArrayND[np.float64]]: ...
+@overload  # ~c128, +c128 Nd, lapack_driver='gelsy' (keyword)
 def lstsq(
-    a: onp.ToJustComplex128_2D | onp.ToJustCLongDouble2D,
+    a: _AsComplex128_2D,
     b: onp.ToComplexND,
     cond: float | None = None,
     overwrite_a: bool = False,
@@ -1269,20 +1462,62 @@ def lstsq(
     *,
     lapack_driver: _LapackDriverY,
 ) -> _LstSqResultND[np.complex128, None]: ...
-@overload  # +c128, ~c128
+@overload  # +c128, ~c128 1d
 def lstsq(
-    a: onp.ToComplex2D,
-    b: onp.ToJustComplex128_ND | onp.ToJustCLongDoubleND,
+    a: onp.ToComplexStrict2D,
+    b: _AsComplex128Strict1D,
     cond: float | None = None,
     overwrite_a: bool = False,
     overwrite_b: bool = False,
     check_finite: bool = True,
     lapack_driver: _LapackDriverDS | None = None,
-) -> _LstSqResultND[np.complex128, onp.Array1D[np.float64]]: ...
-@overload  # +c128, ~c128, lapack_driver='gelsy' (keyword)
+) -> _LstSqResult1N[np.complex128, onp.Array1D[np.float64]]: ...
+@overload  # +c128, ~c128 1d, lapack_driver='gelsy' (keyword)
+def lstsq(
+    a: onp.ToComplexStrict2D,
+    b: _AsComplex128Strict1D,
+    cond: float | None = None,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    *,
+    lapack_driver: _LapackDriverY,
+) -> _LstSqResult11[np.complex128]: ...
+@overload  # +c128, ~c128 2d
+def lstsq(
+    a: onp.ToComplexStrict2D,
+    b: _AsComplex128Strict2D,
+    cond: float | None = None,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    lapack_driver: _LapackDriverDS | None = None,
+) -> _LstSqResult21[np.complex128, onp.Array1D[np.float64]]: ...
+@overload  # +c128, ~c128 2d, lapack_driver='gelsy' (keyword)
+def lstsq(
+    a: onp.ToComplexStrict2D,
+    b: _AsComplex128Strict2D,
+    cond: float | None = None,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    *,
+    lapack_driver: _LapackDriverY,
+) -> _LstSqResult21[np.complex128, None]: ...
+@overload  # +c128, ~c128 Nd
 def lstsq(
     a: onp.ToComplex2D,
-    b: onp.ToJustComplex128_ND | onp.ToJustCLongDoubleND,
+    b: _AsComplex128_ND,
+    cond: float | None = None,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    lapack_driver: _LapackDriverDS | None = None,
+) -> _LstSqResultND[np.complex128, onp.ArrayND[np.float64]]: ...
+@overload  # +c128, ~c128 Nd, lapack_driver='gelsy' (keyword)
+def lstsq(
+    a: onp.ToComplex2D,
+    b: _AsComplex128_ND,
     cond: float | None = None,
     overwrite_a: bool = False,
     overwrite_b: bool = False,
@@ -1290,20 +1525,62 @@ def lstsq(
     *,
     lapack_driver: _LapackDriverY,
 ) -> _LstSqResultND[np.complex128, None]: ...
-@overload  # ~c64, +c64
+@overload  # ~c64 1d
 def lstsq(
-    a: onp.ToJustComplex64_2D,
-    b: onp.ToJustComplex64_ND | onp.ToJustFloat32_ND | onp.ToJustFloat16_ND,
+    a: onp.ToJustComplex64Strict2D,
+    b: _AsComplex64Strict1D,
     cond: float | None = None,
     overwrite_a: bool = False,
     overwrite_b: bool = False,
     check_finite: bool = True,
     lapack_driver: _LapackDriverDS | None = None,
-) -> _LstSqResultND[np.complex64, onp.Array1D[np.float32]]: ...
-@overload  # ~c64, +c64, lapack_driver='gelsy' (keyword)
+) -> _LstSqResult1N[np.complex64, onp.Array1D[np.float32]]: ...
+@overload  # ~c64 1d, lapack_driver='gelsy' (keyword)
+def lstsq(
+    a: onp.ToJustComplex64Strict2D,
+    b: _AsComplex64Strict1D,
+    cond: float | None = None,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    *,
+    lapack_driver: _LapackDriverY,
+) -> _LstSqResult11[np.complex64]: ...
+@overload  # ~c64 2d
+def lstsq(
+    a: onp.ToJustComplex64Strict2D,
+    b: _AsComplex64Strict2D,
+    cond: float | None = None,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    lapack_driver: _LapackDriverDS | None = None,
+) -> _LstSqResult21[np.complex64, onp.Array1D[np.float32]]: ...
+@overload  # ~c64 2d, lapack_driver='gelsy' (keyword)
+def lstsq(
+    a: onp.ToJustComplex64Strict2D,
+    b: _AsComplex64Strict2D,
+    cond: float | None = None,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    *,
+    lapack_driver: _LapackDriverY,
+) -> _LstSqResult21[np.complex64, None]: ...
+@overload  # ~c64 Nd
 def lstsq(
     a: onp.ToJustComplex64_2D,
-    b: onp.ToJustComplex64_ND | onp.ToJustFloat32_ND | onp.ToJustFloat16_ND,
+    b: _AsComplex64_ND,
+    cond: float | None = None,
+    overwrite_a: bool = False,
+    overwrite_b: bool = False,
+    check_finite: bool = True,
+    lapack_driver: _LapackDriverDS | None = None,
+) -> _LstSqResultND[np.complex64, onp.ArrayND[np.float32]]: ...
+@overload  # ~c64 Nd, lapack_driver='gelsy' (keyword)
+def lstsq(
+    a: onp.ToJustComplex64_2D,
+    b: _AsComplex64_ND,
     cond: float | None = None,
     overwrite_a: bool = False,
     overwrite_b: bool = False,
@@ -1320,7 +1597,7 @@ def lstsq(
     overwrite_b: bool = False,
     check_finite: bool = True,
     lapack_driver: _LapackDriver | None = None,
-) -> _LstSqResultND[Incomplete, onp.Array1D[np.float64 | Any] | Any]: ...
+) -> _LstSqResultND[Incomplete, onp.ArrayND[np.float64 | Any] | Any]: ...
 
 # TODO(jorenham): improve this
 @overload

--- a/tests/linalg/test__basic.pyi
+++ b/tests/linalg/test__basic.pyi
@@ -1,6 +1,6 @@
 # type-tests for `linalg/_basic.pyi`
 
-from typing import assert_type
+from typing import Any, assert_type
 
 import numpy as np
 import optype.numpy as onp
@@ -414,32 +414,80 @@ assert_type(det(py_c_3d), onp.Array1D[np.complex128])
 ###
 # lstsq
 
-assert_type(lstsq(py_i_2d, py_i_1d), tuple[onp.ArrayND[np.float64], onp.Array1D[np.float64], int, onp.Array1D[np.float64]])
-assert_type(lstsq(py_f_2d, py_f_1d), tuple[onp.ArrayND[np.float64], onp.Array1D[np.float64], int, onp.Array1D[np.float64]])
-assert_type(lstsq(py_c_2d, py_c_1d), tuple[onp.ArrayND[np.complex128], onp.Array1D[np.complex128], int, onp.Array1D[np.float64]])
-assert_type(lstsq(f16_2d, f16_1d), tuple[onp.ArrayND[np.float32], onp.Array1D[np.float32], int, onp.Array1D[np.float32]])
-assert_type(lstsq(f32_2d, f32_1d), tuple[onp.ArrayND[np.float32], onp.Array1D[np.float32], int, onp.Array1D[np.float32]])
-assert_type(lstsq(f64_2d, f64_1d), tuple[onp.ArrayND[np.float64], onp.Array1D[np.float64], int, onp.Array1D[np.float64]])
-assert_type(lstsq(f80_2d, f80_1d), tuple[onp.ArrayND[np.float64], onp.Array1D[np.float64], int, onp.Array1D[np.float64]])
-assert_type(lstsq(c64_2d, c64_1d), tuple[onp.ArrayND[np.complex64], onp.Array1D[np.complex64], int, onp.Array1D[np.float32]])
-assert_type(lstsq(c128_2d, c128_1d), tuple[onp.ArrayND[np.complex128], onp.Array1D[np.complex128], int, onp.Array1D[np.float64]])
-assert_type(lstsq(c160_2d, c160_1d), tuple[onp.ArrayND[np.complex128], onp.Array1D[np.complex128], int, onp.Array1D[np.float64]])
+assert_type(lstsq(py_i_2d, py_i_1d), tuple[onp.Array1D[np.float64], onp.ArrayND[np.float64], np.int64, onp.Array1D[np.float64]])
+assert_type(lstsq(py_f_2d, py_f_1d), tuple[onp.Array1D[np.float64], onp.ArrayND[np.float64], np.int64, onp.Array1D[np.float64]])
+assert_type(
+    lstsq(py_c_2d, py_c_1d), tuple[onp.Array1D[np.complex128], onp.ArrayND[np.complex128], np.int64, onp.Array1D[np.float64]]
+)
+assert_type(lstsq(f16_2d, f16_1d), tuple[onp.Array1D[np.float32], onp.ArrayND[np.float32], np.int64, onp.Array1D[np.float32]])
+assert_type(lstsq(f32_2d, f32_1d), tuple[onp.Array1D[np.float32], onp.ArrayND[np.float32], np.int64, onp.Array1D[np.float32]])
+assert_type(lstsq(f64_2d, f64_1d), tuple[onp.Array1D[np.float64], onp.ArrayND[np.float64], np.int64, onp.Array1D[np.float64]])
+assert_type(lstsq(f80_2d, f80_1d), tuple[onp.Array1D[np.float64], onp.ArrayND[np.float64], np.int64, onp.Array1D[np.float64]])
+assert_type(lstsq(c64_2d, c64_1d), tuple[onp.Array1D[np.complex64], onp.ArrayND[np.complex64], np.int64, onp.Array1D[np.float32]])
+assert_type(
+    lstsq(c128_2d, c128_1d), tuple[onp.Array1D[np.complex128], onp.ArrayND[np.complex128], np.int64, onp.Array1D[np.float64]]
+)
+assert_type(
+    lstsq(c160_2d, c160_1d), tuple[onp.Array1D[np.complex128], onp.ArrayND[np.complex128], np.int64, onp.Array1D[np.float64]]
+)
+assert_type(
+    lstsq(c160_2d, f64_1d), tuple[onp.Array1D[np.complex128], onp.ArrayND[np.complex128], np.int64, onp.Array1D[np.float64]]
+)
+assert_type(
+    lstsq(f64_2d, c160_1d), tuple[onp.Array1D[np.complex128], onp.ArrayND[np.complex128], np.int64, onp.Array1D[np.float64]]
+)
 
-assert_type(lstsq(py_i_2d, py_i_1d, lapack_driver="gelsy"), tuple[onp.ArrayND[np.float64], onp.Array1D[np.float64], int, None])
-assert_type(lstsq(py_f_2d, py_f_1d, lapack_driver="gelsy"), tuple[onp.ArrayND[np.float64], onp.Array1D[np.float64], int, None])
+assert_type(lstsq(f32_2d, f32_2d), tuple[onp.Array2D[np.float32], onp.Array1D[np.float32], np.int64, onp.Array1D[np.float32]])
+assert_type(lstsq(f64_2d, f64_2d), tuple[onp.Array2D[np.float64], onp.Array1D[np.float64], np.int64, onp.Array1D[np.float64]])
+assert_type(lstsq(c64_2d, c64_2d), tuple[onp.Array2D[np.complex64], onp.Array1D[np.complex64], np.int64, onp.Array1D[np.float32]])
 assert_type(
-    lstsq(py_c_2d, py_c_1d, lapack_driver="gelsy"), tuple[onp.ArrayND[np.complex128], onp.Array1D[np.complex128], int, None]
+    lstsq(c128_2d, c128_2d), tuple[onp.Array2D[np.complex128], onp.Array1D[np.complex128], np.int64, onp.Array1D[np.float64]]
 )
-assert_type(lstsq(f16_2d, f16_1d, lapack_driver="gelsy"), tuple[onp.ArrayND[np.float32], onp.Array1D[np.float32], int, None])
-assert_type(lstsq(f32_2d, f32_1d, lapack_driver="gelsy"), tuple[onp.ArrayND[np.float32], onp.Array1D[np.float32], int, None])
-assert_type(lstsq(f64_2d, f64_1d, lapack_driver="gelsy"), tuple[onp.ArrayND[np.float64], onp.Array1D[np.float64], int, None])
-assert_type(lstsq(f80_2d, f80_1d, lapack_driver="gelsy"), tuple[onp.ArrayND[np.float64], onp.Array1D[np.float64], int, None])
-assert_type(lstsq(c64_2d, c64_1d, lapack_driver="gelsy"), tuple[onp.ArrayND[np.complex64], onp.Array1D[np.complex64], int, None])
+
 assert_type(
-    lstsq(c128_2d, c128_1d, lapack_driver="gelsy"), tuple[onp.ArrayND[np.complex128], onp.Array1D[np.complex128], int, None]
+    lstsq(f64_2d, f64_3d), tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64], np.int64 | Any, onp.ArrayND[np.float64]]
 )
 assert_type(
-    lstsq(c160_2d, c160_1d, lapack_driver="gelsy"), tuple[onp.ArrayND[np.complex128], onp.Array1D[np.complex128], int, None]
+    lstsq(c128_2d, c128_3d),
+    tuple[onp.ArrayND[np.complex128], onp.ArrayND[np.complex128], np.int64 | Any, onp.ArrayND[np.float64]],
+)
+
+assert_type(
+    lstsq(f64_3d, f64_1d), tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64], np.int64 | Any, onp.ArrayND[np.float64]]
+)
+assert_type(
+    lstsq(f64_3d, f64_2d), tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64], np.int64 | Any, onp.ArrayND[np.float64]]
+)
+assert_type(
+    lstsq(c128_3d, c128_1d),
+    tuple[onp.ArrayND[np.complex128], onp.ArrayND[np.complex128], np.int64 | Any, onp.ArrayND[np.float64]],
+)
+
+assert_type(
+    lstsq(py_i_2d, py_i_1d, lapack_driver="gelsy"), tuple[onp.Array1D[np.float64], onp.Array1D[np.float64], np.int64, None]
+)
+assert_type(
+    lstsq(py_f_2d, py_f_1d, lapack_driver="gelsy"), tuple[onp.Array1D[np.float64], onp.Array1D[np.float64], np.int64, None]
+)
+assert_type(
+    lstsq(py_c_2d, py_c_1d, lapack_driver="gelsy"), tuple[onp.Array1D[np.complex128], onp.Array1D[np.complex128], np.int64, None]
+)
+assert_type(lstsq(f16_2d, f16_1d, lapack_driver="gelsy"), tuple[onp.Array1D[np.float32], onp.Array1D[np.float32], np.int64, None])
+assert_type(lstsq(f32_2d, f32_1d, lapack_driver="gelsy"), tuple[onp.Array1D[np.float32], onp.Array1D[np.float32], np.int64, None])
+assert_type(lstsq(f64_2d, f64_1d, lapack_driver="gelsy"), tuple[onp.Array1D[np.float64], onp.Array1D[np.float64], np.int64, None])
+assert_type(lstsq(f80_2d, f80_1d, lapack_driver="gelsy"), tuple[onp.Array1D[np.float64], onp.Array1D[np.float64], np.int64, None])
+assert_type(
+    lstsq(c64_2d, c64_1d, lapack_driver="gelsy"), tuple[onp.Array1D[np.complex64], onp.Array1D[np.complex64], np.int64, None]
+)
+assert_type(
+    lstsq(c128_2d, c128_1d, lapack_driver="gelsy"), tuple[onp.Array1D[np.complex128], onp.Array1D[np.complex128], np.int64, None]
+)
+assert_type(
+    lstsq(c160_2d, c160_1d, lapack_driver="gelsy"), tuple[onp.Array1D[np.complex128], onp.Array1D[np.complex128], np.int64, None]
+)
+assert_type(lstsq(f64_2d, f64_2d, lapack_driver="gelsy"), tuple[onp.Array2D[np.float64], onp.Array1D[np.float64], np.int64, None])
+assert_type(
+    lstsq(f64_2d, f64_3d, lapack_driver="gelsy"), tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64], np.int64 | Any, None]
 )
 
 ###


### PR DESCRIPTION
This was a bit of an experiment to see how well Claude Fable 5 is able to fix medium-complex stubs issues like this one. It took quite a bit of steering, but it eventually landed on something that I'm sufficiently happy with. So I don't think it's quite capable enough yet to do things like this fully autonomously. The entire process also took waaay longer than it would've if I had done this myself though... 

fixes #1805