### PR TITLE
🐛 `stats`: fix `false_discovery_control(0.05)` output should be `scalar`, not Nd

### DIFF
--- a/scipy-stubs/stats/_morestats.pyi
+++ b/scipy-stubs/stats/_morestats.pyi
@@ -1113,6 +1113,11 @@ def circstd(
 def directional_stats(samples: onp.ToFloatND, *, axis: SupportsIndex | None = 0, normalize: bool = True) -> DirectionalStats: ...
 
 #
+@overload
 def false_discovery_control(
-    ps: onp.ToFloat | onp.ToFloatND, *, axis: SupportsIndex | None = 0, method: Literal["bh", "by"] = "bh"
+    ps: onp.ToFloat, *, axis: SupportsIndex | None = 0, method: Literal["bh", "by"] = "bh"
+) -> np.float64: ...
+@overload
+def false_discovery_control(
+    ps: onp.ToFloatND, *, axis: SupportsIndex | None = 0, method: Literal["bh", "by"] = "bh"
 ) -> onp.ArrayND[np.float64]: ...

--- a/tests/stats/test__morestats.pyi
+++ b/tests/stats/test__morestats.pyi
@@ -199,4 +199,4 @@ assert_type(circstd(_fnd, keepdims=True), onp.ArrayND[np.float64])
 
 assert_type(false_discovery_control(_f1d), onp.ArrayND[np.float64])
 assert_type(false_discovery_control(_fnd), onp.ArrayND[np.float64])
-assert_type(false_discovery_control(0.05), onp.ArrayND[np.float64])
+assert_type(false_discovery_control(0.05), np.float64)


### PR DESCRIPTION
Fixes #1866 