### PR TITLE
🐛 `stats.binned_statistic[_2d]`: fix `.binnumber` shape-type and gradual `.statistic` scalar-type

### DIFF
--- a/scipy-stubs/stats/_binned_statistic.pyi
+++ b/scipy-stubs/stats/_binned_statistic.pyi
@@ -1,10 +1,9 @@
 from collections.abc import Callable, Sequence
-from typing import Generic, Literal, NamedTuple, overload
+from typing import Any, Generic, Literal, NamedTuple, overload
 from typing_extensions import TypeVar
 
 import numpy as np
 import optype.numpy as onp
-import optype.numpy.compat as npc
 
 __all__ = ["binned_statistic", "binned_statistic_2d", "binned_statistic_dd"]
 
@@ -12,12 +11,14 @@ __all__ = ["binned_statistic", "binned_statistic_2d", "binned_statistic_dd"]
 
 type _Statistic = Literal["mean", "std", "median", "count", "sum", "min", "max"]
 
-_ShapeT_co = TypeVar("_ShapeT_co", bound=tuple[int] | tuple[int, int], covariant=True, default=tuple[int] | tuple[int, int])
+_ShapeT_co = TypeVar(
+    "_ShapeT_co", bound=tuple[int, int] | tuple[int, int, int], covariant=True, default=tuple[int, int] | tuple[int, int, int]
+)
 
 ###
 
 class BinnedStatisticResult(NamedTuple):
-    statistic: onp.Array1D[npc.inexact]
+    statistic: onp.Array1D[Any]
     bin_edges: onp.Array1D[np.float64]
     binnumber: onp.Array1D[np.intp]
 
@@ -30,7 +31,7 @@ def binned_statistic(
 ) -> BinnedStatisticResult: ...
 
 class BinnedStatistic2dResult(NamedTuple, Generic[_ShapeT_co]):
-    statistic: onp.Array2D[npc.inexact]
+    statistic: onp.Array2D[Any]
     x_edge: onp.Array1D[np.float64]
     y_edge: onp.Array1D[np.float64]
     binnumber: onp.Array[_ShapeT_co, np.intp]
@@ -45,7 +46,7 @@ def binned_statistic_2d(
     bins: onp.ToInt | onp.ToFloat1D | Sequence[onp.ToFloat1D] = 10,
     range: tuple[int, int] | None = None,
     expand_binnumbers: Literal[False] = False,
-) -> BinnedStatistic2dResult[tuple[int]]: ...
+) -> BinnedStatistic2dResult[tuple[int, int]]: ...
 @overload
 def binned_statistic_2d(
     x: onp.ToComplex1D,
@@ -56,10 +57,10 @@ def binned_statistic_2d(
     range: tuple[int, int] | None = None,
     *,
     expand_binnumbers: Literal[True],
-) -> BinnedStatistic2dResult[tuple[int, int]]: ...
+) -> BinnedStatistic2dResult[tuple[int, int, int]]: ...
 
 class BinnedStatisticddResult(NamedTuple, Generic[_ShapeT_co]):
-    statistic: onp.ArrayND[npc.inexact]
+    statistic: onp.ArrayND[Any]
     bin_edges: list[onp.Array1D[np.float64]]
     binnumber: onp.Array[_ShapeT_co, np.intp]
 
@@ -73,7 +74,7 @@ def binned_statistic_dd(
     range: tuple[int, int] | None = None,
     expand_binnumbers: Literal[False] = False,
     binned_statistic_result: BinnedStatisticddResult | None = None,
-) -> BinnedStatisticddResult[tuple[int]]: ...
+) -> BinnedStatisticddResult[tuple[int, int]]: ...
 @overload
 def binned_statistic_dd(
     sample: onp.ToComplex2D,
@@ -84,4 +85,4 @@ def binned_statistic_dd(
     *,
     expand_binnumbers: Literal[True],
     binned_statistic_result: BinnedStatisticddResult | None = None,
-) -> BinnedStatisticddResult[tuple[int, int]]: ...
+) -> BinnedStatisticddResult[tuple[int, int, int]]: ...

--- a/tests/stats/test_binned_statistic.pyi
+++ b/tests/stats/test_binned_statistic.pyi
@@ -15,10 +15,10 @@ _f64_1d: onp.Array1D[np.float64]
 
 assert_type(binned_statistic(_f64_1d, _f64_1d).binnumber, onp.Array1D[np.intp])
 
-assert_type(binned_statistic_2d(_f64_1d, _f64_1d, _f64_1d).binnumber, onp.Array1D[np.intp])
-assert_type(binned_statistic_2d(_f64_1d, _f64_1d, _f64_1d, expand_binnumbers=False).binnumber, onp.Array1D[np.intp])
-assert_type(binned_statistic_2d(_f64_1d, _f64_1d, _f64_1d, expand_binnumbers=True).binnumber, onp.Array2D[np.intp])
+assert_type(binned_statistic_2d(_f64_1d, _f64_1d, _f64_1d).binnumber, onp.Array2D[np.intp])
+assert_type(binned_statistic_2d(_f64_1d, _f64_1d, _f64_1d, expand_binnumbers=False).binnumber, onp.Array2D[np.intp])
+assert_type(binned_statistic_2d(_f64_1d, _f64_1d, _f64_1d, expand_binnumbers=True).binnumber, onp.Array3D[np.intp])
 
-assert_type(binned_statistic_dd(_f64_1d, _f64_1d).binnumber, onp.Array1D[np.intp])
-assert_type(binned_statistic_dd(_f64_1d, _f64_1d, expand_binnumbers=False).binnumber, onp.Array1D[np.intp])
-assert_type(binned_statistic_dd(_f64_1d, _f64_1d, expand_binnumbers=True).binnumber, onp.Array2D[np.intp])
+assert_type(binned_statistic_dd(_f64_1d, _f64_1d).binnumber, onp.Array2D[np.intp])
+assert_type(binned_statistic_dd(_f64_1d, _f64_1d, expand_binnumbers=False).binnumber, onp.Array2D[np.intp])
+assert_type(binned_statistic_dd(_f64_1d, _f64_1d, expand_binnumbers=True).binnumber, onp.Array3D[np.intp])


### PR DESCRIPTION
Fixes #1788, and replaces the awkward `inexact` sctype of the `.statistic`  array attrs with `Any`.