### PR TITLE
🐛 `sparse.linalg.aslinearoperator`: fix integer dtype propagation

### DIFF
--- a/scipy-stubs/sparse/linalg/_interface.pyi
+++ b/scipy-stubs/sparse/linalg/_interface.pyi
@@ -654,22 +654,16 @@ class IdentityOperator(LinearOperator[_SCT_co, _ShapeT_co], Generic[_SCT_co, _Sh
 
 #
 @overload
-def aslinearoperator[InexactT: npc.inexact, ShapeT: _Shape](
-    A: nptc.CanArray[ShapeT, np.dtype[InexactT]],
-) -> MatrixLinearOperator[InexactT, ShapeT]: ...
+def aslinearoperator[ScalarT: _Scalar, ShapeT: _Shape](
+    A: nptc.CanArray[ShapeT, np.dtype[ScalarT]],
+) -> MatrixLinearOperator[ScalarT, ShapeT]: ...
 @overload
-def aslinearoperator[InexactT: npc.inexact, ShapeT: _Shape](
-    A: _spbase[InexactT, ShapeT],
-) -> MatrixLinearOperator[InexactT, ShapeT]: ...
+def aslinearoperator[ScalarT: _Scalar, ShapeT: _Shape](A: _spbase[ScalarT, ShapeT]) -> MatrixLinearOperator[ScalarT, ShapeT]: ...
 @overload
-def aslinearoperator[ShapeT: _Shape](
-    A: onp.ArrayND[np.bool | npc.integer | np.float64, ShapeT] | _spbase[np.bool | npc.integer | np.float64, ShapeT],
-) -> MatrixLinearOperator[np.float64, ShapeT]: ...
+def aslinearoperator[ScalarT: npc.inexact, ShapeT: _Shape](
+    A: _HasShapeAndDTypeAndMatVec[ScalarT, ShapeT],
+) -> MatrixLinearOperator[ScalarT, ShapeT]: ...
 @overload
-def aslinearoperator[InexactT: npc.inexact, ShapeT: _Shape](
-    A: _HasShapeAndDTypeAndMatVec[InexactT, ShapeT],
-) -> MatrixLinearOperator[InexactT, ShapeT]: ...
-@overload
-def aslinearoperator[InexactT: npc.inexact, ShapeT: _Shape](
-    A: _HasShapeAndMatVec[InexactT, ShapeT],
-) -> MatrixLinearOperator[InexactT, ShapeT]: ...
+def aslinearoperator[ScalarT: npc.inexact, ShapeT: _Shape](
+    A: _HasShapeAndMatVec[ScalarT, ShapeT],
+) -> MatrixLinearOperator[ScalarT, ShapeT]: ...

--- a/tests/sparse/linalg/test__interface.pyi
+++ b/tests/sparse/linalg/test__interface.pyi
@@ -15,6 +15,7 @@ _type_complex: type[complex]
 _2d: tuple[int, int]
 _3d: tuple[int, int, int]
 
+_2d_bool: onp.Array2D[np.bool]
 _2d_i64: onp.Array2D[np.int64]
 _2d_f64: onp.Array2D[np.float64]
 _2d_c128: onp.Array2D[np.complex128]
@@ -23,6 +24,7 @@ _3d_i64: onp.Array3D[np.int64]
 _3d_f64: onp.Array3D[np.float64]
 _3d_c128: onp.Array3D[np.complex128]
 
+_sp_i64: csr_array[np.int64]
 _sp_f64: csr_array[np.float64]
 _sp_c128: csr_array[np.complex128]
 
@@ -48,11 +50,13 @@ assert_type(LinearOperator(_3d, matvec=mv), _CustomLinearOperator[np.int8 | Any,
 
 assert_type(aslinearoperator(_2d_f64), MatrixLinearOperator[np.float64, tuple[int, int]])
 assert_type(aslinearoperator(_2d_c128), MatrixLinearOperator[np.complex128, tuple[int, int]])
-assert_type(aslinearoperator(_2d_i64), MatrixLinearOperator[np.float64, tuple[int, int]])
+assert_type(aslinearoperator(_2d_i64), MatrixLinearOperator[np.int64, tuple[int, int]])
+assert_type(aslinearoperator(_2d_bool), MatrixLinearOperator[np.bool, tuple[int, int]])
 
 assert_type(aslinearoperator(_3d_f64), MatrixLinearOperator[np.float64, tuple[int, int, int]])
 assert_type(aslinearoperator(_3d_c128), MatrixLinearOperator[np.complex128, tuple[int, int, int]])
-assert_type(aslinearoperator(_3d_i64), MatrixLinearOperator[np.float64, tuple[int, int, int]])
+assert_type(aslinearoperator(_3d_i64), MatrixLinearOperator[np.int64, tuple[int, int, int]])
 
+assert_type(aslinearoperator(_sp_i64), MatrixLinearOperator[np.int64, tuple[int, int]])
 assert_type(aslinearoperator(_sp_f64), MatrixLinearOperator[np.float64, tuple[int, int]])
 assert_type(aslinearoperator(_sp_c128), MatrixLinearOperator[np.complex128, tuple[int, int]])


### PR DESCRIPTION
fixes #1814