### PR TITLE
🐛 `io.FortranFile.read_record`: fix dtype and dtype tuple propagation

### DIFF
--- a/scipy-stubs/io/_fortran.pyi
+++ b/scipy-stubs/io/_fortran.pyi
@@ -1,4 +1,4 @@
-from typing import Literal, Self, overload
+from typing import Any, Literal, Self, overload
 
 import numpy as np
 import optype.numpy as onp
@@ -11,10 +11,6 @@ __all__ = ["FortranEOFError", "FortranFile", "FortranFormattingError"]
 
 ###
 
-type _FileModeRW = Literal["r", "w"]
-
-###
-
 class FortranEOFError(TypeError, OSError): ...
 class FortranFormattingError(TypeError, OSError): ...
 
@@ -23,7 +19,7 @@ class FortranFile(ExitMixin):
         self,
         /,
         filename: FileLike[bytes],
-        mode: _FileModeRW = "r",
+        mode: Literal["r", "w"] = "r",
         header_dtype: onp.AnyDType = np.uint32,  # noqa: PYI011
     ) -> None: ...
 
@@ -33,7 +29,39 @@ class FortranFile(ExitMixin):
 
     #
     def write_record(self, /, *items: onp.ToArrayND) -> None: ...
-    def read_record(self, /, *dtypes: onp.ToDType, dtype: onp.ToDType | None = None) -> onp.Array1D[np.void]: ...
+
+    #
+    @overload
+    def read_record[ScalarT: np.generic](
+        self, dtype0: onp.ToDType[ScalarT], /, *, dtype: None = None
+    ) -> onp.Array1D[ScalarT]: ...
+    @overload
+    def read_record[ScalarT: np.generic](self, /, *, dtype: onp.ToDType[ScalarT]) -> onp.Array1D[ScalarT]: ...
+    @overload
+    def read_record(self, dtype0: str | type, /, *, dtype: None = None) -> onp.Array1D: ...
+    @overload
+    def read_record(self, /, *, dtype: str | type) -> onp.Array1D: ...
+    @overload
+    def read_record[T1: np.generic, T2: np.generic](
+        self, dtype0: onp.ToDType[T1], dtype1: onp.ToDType[T2], /, *, dtype: None = None
+    ) -> tuple[onp.Array1D[T1], onp.Array1D[T2]]: ...
+    @overload
+    def read_record[T1: np.generic, T2: np.generic](
+        self, dtype0: onp.ToDType[T1], /, *, dtype: onp.ToDType[T2]
+    ) -> tuple[onp.Array1D[T1], onp.Array1D[T2]]: ...
+    @overload
+    def read_record(
+        self,
+        dtype0: np.dtype[Any] | str | type,
+        dtype1: np.dtype[Any] | str | type,
+        /,
+        *dtypes: np.dtype[Any] | str | type,
+        dtype: np.dtype[Any] | str | type | None = None,
+    ) -> tuple[onp.Array1D, ...]: ...
+    @overload
+    def read_record(
+        self, dtype0: np.dtype[Any] | str | type, /, *, dtype: np.dtype[Any] | str | type
+    ) -> tuple[onp.Array1D, ...]: ...
 
     #
     @overload

--- a/tests/io/test_fortran.pyi
+++ b/tests/io/test_fortran.pyi
@@ -9,12 +9,23 @@ _i32_1d: onp.Array1D[np.int32]
 
 ###
 
-f = FortranFile("test.unf", "w")
-assert_type(f, FortranFile)
-assert_type(f.write_record(_i32_1d), None)
-assert_type(f.read_record(), onp.Array1D[np.void])
-assert_type(f.read_ints(), onp.Array1D[np.int32])
-assert_type(f.read_ints(np.int16), onp.Array1D[np.int16])
-assert_type(f.read_reals(), onp.Array1D[np.float64])
-assert_type(f.read_reals(np.float32), onp.Array1D[np.float32])
-assert_type(f.close(), None)
+_f = FortranFile("test.unf", "w")
+assert_type(_f, FortranFile)
+assert_type(_f.write_record(_i32_1d), None)
+
+_f.read_record()  # type:ignore[call-overload] # pyright:ignore[reportCallIssue] # pyrefly:ignore[no-matching-overload]
+
+assert_type(_f.read_record(np.float32), onp.Array1D[np.float32])
+assert_type(_f.read_record(dtype=np.float64), onp.Array1D[np.float64])
+assert_type(_f.read_record("<f4"), onp.Array1D)
+assert_type(_f.read_record(dtype="<f4"), onp.Array1D)
+assert_type(_f.read_record(np.float32, np.int32), tuple[onp.Array1D[np.float32], onp.Array1D[np.int32]])
+assert_type(_f.read_record(np.float32, dtype=np.int32), tuple[onp.Array1D[np.float32], onp.Array1D[np.int32]])
+assert_type(_f.read_record("<f4", "<i4"), tuple[onp.Array1D, ...])
+assert_type(_f.read_record("<f4", "<i4", "<i2"), tuple[onp.Array1D, ...])
+assert_type(_f.read_record("<f4", dtype="<i4"), tuple[onp.Array1D, ...])
+assert_type(_f.read_ints(), onp.Array1D[np.int32])
+assert_type(_f.read_ints(np.int16), onp.Array1D[np.int16])
+assert_type(_f.read_reals(), onp.Array1D[np.float64])
+assert_type(_f.read_reals(np.float32), onp.Array1D[np.float32])
+assert_type(_f.close(), None)


### PR DESCRIPTION
fixes #1838