### PR TITLE
🐛 `stats.sampling.FastGeneratorInversion`: fix `.qrvs()` return type for `size=(1,)`

### DIFF
--- a/scipy-stubs/stats/_sampling.pyi
+++ b/scipy-stubs/stats/_sampling.pyi
@@ -46,39 +46,52 @@ class FastGeneratorInversion:
         ignore_shape_range: bool = False,
         random_state: onp.random.ToRNG | None = None,
     ) -> None: ...
+
+    #
     @property
     def random_state(self, /) -> np.random.Generator: ...
     @random_state.setter
     def random_state(self, random_state: onp.random.ToRNG | None, /) -> None: ...
+
+    #
     @property
     def loc(self, /) -> float | np.float64: ...
     @loc.setter
     def loc(self, loc: onp.ToFloat, /) -> None: ...
+
+    #
     @property
     def scale(self, /) -> float | np.float64: ...
     @scale.setter
     def scale(self, scale: onp.ToFloat, /) -> None: ...
+
+    #
     @overload
     def rvs(self, /, size: None = None) -> np.float64: ...
     @overload
     def rvs(self, /, size: AnyShape) -> onp.ArrayND[np.float64]: ...
+
+    #
     @overload
-    def qrvs(
-        self, /, size: tuple[Literal[1]] | None = None, d: int | None = None, qmc_engine: QMCEngine | None = None
-    ) -> np.float64: ...
+    def qrvs(self, /, size: None = None, d: int | None = None, qmc_engine: QMCEngine | None = None) -> np.float64: ...
     @overload
-    def qrvs(
-        self, /, size: AnyShape, d: int | None = None, qmc_engine: QMCEngine | None = None
-    ) -> np.float64 | onp.ArrayND[np.float64]: ...
+    def qrvs(self, /, size: AnyShape, d: int | None = None, qmc_engine: QMCEngine | None = None) -> onp.ArrayND[np.float64]: ...
+
+    #
     @overload
     def ppf(self, /, q: onp.ToFloat) -> np.float64: ...
     @overload
     def ppf(self, /, q: onp.ToFloatND) -> onp.ArrayND[np.float64]: ...
+
+    #
     def evaluate_error(
         self, /, size: int = 100_000, random_state: onp.random.ToRNG | None = None, x_error: bool = False
     ) -> tuple[np.float64, np.float64]: ...
+
+    #
     def support(self, /) -> tuple[float, float] | tuple[np.float64, np.float64]: ...
 
+#
 def argus_pdf(x: onp.ToFloat, chi: onp.ToFloat) -> float: ...  # undocumented
 def argus_gamma_trf(x: onp.ToFloat, chi: onp.ToFloat) -> np.float64: ...  # undocumented
 def argus_gamma_inv_trf(x: onp.ToFloat, chi: onp.ToFloat) -> onp.ToFloat: ...  # undocumented


### PR DESCRIPTION
fixes #1863