### PR TITLE
🐛 `differentiate.hessian`: fix result class `nfev` dtype

### DIFF
--- a/scipy-stubs/differentiate/_differentiate.pyi
+++ b/scipy-stubs/differentiate/_differentiate.pyi
@@ -55,7 +55,7 @@ class _JacobianResult(_RichResult, Generic[_FloatT_co, _ShapeT_co]):
 class _HessianResult(_RichResult, Generic[_FloatT_co, _ShapeT2_co]):
     status: onp.Array[_ShapeT2_co, np.int32]
     error: onp.Array[_ShapeT2_co, _FloatT_co]
-    nfev: onp.Array[_ShapeT2_co, np.int32]
+    nfev: onp.Array[_ShapeT2_co, np.int64]
     success: onp.Array[_ShapeT2_co, np.bool]
     ddf: onp.Array[_ShapeT2_co, _FloatT_co]
 

--- a/tests/differentiate/test_differentiate.pyi
+++ b/tests/differentiate/test_differentiate.pyi
@@ -123,6 +123,6 @@ assert_type(hessian(f_f64_1nd_0d, f64_2d, initial_step=f64_1d), _HessianResult[n
 res_hes = hessian(f_f64_1nd_0d, f64_1d)
 assert_type(res_hes.status, onp.Array[onp.AtLeast2D, np.int32])
 assert_type(res_hes.error, onp.Array[onp.AtLeast2D, np.float64])
-assert_type(res_hes.nfev, onp.Array[onp.AtLeast2D, np.int32])
+assert_type(res_hes.nfev, onp.Array[onp.AtLeast2D, np.int64])
 assert_type(res_hes.success, onp.Array[onp.AtLeast2D, np.bool])
 assert_type(res_hes.ddf, onp.Array[onp.AtLeast2D, np.float64])


### PR DESCRIPTION
fixes #1837