### PR TITLE
⬆️ increase `optype` lower bound from `0.14` to `0.15`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ classifiers = [
   "Typing :: Stubs Only",
 ]
 requires-python = ">=3.12"
-dependencies = ["optype[numpy]>=0.14.0,<0.19"]
+dependencies = ["optype[numpy]>=0.15.0,<0.20"]
 
 [project.optional-dependencies]
 scipy = ["scipy>=1.18.0,<1.19"]

--- a/uv.lock
+++ b/uv.lock
@@ -1109,7 +1109,7 @@ type = [
 
 [package.metadata]
 requires-dist = [
-    { name = "optype", extras = ["numpy"], specifier = ">=0.14.0,<0.19" },
+    { name = "optype", extras = ["numpy"], specifier = ">=0.15.0,<0.20" },
     { name = "scipy", marker = "extra == 'scipy'", specifier = ">=1.18.0,<1.19" },
 ]
 provides-extras = ["scipy"]


### PR DESCRIPTION
This also loosens the upper bound on `optype` from `<0.19` to `<0.20`.