### PR TITLE
🐛 `sparse.csgraph`: fix return dtype propagation

### DIFF
--- a/scipy-stubs/sparse/csgraph/_flow.pyi
+++ b/scipy-stubs/sparse/csgraph/_flow.pyi
@@ -1,6 +1,7 @@
 from typing import Final, Literal
 
 import numpy as np
+import optype.numpy.compat as npc
 
 from scipy.sparse import csr_array
 
@@ -10,11 +11,15 @@ DTYPE: Final[type[np.float64]] = ...
 ITYPE: Final[type[np.int32]] = ...
 
 class MaximumFlowResult:
-    flow_value: Final[int | np.int32 | np.int64]
-    flow: csr_array[np.float64, tuple[int, int]]
+    flow_value: Final[np.int_]
+    flow: csr_array[np.int32, tuple[int, int]]
 
-    def __init__(self, /, flow_value: int | np.int32 | np.int64, flow: csr_array[np.float64, tuple[int, int]]) -> None: ...
+    def __init__(self, /, flow_value: np.int_, flow: csr_array[np.int32, tuple[int, int]]) -> None: ...
 
 def maximum_flow(
-    csgraph: csr_array, source: int, sink: int, *, method: Literal["edmonds_karp", "dinic"] = "dinic"
+    csgraph: csr_array[npc.integer, tuple[int, int]],
+    source: int,
+    sink: int,
+    *,
+    method: Literal["edmonds_karp", "dinic"] = "dinic",
 ) -> MaximumFlowResult: ...

--- a/scipy-stubs/sparse/csgraph/_min_spanning_tree.pyi
+++ b/scipy-stubs/sparse/csgraph/_min_spanning_tree.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Final, overload
+from typing import Final
 
 import numpy as np
 import optype.numpy as onp
@@ -9,20 +9,9 @@ from scipy.sparse._base import _spbase
 
 ###
 
-type _Graph[RealT: npc.integer | npc.floating] = onp.CanArrayND[RealT] | _spbase[RealT, tuple[int, int]]
-
-###
-
 DTYPE: Final[type[np.float64]] = ...
 ITYPE: Final[type[np.int32]] = ...
 
-@overload
-def minimum_spanning_tree[RealT: npc.integer | npc.floating](
-    csgraph: _Graph[RealT], overwrite: bool = False
-) -> csr_array[RealT, tuple[int, int]]: ...
-@overload
-def minimum_spanning_tree(csgraph: onp.ToJustInt2D, overwrite: bool = False) -> csr_array[np.int_, tuple[int, int]]: ...
-@overload
-def minimum_spanning_tree(csgraph: onp.ToJustFloat64_2D, overwrite: bool = False) -> csr_array[np.float64, tuple[int, int]]: ...
-@overload
-def minimum_spanning_tree(csgraph: onp.ToFloat2D, overwrite: bool = False) -> csr_array[Any, tuple[int, int]]: ...
+def minimum_spanning_tree(
+    csgraph: onp.ToFloat2D | _spbase[npc.integer | npc.floating, tuple[int, int]], overwrite: bool = False
+) -> csr_array[np.float64, tuple[int, int]]: ...

--- a/scipy-stubs/sparse/csgraph/_tools.pyi
+++ b/scipy-stubs/sparse/csgraph/_tools.pyi
@@ -1,4 +1,5 @@
-from typing import Final, overload
+from collections.abc import Sequence
+from typing import Any, Final, overload
 
 import numpy as np
 import optype.numpy as onp
@@ -18,7 +19,6 @@ type _SparseGraph[RealT: _Real] = (
 )  # fmt: skip
 
 type _ToGraph = onp.ToFloat2D | _spbase[_Real, tuple[int, int]]
-type _Graph[RealT: _Real] = onp.CanArray2D[RealT] | _spbase[RealT, tuple[int, int]]
 
 ###
 
@@ -26,81 +26,43 @@ DTYPE: Final[type[np.float64]] = ...
 ITYPE: Final[type[np.int32]] = ...
 
 #
-@overload
-def csgraph_from_masked(graph: onp.MArray2D[npc.integer]) -> csr_array[np.int32, tuple[int, int]]: ...
-@overload
-def csgraph_from_masked(graph: onp.MArray2D[npc.floating]) -> csr_array[np.float64, tuple[int, int]]: ...
-@overload
-def csgraph_from_masked(graph: onp.MArray2D[_Real]) -> csr_array[np.float64 | np.int32, tuple[int, int]]: ...
+def csgraph_from_masked(graph: onp.MArray2D[_Real]) -> csr_array[np.float64, tuple[int, int]]: ...
 
 #
 @overload
-def csgraph_masked_from_dense(
-    graph: onp.ToInt2D, null_value: int | None = 0, nan_null: bool = True, infinity_null: bool = True, copy: bool = True
-) -> onp.MArray2D[np.int32]: ...
+def csgraph_masked_from_dense[ScalarT: npc.number | np.bool](
+    graph: onp.ArrayND[ScalarT], null_value: int | None = 0, nan_null: bool = True, infinity_null: bool = True, copy: bool = True
+) -> onp.MArray2D[ScalarT]: ...
 @overload
 def csgraph_masked_from_dense(
-    graph: onp.ToJustFloat2D, null_value: float | None = 0, nan_null: bool = True, infinity_null: bool = True, copy: bool = True
+    graph: Sequence[list[int]], null_value: int | None = 0, nan_null: bool = True, infinity_null: bool = True, copy: bool = True
+) -> onp.MArray2D[np.int_]: ...
+@overload
+def csgraph_masked_from_dense(
+    graph: Sequence[list[float]], null_value: int | None = 0, nan_null: bool = True, infinity_null: bool = True, copy: bool = True
 ) -> onp.MArray2D[np.float64]: ...
 @overload
 def csgraph_masked_from_dense(
-    graph: onp.ToFloat2D, null_value: float | None = 0, nan_null: bool = True, infinity_null: bool = True, copy: bool = True
-) -> onp.MArray2D[np.float64 | np.int32]: ...
+    graph: onp.ToComplex2D, null_value: float | None = 0, nan_null: bool = True, infinity_null: bool = True, copy: bool = True
+) -> onp.MArray2D[Any]: ...
 
 #
-@overload
-def csgraph_from_dense(
-    graph: onp.ToInt2D, null_value: int | None = 0, nan_null: bool = True, infinity_null: bool = True
-) -> csr_array[np.int32, tuple[int, int]]: ...
-@overload
-def csgraph_from_dense(
-    graph: onp.ToJustFloat2D, null_value: float | None = 0, nan_null: bool = True, infinity_null: bool = True
-) -> csr_array[np.float64, tuple[int, int]]: ...
-@overload
 def csgraph_from_dense(
     graph: onp.ToFloat2D, null_value: float | None = 0, nan_null: bool = True, infinity_null: bool = True
-) -> csr_array[np.float64 | np.int32, tuple[int, int]]: ...
-
-#
-@overload
-def csgraph_to_dense(csgraph: _SparseGraph[npc.integer], null_value: int | None = 0) -> onp.Array2D[np.int32]: ...
-@overload
-def csgraph_to_dense(csgraph: _SparseGraph[npc.floating], null_value: float | None = 0) -> onp.Array2D[np.float64]: ...
-@overload
-def csgraph_to_dense(csgraph: _SparseGraph[_Real], null_value: float | None = 0) -> onp.Array2D[np.float64 | np.int32]: ...
-
-#
-@overload
-def csgraph_to_masked(csgraph: _SparseGraph[npc.integer]) -> onp.MArray2D[np.int32]: ...
-@overload
-def csgraph_to_masked(csgraph: _SparseGraph[npc.floating]) -> onp.MArray2D[np.float64]: ...
-@overload
-def csgraph_to_masked(csgraph: _SparseGraph[_Real]) -> onp.MArray2D[np.float64 | np.int32]: ...
-
-#
-@overload
-def reconstruct_path(
-    csgraph: _Graph[npc.integer], predecessors: onp.ToIntND, directed: bool = True
-) -> csr_array[np.int32, tuple[int, int]]: ...
-@overload
-def reconstruct_path(
-    csgraph: _Graph[npc.floating], predecessors: onp.ToFloatND, directed: bool = True
 ) -> csr_array[np.float64, tuple[int, int]]: ...
-@overload
+
+#
+def csgraph_to_dense(csgraph: _SparseGraph[_Real], null_value: float | None = 0) -> onp.Array2D[np.float64]: ...
+
+#
+def csgraph_to_masked(csgraph: _SparseGraph[_Real]) -> onp.MArray2D[np.float64]: ...
+
+#
 def reconstruct_path(
     csgraph: _ToGraph, predecessors: onp.ToFloatND, directed: bool = True
-) -> csr_array[np.float64 | np.int32, tuple[int, int]]: ...
+) -> csr_array[np.float64, tuple[int, int]]: ...
 
 #
-@overload
-def construct_dist_matrix(
-    graph: _Graph[npc.integer], predecessors: onp.ToIntND, directed: bool = True, null_value: float = ...
-) -> onp.Array2D[np.int32]: ...
-@overload
-def construct_dist_matrix(
-    graph: _Graph[npc.floating], predecessors: onp.ToFloatND, directed: bool = True, null_value: float = ...
-) -> onp.Array2D[np.float64]: ...
-@overload
 def construct_dist_matrix(
     graph: _ToGraph, predecessors: onp.ToFloatND, directed: bool = True, null_value: float = ...
-) -> onp.Array2D[np.float64 | np.int32]: ...
+) -> onp.Array2D[np.float64]: ...

--- a/scipy-stubs/sparse/csgraph/_traversal.pyi
+++ b/scipy-stubs/sparse/csgraph/_traversal.pyi
@@ -15,7 +15,6 @@ type _Real = npc.integer | npc.floating
 type _Int1D = onp.Array1D[np.int32]
 
 type _ToGraph = onp.ToFloat2D | _spbase[_Real, tuple[int, int]]
-type _Graph[RealT: _Real] = onp.CanArrayND[RealT] | _spbase[RealT, tuple[int, int]]
 
 ###
 
@@ -32,20 +31,10 @@ def connected_components(
 ) -> int: ...
 
 #
-@overload
-def breadth_first_tree[RealT: _Real](
-    csgraph: _Graph[RealT], i_start: int, directed: bool = True
-) -> csr_array[RealT, tuple[int, int]]: ...
-@overload
-def breadth_first_tree(csgraph: _ToGraph, i_start: int, directed: bool = True) -> csr_array[_Real, tuple[int, int]]: ...
+def breadth_first_tree(csgraph: _ToGraph, i_start: int, directed: bool = True) -> csr_array[np.float64, tuple[int, int]]: ...
 
 #
-@overload
-def depth_first_tree[RealT: _Real](
-    csgraph: _Graph[RealT], i_start: int, directed: bool = True
-) -> csr_array[RealT, tuple[int, int]]: ...
-@overload
-def depth_first_tree(csgraph: _ToGraph, i_start: int, directed: bool = True) -> csr_array[_Real, tuple[int, int]]: ...
+def depth_first_tree(csgraph: _ToGraph, i_start: int, directed: bool = True) -> csr_array[np.float64, tuple[int, int]]: ...
 
 #
 @overload

--- a/tests/sparse/csgraph/test_flow.pyi
+++ b/tests/sparse/csgraph/test_flow.pyi
@@ -9,13 +9,12 @@ from scipy.sparse.csgraph import maximum_flow
 
 ###
 
-_csr_arr: sparse.csr_array[np.float64, tuple[int, int]]
+_csr_arr: sparse.csr_array[np.int8, tuple[int, int]]
 
 ###
 
 # maximum_flow
 
 _flow = maximum_flow(_csr_arr, 0, 1)
-
-assert_type(_flow.flow_value, int | np.int32 | np.int64)
-assert_type(_flow.flow, sparse.csr_array[np.float64, tuple[int, int]])
+assert_type(_flow.flow_value, np.int_)
+assert_type(_flow.flow, sparse.csr_array[np.int32, tuple[int, int]])

--- a/tests/sparse/csgraph/test_shortest_path.pyi
+++ b/tests/sparse/csgraph/test_shortest_path.pyi
@@ -22,7 +22,7 @@ assert_type(bellman_ford(_csr_arr, return_predecessors=True), tuple[onp.Array2D[
 
 # minimum_spanning_tree
 
-assert_type(minimum_spanning_tree(_csr_arr), sparse.csr_array[_ScalarType, tuple[int, int]])
+assert_type(minimum_spanning_tree(_csr_arr), sparse.csr_array[np.float64, tuple[int, int]])
 
 # shortest_path
 

--- a/tests/sparse/csgraph/test_tools.pyi
+++ b/tests/sparse/csgraph/test_tools.pyi
@@ -33,12 +33,12 @@ _pred_float: onp.Array2D[np.float64]
 
 # csgraph_from_dense
 
-assert_type(csgraph_from_dense(_int_graph), sparse.csr_array[np.int32, tuple[int, int]])
+assert_type(csgraph_from_dense(_int_graph), sparse.csr_array[np.float64, tuple[int, int]])
 assert_type(csgraph_from_dense(_float_graph), sparse.csr_array[np.float64, tuple[int, int]])
 
 # csgraph_from_masked
 
-assert_type(csgraph_from_masked(_masked_int_graph), sparse.csr_array[np.int32, tuple[int, int]])
+assert_type(csgraph_from_masked(_masked_int_graph), sparse.csr_array[np.float64, tuple[int, int]])
 assert_type(csgraph_from_masked(_masked_float_graph), sparse.csr_array[np.float64, tuple[int, int]])
 
 # csgraph_masked_from_dense
@@ -48,20 +48,20 @@ assert_type(csgraph_masked_from_dense(_float_graph), onp.MArray2D[np.float64])
 
 # csgraph_to_dense
 
-assert_type(csgraph_to_dense(_csr_int), onp.Array2D[np.int32])
+assert_type(csgraph_to_dense(_csr_int), onp.Array2D[np.float64])
 assert_type(csgraph_to_dense(_csr_float), onp.Array2D[np.float64])
 
 # csgraph_to_masked
 
-assert_type(csgraph_to_masked(_csr_int), onp.MArray2D[np.int32])
+assert_type(csgraph_to_masked(_csr_int), onp.MArray2D[np.float64])
 assert_type(csgraph_to_masked(_csr_float), onp.MArray2D[np.float64])
 
 # reconstruct_path
 
-assert_type(reconstruct_path(_int_graph, _pred_int), sparse.csr_array[np.int32, tuple[int, int]])
+assert_type(reconstruct_path(_int_graph, _pred_int), sparse.csr_array[np.float64, tuple[int, int]])
 assert_type(reconstruct_path(_float_graph, _pred_float), sparse.csr_array[np.float64, tuple[int, int]])
 
 # construct_dist_matrix
 
-assert_type(construct_dist_matrix(_int_graph, _pred_int), onp.Array2D[np.int32])
+assert_type(construct_dist_matrix(_int_graph, _pred_int), onp.Array2D[np.float64])
 assert_type(construct_dist_matrix(_float_graph, _pred_float), onp.Array2D[np.float64])

--- a/tests/sparse/csgraph/test_traversal.pyi
+++ b/tests/sparse/csgraph/test_traversal.pyi
@@ -29,7 +29,7 @@ assert_type(breadth_first_order(_csr_arr, 0), tuple[onp.Array1D[np.int32], onp.A
 
 # breadth_first_tree
 
-assert_type(breadth_first_tree(_csr_arr, 0), sparse.csr_array[_ScalarType, tuple[int, int]])
+assert_type(breadth_first_tree(_csr_arr, 0), sparse.csr_array[np.float64, tuple[int, int]])
 
 # depth_first_order
 
@@ -39,7 +39,7 @@ assert_type(depth_first_order(_csr_arr, 0), tuple[onp.Array1D[np.int32], onp.Arr
 
 # depth_first_tree
 
-assert_type(depth_first_tree(_csr_arr, 0), sparse.csr_array[_ScalarType, tuple[int, int]])
+assert_type(depth_first_tree(_csr_arr, 0), sparse.csr_array[np.float64, tuple[int, int]])
 
 # connected_components
 


### PR DESCRIPTION
This fixes incorrect dtype propagation of the following public `scipy.sparse.csgraph` functions:

- `csgraph_from_dense`
- `csgraph_from_masked`
- `csgraph_to_dense`
- `reconstruct_path`
- `construct_dist_matrix`
- `csgraph_masked_from_dense`
- `minimum_spanning_tree`
- `breadth_first_tree`
- `depth_first_tree`
- `minimum_spanning_tree`
- `maximum_flow` / `MaximumFlowResult`

fixes #1766