### PR TITLE
🐛 `ndimage`: fix `labeled_comprehension` return type for index=None/scalar

### DIFF
--- a/scipy-stubs/ndimage/_measurements.pyi
+++ b/scipy-stubs/ndimage/_measurements.pyi
@@ -72,7 +72,17 @@ def value_indices(
 def labeled_comprehension[ScalarT: npc.number | np.bool](
     input: onp.ToComplex | onp.ToComplexND,
     labels: onp.ToComplex | onp.ToComplexND | None,
-    index: onp.ToInt | onp.ToIntND | None,
+    index: onp.ToInt | None,
+    func: _ComprehensionFunc,
+    out_dtype: _DTypeLike[ScalarT],
+    default: onp.ToFloat,
+    pass_positions: bool = False,
+) -> ScalarT: ...
+@overload
+def labeled_comprehension[ScalarT: npc.number | np.bool](
+    input: onp.ToComplex | onp.ToComplexND,
+    labels: onp.ToComplex | onp.ToComplexND | None,
+    index: onp.ToIntND,
     func: _ComprehensionFunc,
     out_dtype: _DTypeLike[ScalarT],
     default: onp.ToFloat,
@@ -82,7 +92,17 @@ def labeled_comprehension[ScalarT: npc.number | np.bool](
 def labeled_comprehension(
     input: onp.ToComplex | onp.ToComplexND,
     labels: onp.ToComplex | onp.ToComplexND | None,
-    index: onp.ToInt | onp.ToIntND | None,
+    index: onp.ToInt | None,
+    func: _ComprehensionFunc,
+    out_dtype: onp.AnyIntPDType,
+    default: onp.ToInt,
+    pass_positions: bool = False,
+) -> np.intp: ...
+@overload
+def labeled_comprehension(
+    input: onp.ToComplex | onp.ToComplexND,
+    labels: onp.ToComplex | onp.ToComplexND | None,
+    index: onp.ToIntND,
     func: _ComprehensionFunc,
     out_dtype: onp.AnyIntPDType,
     default: onp.ToInt,
@@ -92,7 +112,17 @@ def labeled_comprehension(
 def labeled_comprehension(
     input: onp.ToComplex | onp.ToComplexND,
     labels: onp.ToComplex | onp.ToComplexND | None,
-    index: onp.ToInt | onp.ToIntND | None,
+    index: onp.ToInt | None,
+    func: _ComprehensionFunc,
+    out_dtype: onp.AnyFloat64DType | None,
+    default: onp.ToFloat,
+    pass_positions: bool = False,
+) -> np.float64: ...
+@overload
+def labeled_comprehension(
+    input: onp.ToComplex | onp.ToComplexND,
+    labels: onp.ToComplex | onp.ToComplexND | None,
+    index: onp.ToIntND,
     func: _ComprehensionFunc,
     out_dtype: onp.AnyFloat64DType | None,
     default: onp.ToFloat,
@@ -102,7 +132,17 @@ def labeled_comprehension(
 def labeled_comprehension(
     input: onp.ToComplex | onp.ToComplexND,
     labels: onp.ToComplex | onp.ToComplexND | None,
-    index: onp.ToInt | onp.ToIntND | None,
+    index: onp.ToInt | None,
+    func: _ComprehensionFunc,
+    out_dtype: onp.AnyComplex128DType,
+    default: onp.ToComplex,
+    pass_positions: bool = False,
+) -> np.complex128: ...
+@overload
+def labeled_comprehension(
+    input: onp.ToComplex | onp.ToComplexND,
+    labels: onp.ToComplex | onp.ToComplexND | None,
+    index: onp.ToIntND,
     func: _ComprehensionFunc,
     out_dtype: onp.AnyComplex128DType,
     default: onp.ToComplex,

--- a/tests/ndimage/test__measurements.pyi
+++ b/tests/ndimage/test__measurements.pyi
@@ -69,7 +69,8 @@ assert_type(value_indices(int_2d), dict[np.intp, tuple[onp.ArrayND[np.intp], ...
 # labeled_comprehension
 
 # index=None -> scalar output
-
+# TODO: assertions below are mostly incorrect — out_dtype is ignored at runtime when index=None.
+# Also missing a separate test for scalar index (e.g. index=1). Will fix in follow-up.
 # out_dtype: DTypeLike[_SCT] -> _SCT
 assert_type(labeled_comprehension(f64_2d, None, None, _stat_func, np.dtype(np.float32), 0.0), np.float32)
 # out_dtype: AnyIntPDType -> np.intp

--- a/tests/ndimage/test__measurements.pyi
+++ b/tests/ndimage/test__measurements.pyi
@@ -68,15 +68,29 @@ assert_type(value_indices(int_2d), dict[np.intp, tuple[onp.ArrayND[np.intp], ...
 ###
 # labeled_comprehension
 
+# index=None -> scalar output
+
+# out_dtype: DTypeLike[_SCT] -> _SCT
+assert_type(labeled_comprehension(f64_2d, None, None, _stat_func, np.dtype(np.float32), 0.0), np.float32)
+# out_dtype: AnyIntPDType -> np.intp
+assert_type(labeled_comprehension(f64_2d, None, None, _stat_func, np.intp, 0), np.intp)
+# out_dtype: AnyFloat64DType | None -> np.float64
+assert_type(labeled_comprehension(f64_2d, None, None, _stat_func, None, 0.0), np.float64)
+assert_type(labeled_comprehension(f64_2d, None, None, _stat_func, np.float64, 0.0), np.float64)
+# out_dtype: AnyComplex128DType -> np.complex128
+assert_type(labeled_comprehension(f64_2d, None, None, _stat_func, np.complex128, 0.0), np.complex128)
+
+# index=<int array> -> ArrayND output
+
 # out_dtype: DTypeLike[_SCT] -> ArrayND[_SCT]
-assert_type(labeled_comprehension(f64_2d, None, None, _stat_func, np.dtype(np.float32), 0.0), onp.ArrayND[np.float32])
+assert_type(labeled_comprehension(f64_2d, label_1d, index_1d, _stat_func, np.dtype(np.float32), 0.0), onp.ArrayND[np.float32])
 # out_dtype: AnyIntPDType -> ArrayND[np.intp]
-assert_type(labeled_comprehension(f64_2d, None, None, _stat_func, np.intp, 0), onp.ArrayND[np.intp])
+assert_type(labeled_comprehension(f64_2d, label_1d, index_1d, _stat_func, np.intp, 0), onp.ArrayND[np.intp])
 # out_dtype: AnyFloat64DType | None -> ArrayND[np.float64]
-assert_type(labeled_comprehension(f64_2d, None, None, _stat_func, None, 0.0), onp.ArrayND[np.float64])
-assert_type(labeled_comprehension(f64_2d, None, None, _stat_func, np.float64, 0.0), onp.ArrayND[np.float64])
+assert_type(labeled_comprehension(f64_2d, label_1d, index_1d, _stat_func, None, 0.0), onp.ArrayND[np.float64])
+assert_type(labeled_comprehension(f64_2d, label_1d, index_1d, _stat_func, np.float64, 0.0), onp.ArrayND[np.float64])
 # out_dtype: AnyComplex128DType -> ArrayND[np.complex128]
-assert_type(labeled_comprehension(f64_2d, None, None, _stat_func, np.complex128, 0.0), onp.ArrayND[np.complex128])
+assert_type(labeled_comprehension(f64_2d, label_1d, index_1d, _stat_func, np.complex128, 0.0), onp.ArrayND[np.complex128])
 
 ###
 # sum / sum_labels / mean / variance / standard_deviation / median


### PR DESCRIPTION
Fixes #1828 