### PR TITLE
🐛✨ `stats.directional_stats`: fix and improve shape-typing and dtype propagation

### DIFF
--- a/scipy-stubs/stats/_morestats.pyi
+++ b/scipy-stubs/stats/_morestats.pyi
@@ -71,6 +71,11 @@ _NDT_co = TypeVar(
     default=np.float64 | onp.ArrayND[np.float64],
 )  # fmt: skip
 
+_DirectionT_co = TypeVar("_DirectionT_co", bound=onp.ArrayND[npc.inexact], default=onp.ArrayND[np.float64 | Any], covariant=True)
+_LengthT_co = TypeVar(
+    "_LengthT_co", bound=npc.floating | onp.ArrayND[npc.floating], default=onp.ArrayND[np.float64 | Any], covariant=True
+)
+
 type _JustAnyShape = tuple[Never, Never, Never, Never]  # workaround for https://github.com/microsoft/pyright/issues/10232
 type _Tuple2[T] = tuple[T, T]
 type _Tuple3[T] = tuple[T, T, T]
@@ -186,10 +191,12 @@ class _HasX(Protocol):
 @final
 class _BigFloat: ...
 
-class DirectionalStats:
-    mean_direction: onp.ArrayND[np.float64]
-    mean_resultant_length: onp.ArrayND[np.float64]
-    def __init__(self, /, mean_direction: onp.ArrayND[np.float64], mean_resultant_length: onp.ArrayND[np.float64]) -> None: ...
+@final
+class DirectionalStats(Generic[_DirectionT_co, _LengthT_co]):
+    mean_direction: _DirectionT_co
+    mean_resultant_length: _LengthT_co
+
+    def __init__(self, /, mean_direction: _DirectionT_co, mean_resultant_length: _LengthT_co) -> None: ...
 
 class ShapiroResult(_TestResult[_NDT_co], Generic[_NDT_co]): ...
 class AnsariResult(_TestResult[_NDT_co], Generic[_NDT_co]): ...
@@ -1110,7 +1117,86 @@ def circstd(
 ) -> np.float64 | onp.ArrayND[np.float64]: ...
 
 #
-def directional_stats(samples: onp.ToFloatND, *, axis: SupportsIndex | None = 0, normalize: bool = True) -> DirectionalStats: ...
+@overload  # ?d +T@floating
+def directional_stats[ScalarT: npc.floating](
+    samples: onp.ArrayND[ScalarT, _JustAnyShape], *, axis: SupportsIndex = 0, normalize: bool = True
+) -> DirectionalStats[onp.ArrayND[ScalarT], ScalarT | onp.ArrayND[ScalarT]]: ...
+@overload  # ?d +integer
+def directional_stats(
+    samples: onp.ArrayND[npc.integer | np.bool, _JustAnyShape], *, axis: SupportsIndex = 0, normalize: bool = True
+) -> DirectionalStats[onp.ArrayND[np.float64], np.float64 | onp.ArrayND[np.float64]]: ...
+@overload  # ?d ~c128
+def directional_stats(
+    samples: onp.ArrayND[npc.complexfloating128, _JustAnyShape], *, axis: SupportsIndex = 0, normalize: bool = True
+) -> DirectionalStats[onp.ArrayND[np.complex128], np.float64 | onp.ArrayND[np.float64]]: ...
+@overload  # ?d ~c64
+def directional_stats(
+    samples: onp.ArrayND[npc.complexfloating64, _JustAnyShape], *, axis: SupportsIndex = 0, normalize: bool = True
+) -> DirectionalStats[onp.ArrayND[np.complex64], np.float32 | onp.ArrayND[np.float32]]: ...
+@overload  # ?d ~c160
+def directional_stats(
+    samples: onp.ArrayND[npc.complexfloating160, _JustAnyShape], *, axis: SupportsIndex = 0, normalize: bool = True
+) -> DirectionalStats[onp.ArrayND[np.clongdouble], np.longdouble | onp.ArrayND[np.longdouble]]: ...
+@overload  # 2d +T@floating
+def directional_stats[ScalarT: npc.floating](
+    samples: onp.Array2D[ScalarT], *, axis: SupportsIndex = 0, normalize: bool = True
+) -> DirectionalStats[onp.Array1D[ScalarT], ScalarT]: ...
+@overload  # 2d +integer | +float
+def directional_stats(
+    samples: onp.ToArrayStrict2D[float, npc.integer | np.bool], *, axis: SupportsIndex = 0, normalize: bool = True
+) -> DirectionalStats[onp.Array1D[np.float64], np.float64]: ...
+@overload  # 2d ~c128
+def directional_stats(
+    samples: onp.ToJustComplex128Strict2D, *, axis: SupportsIndex = 0, normalize: bool = True
+) -> DirectionalStats[onp.Array1D[np.complex128], np.float64]: ...
+@overload  # 2d ~c64
+def directional_stats(
+    samples: onp.ToJustComplex64Strict2D, *, axis: SupportsIndex = 0, normalize: bool = True
+) -> DirectionalStats[onp.Array1D[np.complex64], np.float32]: ...
+@overload  # 2d ~c160
+def directional_stats(
+    samples: onp.ToJustCLongDoubleStrict2D, *, axis: SupportsIndex = 0, normalize: bool = True
+) -> DirectionalStats[onp.Array1D[np.clongdouble], np.longdouble]: ...
+@overload  # 3d +T@floating
+def directional_stats[ScalarT: npc.floating](
+    samples: onp.Array3D[ScalarT], *, axis: SupportsIndex = 0, normalize: bool = True
+) -> DirectionalStats[onp.Array2D[ScalarT], onp.Array1D[ScalarT]]: ...
+@overload  # 3d +integer | +float
+def directional_stats(
+    samples: onp.ToArrayStrict3D[float, npc.integer | np.bool], *, axis: SupportsIndex = 0, normalize: bool = True
+) -> DirectionalStats[onp.Array2D[np.float64], onp.Array1D[np.float64]]: ...
+@overload  # 3d ~c128
+def directional_stats(
+    samples: onp.ToJustComplex128Strict3D, *, axis: SupportsIndex = 0, normalize: bool = True
+) -> DirectionalStats[onp.Array2D[np.complex128], onp.Array1D[np.float64]]: ...
+@overload  # 3d ~c64
+def directional_stats(
+    samples: onp.ToJustComplex64Strict3D, *, axis: SupportsIndex = 0, normalize: bool = True
+) -> DirectionalStats[onp.Array2D[np.complex64], onp.Array1D[np.float32]]: ...
+@overload  # 3d ~c160
+def directional_stats(
+    samples: onp.ToJustCLongDoubleStrict3D, *, axis: SupportsIndex = 0, normalize: bool = True
+) -> DirectionalStats[onp.Array2D[np.clongdouble], onp.Array1D[np.longdouble]]: ...
+@overload  # Nd +T@floating
+def directional_stats[ScalarT: npc.floating](
+    samples: onp.ArrayND[ScalarT], *, axis: SupportsIndex = 0, normalize: bool = True
+) -> DirectionalStats[onp.ArrayND[ScalarT], ScalarT | onp.ArrayND[ScalarT]]: ...
+@overload  # Nd +integer | +float
+def directional_stats(
+    samples: onp.ToArrayND[float, npc.integer | np.bool], *, axis: SupportsIndex = 0, normalize: bool = True
+) -> DirectionalStats[onp.ArrayND[np.float64], np.float64 | onp.ArrayND[np.float64]]: ...
+@overload  # Nd ~c128
+def directional_stats(
+    samples: onp.ToJustComplex128_ND, *, axis: SupportsIndex = 0, normalize: bool = True
+) -> DirectionalStats[onp.ArrayND[np.complex128], np.float64 | onp.ArrayND[np.float64]]: ...
+@overload  # Nd ~c64
+def directional_stats(
+    samples: onp.ToJustComplex64_ND, *, axis: SupportsIndex = 0, normalize: bool = True
+) -> DirectionalStats[onp.ArrayND[np.complex64], np.float32 | onp.ArrayND[np.float32]]: ...
+@overload  # Nd ~c160
+def directional_stats(
+    samples: onp.ToJustCLongDoubleND, *, axis: SupportsIndex = 0, normalize: bool = True
+) -> DirectionalStats[onp.ArrayND[np.clongdouble], np.longdouble | onp.ArrayND[np.longdouble]]: ...
 
 #
 @overload

--- a/tests/stats/test__morestats.pyi
+++ b/tests/stats/test__morestats.pyi
@@ -15,6 +15,7 @@ from scipy.stats import (
     circmean,
     circstd,
     circvar,
+    directional_stats,
     false_discovery_control,
     fligner,
     kstat,
@@ -35,6 +36,7 @@ from scipy.stats._morestats import (
     Anderson_ksampResult,
     AnsariResult,
     BartlettResult,
+    DirectionalStats,
     FlignerResult,
     LeveneResult,
     Mean,
@@ -48,9 +50,30 @@ from scipy.stats._stats_py import SignificanceResult
 
 ###
 
-_f1d: onp.Array1D[np.float64]
-_f2d: onp.Array2D[np.float64]
-_fnd: onp.ArrayND[np.float64]
+_i16_2d: onp.Array2D[np.int16]
+_i16_3d: onp.Array3D[np.int16]
+_i16_nd: onp.ArrayND[np.int16]
+
+_f32_2d: onp.Array2D[np.float32]
+_f32_3d: onp.Array3D[np.float32]
+_f32_nd: onp.ArrayND[np.float32]
+
+_f64_1d: onp.Array1D[np.float64]
+_f64_2d: onp.Array2D[np.float64]
+_f64_3d: onp.Array3D[np.float64]
+_f64_nd: onp.ArrayND[np.float64]
+
+_c64_2d: onp.Array2D[np.complex64]
+_c64_3d: onp.Array3D[np.complex64]
+_c64_nd: onp.ArrayND[np.complex64]
+
+_c128_2d: onp.Array2D[np.complex128]
+_c128_3d: onp.Array3D[np.complex128]
+_c128_nd: onp.ArrayND[np.complex128]
+
+_c160_2d: onp.Array2D[np.complex256]
+_c160_3d: onp.Array3D[np.complex256]
+_c160_nd: onp.ArrayND[np.complex256]
 
 _py_f_1d: list[float]
 _py_f_2d: list[list[float]]
@@ -59,144 +82,170 @@ _py_f_2d: list[list[float]]
 # bayes_mvs
 
 assert_type(bayes_mvs(_py_f_1d), tuple[Mean, Variance, Std_dev])
-assert_type(bayes_mvs(_f1d), tuple[Mean, Variance, Std_dev])
+assert_type(bayes_mvs(_f64_1d), tuple[Mean, Variance, Std_dev])
 
 ###
 # mvsdist
 
-assert_subtype[rv_continuous_frozen](mvsdist(_f1d)[0])
-assert_subtype[rv_continuous_frozen](mvsdist(_f1d)[1])
-assert_subtype[rv_continuous_frozen](mvsdist(_f1d)[2])
+assert_subtype[rv_continuous_frozen](mvsdist(_f64_1d)[0])
+assert_subtype[rv_continuous_frozen](mvsdist(_f64_1d)[1])
+assert_subtype[rv_continuous_frozen](mvsdist(_f64_1d)[2])
 
 ###
 # kstat
 
-assert_type(kstat(_fnd), np.float64)
-assert_type(kstat(_fnd, axis=None), np.float64)
-assert_type(kstat(_fnd, axis=0), np.float64 | onp.ArrayND[np.float64])
-assert_type(kstat(_fnd, keepdims=True), onp.ArrayND[np.float64])
+assert_type(kstat(_f64_nd), np.float64)
+assert_type(kstat(_f64_nd, axis=None), np.float64)
+assert_type(kstat(_f64_nd, axis=0), np.float64 | onp.ArrayND[np.float64])
+assert_type(kstat(_f64_nd, keepdims=True), onp.ArrayND[np.float64])
 
 ###
 # kstatvar
 
-assert_type(kstatvar(_fnd), np.float64)
-assert_type(kstatvar(_fnd, axis=None), np.float64)
-assert_type(kstatvar(_fnd, axis=0), np.float64 | onp.ArrayND[np.float64])
-assert_type(kstatvar(_fnd, keepdims=True), onp.ArrayND[np.float64])
+assert_type(kstatvar(_f64_nd), np.float64)
+assert_type(kstatvar(_f64_nd, axis=None), np.float64)
+assert_type(kstatvar(_f64_nd, axis=0), np.float64 | onp.ArrayND[np.float64])
+assert_type(kstatvar(_f64_nd, keepdims=True), onp.ArrayND[np.float64])
 
 ###
 # probplot
 
 assert_type(
-    probplot(_f1d), tuple[tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64]], tuple[np.float64, np.float64, np.float64]]
+    probplot(_f64_1d), tuple[tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64]], tuple[np.float64, np.float64, np.float64]]
 )
-assert_type(probplot(_f1d, fit=False), tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64]])
+assert_type(probplot(_f64_1d, fit=False), tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64]])
 
 ###
 # ppcc_max
 
-assert_type(ppcc_max(_f1d), np.float64)
-assert_type(ppcc_max(_f2d), np.float64)
+assert_type(ppcc_max(_f64_1d), np.float64)
+assert_type(ppcc_max(_f64_2d), np.float64)
 
 ###
 # ppcc_plot
 
-assert_type(ppcc_plot(_f1d, 0.0, 2.0), tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64]])
+assert_type(ppcc_plot(_f64_1d, 0.0, 2.0), tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64]])
 
 ###
 # anderson
 
-assert_type(anderson(_f1d), AndersonResult)  # pyright: ignore[reportDeprecated]  # pyrefly: ignore[deprecated]
-assert_type(anderson(_fnd), AndersonResult)  # pyright: ignore[reportDeprecated]  # pyrefly: ignore[deprecated]
+assert_type(anderson(_f64_1d), AndersonResult)  # pyright: ignore[reportDeprecated]  # pyrefly: ignore[deprecated]
+assert_type(anderson(_f64_nd), AndersonResult)  # pyright: ignore[reportDeprecated]  # pyrefly: ignore[deprecated]
 
 ###
 # anderson_ksamp
 
-assert_type(anderson_ksamp(_fnd), Anderson_ksampResult)
+assert_type(anderson_ksamp(_f64_nd), Anderson_ksampResult)
 
 ###
 # shapiro
 
-assert_type(shapiro(_fnd), ShapiroResult[np.float64])
-assert_type(shapiro(_fnd, axis=None), ShapiroResult[np.float64])
-assert_type(shapiro(_fnd, axis=0), ShapiroResult)
-assert_type(shapiro(_fnd, keepdims=True), ShapiroResult[onp.ArrayND[np.float64]])
+assert_type(shapiro(_f64_nd), ShapiroResult[np.float64])
+assert_type(shapiro(_f64_nd, axis=None), ShapiroResult[np.float64])
+assert_type(shapiro(_f64_nd, axis=0), ShapiroResult)
+assert_type(shapiro(_f64_nd, keepdims=True), ShapiroResult[onp.ArrayND[np.float64]])
 
 ###
 # ansari
 
-assert_type(ansari(_fnd, _fnd, axis=None), AnsariResult[np.float64])
-assert_type(ansari(_fnd, _fnd, keepdims=True), AnsariResult[onp.ArrayND[np.float64]])
-assert_type(ansari(_fnd, _fnd), AnsariResult)
+assert_type(ansari(_f64_nd, _f64_nd, axis=None), AnsariResult[np.float64])
+assert_type(ansari(_f64_nd, _f64_nd, keepdims=True), AnsariResult[onp.ArrayND[np.float64]])
+assert_type(ansari(_f64_nd, _f64_nd), AnsariResult)
 
 ###
 # bartlett
 
-assert_type(bartlett(_fnd, _fnd, axis=None), BartlettResult[np.float64])
-assert_type(bartlett(_fnd, _fnd, keepdims=True), BartlettResult[onp.ArrayND[np.float64]])
-assert_type(bartlett(_fnd, _fnd), BartlettResult)
+assert_type(bartlett(_f64_nd, _f64_nd, axis=None), BartlettResult[np.float64])
+assert_type(bartlett(_f64_nd, _f64_nd, keepdims=True), BartlettResult[onp.ArrayND[np.float64]])
+assert_type(bartlett(_f64_nd, _f64_nd), BartlettResult)
 
 ###
 # levene
 
-assert_type(levene(_fnd, _fnd), LeveneResult[np.float64 | onp.ArrayND[np.float64]])
-assert_type(levene(_fnd, _fnd, axis=None), LeveneResult[np.float64])
-assert_type(levene(_fnd, _fnd, keepdims=True), LeveneResult[onp.ArrayND[np.float64]])
+assert_type(levene(_f64_nd, _f64_nd), LeveneResult[np.float64 | onp.ArrayND[np.float64]])
+assert_type(levene(_f64_nd, _f64_nd, axis=None), LeveneResult[np.float64])
+assert_type(levene(_f64_nd, _f64_nd, keepdims=True), LeveneResult[onp.ArrayND[np.float64]])
 
 ###
 # fligner
 
-assert_type(fligner(_fnd, _fnd, axis=None), FlignerResult[np.float64])
-assert_type(fligner(_fnd, _fnd, keepdims=True), FlignerResult[onp.ArrayND[np.float64]])
-assert_type(fligner(_fnd, _fnd), FlignerResult)
+assert_type(fligner(_f64_nd, _f64_nd, axis=None), FlignerResult[np.float64])
+assert_type(fligner(_f64_nd, _f64_nd, keepdims=True), FlignerResult[onp.ArrayND[np.float64]])
+assert_type(fligner(_f64_nd, _f64_nd), FlignerResult)
 
 ###
 # mood
 
-assert_type(mood(_fnd, _fnd, None), SignificanceResult[np.float64])
-assert_type(mood(_fnd, _fnd, keepdims=True), SignificanceResult[onp.ArrayND[np.float64]])
-assert_type(mood(_fnd, _fnd), SignificanceResult[np.float64 | onp.ArrayND[np.float64]])
+assert_type(mood(_f64_nd, _f64_nd, None), SignificanceResult[np.float64])
+assert_type(mood(_f64_nd, _f64_nd, keepdims=True), SignificanceResult[onp.ArrayND[np.float64]])
+assert_type(mood(_f64_nd, _f64_nd), SignificanceResult[np.float64 | onp.ArrayND[np.float64]])
 
 ###
 # wilcoxon
 
-assert_type(wilcoxon(_fnd, axis=None), WilcoxonResult[np.float64])
-assert_type(wilcoxon(_fnd, keepdims=True), WilcoxonResult[onp.ArrayND[np.float64]])
-assert_type(wilcoxon(_fnd), WilcoxonResult)
+assert_type(wilcoxon(_f64_nd, axis=None), WilcoxonResult[np.float64])
+assert_type(wilcoxon(_f64_nd, keepdims=True), WilcoxonResult[onp.ArrayND[np.float64]])
+assert_type(wilcoxon(_f64_nd), WilcoxonResult)
 
 ###
 # median_test
 
-assert_type(median_test(_f1d, _f1d), MedianTestResult)
-assert_type(median_test(_f1d, _f1d, _f1d), MedianTestResult)
+assert_type(median_test(_f64_1d, _f64_1d), MedianTestResult)
+assert_type(median_test(_f64_1d, _f64_1d, _f64_1d), MedianTestResult)
 
 ###
 # circmean
 
-assert_type(circmean(_fnd), np.float64)
-assert_type(circmean(_fnd, axis=None), np.float64)
-assert_type(circmean(_fnd, axis=0), np.float64 | onp.ArrayND[np.float64])
-assert_type(circmean(_fnd, keepdims=True), onp.ArrayND[np.float64])
+assert_type(circmean(_f64_nd), np.float64)
+assert_type(circmean(_f64_nd, axis=None), np.float64)
+assert_type(circmean(_f64_nd, axis=0), np.float64 | onp.ArrayND[np.float64])
+assert_type(circmean(_f64_nd, keepdims=True), onp.ArrayND[np.float64])
 
 ###
 # circvar
 
-assert_type(circvar(_fnd), np.float64)
-assert_type(circvar(_fnd, axis=None), np.float64)
-assert_type(circvar(_fnd, axis=0), np.float64 | onp.ArrayND[np.float64])
-assert_type(circvar(_fnd, keepdims=True), onp.ArrayND[np.float64])
+assert_type(circvar(_f64_nd), np.float64)
+assert_type(circvar(_f64_nd, axis=None), np.float64)
+assert_type(circvar(_f64_nd, axis=0), np.float64 | onp.ArrayND[np.float64])
+assert_type(circvar(_f64_nd, keepdims=True), onp.ArrayND[np.float64])
 
 ###
 # circstd
 
-assert_type(circstd(_fnd), np.float64)
-assert_type(circstd(_fnd, axis=None), np.float64)
-assert_type(circstd(_fnd, axis=0), np.float64 | onp.ArrayND[np.float64])
-assert_type(circstd(_fnd, keepdims=True), onp.ArrayND[np.float64])
+assert_type(circstd(_f64_nd), np.float64)
+assert_type(circstd(_f64_nd, axis=None), np.float64)
+assert_type(circstd(_f64_nd, axis=0), np.float64 | onp.ArrayND[np.float64])
+assert_type(circstd(_f64_nd, keepdims=True), onp.ArrayND[np.float64])
+
+###
+# directional_stats
+
+assert_type(directional_stats(_i16_2d), DirectionalStats[onp.Array1D[np.float64], np.float64])
+assert_type(directional_stats(_f32_2d), DirectionalStats[onp.Array1D[np.float32], np.float32])
+assert_type(directional_stats(_f64_2d), DirectionalStats[onp.Array1D[np.float64], np.float64])
+assert_type(directional_stats(_c64_2d), DirectionalStats[onp.Array1D[np.complex64], np.float32])
+assert_type(directional_stats(_c128_2d), DirectionalStats[onp.Array1D[np.complex128], np.float64])
+assert_type(directional_stats(_c160_2d), DirectionalStats[onp.Array1D[np.clongdouble], np.longdouble])
+
+assert_type(directional_stats(_i16_3d), DirectionalStats[onp.Array2D[np.float64], onp.Array1D[np.float64]])
+assert_type(directional_stats(_f32_3d), DirectionalStats[onp.Array2D[np.float32], onp.Array1D[np.float32]])
+assert_type(directional_stats(_f64_3d), DirectionalStats[onp.Array2D[np.float64], onp.Array1D[np.float64]])
+assert_type(directional_stats(_c64_3d), DirectionalStats[onp.Array2D[np.complex64], onp.Array1D[np.float32]])
+assert_type(directional_stats(_c128_3d), DirectionalStats[onp.Array2D[np.complex128], onp.Array1D[np.float64]])
+assert_type(directional_stats(_c160_3d), DirectionalStats[onp.Array2D[np.clongdouble], onp.Array1D[np.longdouble]])
+
+assert_type(directional_stats(_i16_nd), DirectionalStats[onp.ArrayND[np.float64], np.float64 | onp.ArrayND[np.float64]])
+assert_type(directional_stats(_f32_nd), DirectionalStats[onp.ArrayND[np.float32], np.float32 | onp.ArrayND[np.float32]])
+assert_type(directional_stats(_f64_nd), DirectionalStats[onp.ArrayND[np.float64], np.float64 | onp.ArrayND[np.float64]])
+assert_type(directional_stats(_c64_nd), DirectionalStats[onp.ArrayND[np.complex64], np.float32 | onp.ArrayND[np.float32]])
+assert_type(directional_stats(_c128_nd), DirectionalStats[onp.ArrayND[np.complex128], np.float64 | onp.ArrayND[np.float64]])
+assert_type(
+    directional_stats(_c160_nd), DirectionalStats[onp.ArrayND[np.clongdouble], np.longdouble | onp.ArrayND[np.longdouble]]
+)
 
 ###
 # false_discovery_control
 
-assert_type(false_discovery_control(_f1d), onp.ArrayND[np.float64])
-assert_type(false_discovery_control(_fnd), onp.ArrayND[np.float64])
+assert_type(false_discovery_control(_f64_1d), onp.ArrayND[np.float64])
+assert_type(false_discovery_control(_f64_nd), onp.ArrayND[np.float64])
 assert_type(false_discovery_control(0.05), np.float64)


### PR DESCRIPTION
This fixes #1782 by adding shape-typing support to `direction_stats` by making the result class (`DirectionalStats`, not public API) a generic type with type parameters for its two attributes. This also fixes dtype propagation for the non-`float64` cases and adds support for complex input dtypes.