### PR TITLE
🐛 `ndimage`: `labeled_comprehension` ignores `out_dtype` when `index=None`; reject `labels=None` with non-`None` `index`

### DIFF
--- a/scipy-stubs/ndimage/_measurements.pyi
+++ b/scipy-stubs/ndimage/_measurements.pyi
@@ -29,10 +29,9 @@ __all__ = [
 ]
 
 ###
-
-type __Func1 = Callable[[onp.ToComplex | onp.ToComplexND], onp.ToComplex]
-type __Func2 = Callable[[onp.ToComplex | onp.ToComplexND, onp.ToComplex | onp.ToComplexND], onp.ToComplex]
-type _ComprehensionFunc = __Func1 | __Func2
+type __Func1[T] = Callable[[onp.ToComplex | onp.ToComplexND], T]
+type __Func2[T] = Callable[[onp.ToComplex | onp.ToComplexND, onp.ToComplex | onp.ToComplexND], T]
+type _ComprehensionFunc[T] = __Func1[T] | __Func2[T]
 
 type _Idx0D = tuple[np.intp, ...]
 type _IdxND = list[_Idx0D]
@@ -72,11 +71,21 @@ def value_indices(
 
 #
 @overload
-def labeled_comprehension[ScalarT: npc.number | np.bool](
+def labeled_comprehension[T](
     input: onp.ToComplex | onp.ToComplexND,
     labels: onp.ToComplex | onp.ToComplexND | None,
-    index: onp.ToInt | None,
-    func: _ComprehensionFunc,
+    index: None,
+    func: _ComprehensionFunc[T],
+    out_dtype: object,
+    default: object,
+    pass_positions: bool = False,
+) -> T: ...
+@overload
+def labeled_comprehension[ScalarT: npc.number | np.bool](
+    input: onp.ToComplex | onp.ToComplexND,
+    labels: onp.ToComplex | onp.ToComplexND,
+    index: onp.ToInt,
+    func: _ComprehensionFunc[onp.ToComplex],
     out_dtype: _DTypeLike[ScalarT],
     default: onp.ToFloat,
     pass_positions: bool = False,
@@ -84,9 +93,9 @@ def labeled_comprehension[ScalarT: npc.number | np.bool](
 @overload
 def labeled_comprehension[ScalarT: npc.number | np.bool](
     input: onp.ToComplex | onp.ToComplexND,
-    labels: onp.ToComplex | onp.ToComplexND | None,
+    labels: onp.ToComplex | onp.ToComplexND,
     index: onp.ToIntND,
-    func: _ComprehensionFunc,
+    func: _ComprehensionFunc[onp.ToComplex],
     out_dtype: _DTypeLike[ScalarT],
     default: onp.ToFloat,
     pass_positions: bool = False,
@@ -94,9 +103,9 @@ def labeled_comprehension[ScalarT: npc.number | np.bool](
 @overload
 def labeled_comprehension(
     input: onp.ToComplex | onp.ToComplexND,
-    labels: onp.ToComplex | onp.ToComplexND | None,
-    index: onp.ToInt | None,
-    func: _ComprehensionFunc,
+    labels: onp.ToComplex | onp.ToComplexND,
+    index: onp.ToInt,
+    func: _ComprehensionFunc[onp.ToComplex],
     out_dtype: onp.AnyIntPDType,
     default: onp.ToInt,
     pass_positions: bool = False,
@@ -104,9 +113,9 @@ def labeled_comprehension(
 @overload
 def labeled_comprehension(
     input: onp.ToComplex | onp.ToComplexND,
-    labels: onp.ToComplex | onp.ToComplexND | None,
+    labels: onp.ToComplex | onp.ToComplexND,
     index: onp.ToIntND,
-    func: _ComprehensionFunc,
+    func: _ComprehensionFunc[onp.ToComplex],
     out_dtype: onp.AnyIntPDType,
     default: onp.ToInt,
     pass_positions: bool = False,
@@ -114,9 +123,9 @@ def labeled_comprehension(
 @overload
 def labeled_comprehension(
     input: onp.ToComplex | onp.ToComplexND,
-    labels: onp.ToComplex | onp.ToComplexND | None,
-    index: onp.ToInt | None,
-    func: _ComprehensionFunc,
+    labels: onp.ToComplex | onp.ToComplexND,
+    index: onp.ToInt,
+    func: _ComprehensionFunc[onp.ToComplex],
     out_dtype: onp.AnyFloat64DType | None,
     default: onp.ToFloat,
     pass_positions: bool = False,
@@ -124,9 +133,9 @@ def labeled_comprehension(
 @overload
 def labeled_comprehension(
     input: onp.ToComplex | onp.ToComplexND,
-    labels: onp.ToComplex | onp.ToComplexND | None,
+    labels: onp.ToComplex | onp.ToComplexND,
     index: onp.ToIntND,
-    func: _ComprehensionFunc,
+    func: _ComprehensionFunc[onp.ToComplex],
     out_dtype: onp.AnyFloat64DType | None,
     default: onp.ToFloat,
     pass_positions: bool = False,
@@ -134,9 +143,9 @@ def labeled_comprehension(
 @overload
 def labeled_comprehension(
     input: onp.ToComplex | onp.ToComplexND,
-    labels: onp.ToComplex | onp.ToComplexND | None,
-    index: onp.ToInt | None,
-    func: _ComprehensionFunc,
+    labels: onp.ToComplex | onp.ToComplexND,
+    index: onp.ToInt,
+    func: _ComprehensionFunc[onp.ToComplex],
     out_dtype: onp.AnyComplex128DType,
     default: onp.ToComplex,
     pass_positions: bool = False,
@@ -144,9 +153,9 @@ def labeled_comprehension(
 @overload
 def labeled_comprehension(
     input: onp.ToComplex | onp.ToComplexND,
-    labels: onp.ToComplex | onp.ToComplexND | None,
+    labels: onp.ToComplex | onp.ToComplexND,
     index: onp.ToIntND,
-    func: _ComprehensionFunc,
+    func: _ComprehensionFunc[onp.ToComplex],
     out_dtype: onp.AnyComplex128DType,
     default: onp.ToComplex,
     pass_positions: bool = False,

--- a/tests/ndimage/test__measurements.pyi
+++ b/tests/ndimage/test__measurements.pyi
@@ -43,6 +43,7 @@ out_labeled: onp.ArrayND[np.int32 | np.intp]
 
 # helper function for labeled_comprehension
 def _stat_func(x: onp.ToComplex | onp.ToComplexND) -> np.float64: ...
+def _stat_func_with_positions(x: onp.ToComplex | onp.ToComplexND, positions: onp.ToComplex | onp.ToComplexND) -> np.float64: ...
 
 ###
 # label
@@ -69,12 +70,15 @@ assert_type(value_indices(int_2d), dict[np.intp, tuple[onp.ArrayND[np.intp], ...
 ###
 # labeled_comprehension
 
-# index=None -> the return type of `func`, as-is; out_dtype and default are ignored at runtime
+# index=None -> the return type of `func`, as-is; `out_dtype` and `default` are ignored at runtime
 assert_type(labeled_comprehension(f64_2d, None, None, _stat_func, np.dtype(np.float32), 0.0), np.float64)
 assert_type(labeled_comprehension(f64_2d, None, None, _stat_func, np.intp, 0), np.float64)
 assert_type(labeled_comprehension(f64_2d, None, None, _stat_func, None, 0.0), np.float64)
 assert_type(labeled_comprehension(f64_2d, None, None, _stat_func, np.float64, 0.0), np.float64)
 assert_type(labeled_comprehension(f64_2d, None, None, _stat_func, np.complex128, 0.0), np.float64)
+assert_type(
+    labeled_comprehension(f64_2d, None, None, _stat_func_with_positions, np.float64, 0.0, pass_positions=True), np.float64
+)
 # labels may also be given with index=None
 assert_type(labeled_comprehension(f64_2d, label_1d, None, _stat_func, np.complex128, 0.0), np.float64)
 

--- a/tests/ndimage/test__measurements.pyi
+++ b/tests/ndimage/test__measurements.pyi
@@ -42,7 +42,7 @@ index_1d: onp.Array1D[np.intp]
 out_labeled: onp.ArrayND[np.int32 | np.intp]
 
 # helper function for labeled_comprehension
-def _stat_func(x: onp.ToComplex | onp.ToComplexND) -> onp.ToComplex: ...
+def _stat_func(x: onp.ToComplex | onp.ToComplexND) -> np.float64: ...
 
 ###
 # label
@@ -69,18 +69,24 @@ assert_type(value_indices(int_2d), dict[np.intp, tuple[onp.ArrayND[np.intp], ...
 ###
 # labeled_comprehension
 
-# index=None -> scalar output
-# TODO: assertions below are mostly incorrect — out_dtype is ignored at runtime when index=None.
-# Also missing a separate test for scalar index (e.g. index=1). Will fix in follow-up.
-# out_dtype: DTypeLike[_SCT] -> _SCT
-assert_type(labeled_comprehension(f64_2d, None, None, _stat_func, np.dtype(np.float32), 0.0), np.float32)
-# out_dtype: AnyIntPDType -> np.intp
-assert_type(labeled_comprehension(f64_2d, None, None, _stat_func, np.intp, 0), np.intp)
-# out_dtype: AnyFloat64DType | None -> np.float64
+# index=None -> the return type of `func`, as-is; out_dtype and default are ignored at runtime
+assert_type(labeled_comprehension(f64_2d, None, None, _stat_func, np.dtype(np.float32), 0.0), np.float64)
+assert_type(labeled_comprehension(f64_2d, None, None, _stat_func, np.intp, 0), np.float64)
 assert_type(labeled_comprehension(f64_2d, None, None, _stat_func, None, 0.0), np.float64)
 assert_type(labeled_comprehension(f64_2d, None, None, _stat_func, np.float64, 0.0), np.float64)
+assert_type(labeled_comprehension(f64_2d, None, None, _stat_func, np.complex128, 0.0), np.float64)
+# labels may also be given with index=None
+assert_type(labeled_comprehension(f64_2d, label_1d, None, _stat_func, np.complex128, 0.0), np.float64)
+
+# out_dtype: DTypeLike[_SCT] -> _SCT
+assert_type(labeled_comprehension(f64_2d, label_1d, 1, _stat_func, np.dtype(np.float32), 0.0), np.float32)
+# out_dtype: AnyIntPDType -> np.intp
+assert_type(labeled_comprehension(f64_2d, label_1d, 1, _stat_func, np.intp, 0), np.intp)
+# out_dtype: AnyFloat64DType | None -> np.float64
+assert_type(labeled_comprehension(f64_2d, label_1d, 1, _stat_func, None, 0.0), np.float64)
+assert_type(labeled_comprehension(f64_2d, label_1d, 1, _stat_func, np.float64, 0.0), np.float64)
 # out_dtype: AnyComplex128DType -> np.complex128
-assert_type(labeled_comprehension(f64_2d, None, None, _stat_func, np.complex128, 0.0), np.complex128)
+assert_type(labeled_comprehension(f64_2d, label_1d, 1, _stat_func, np.complex128, 0.0), np.complex128)
 
 # index=<int array> -> ArrayND output
 
@@ -93,6 +99,10 @@ assert_type(labeled_comprehension(f64_2d, label_1d, index_1d, _stat_func, None, 
 assert_type(labeled_comprehension(f64_2d, label_1d, index_1d, _stat_func, np.float64, 0.0), onp.ArrayND[np.float64])
 # out_dtype: AnyComplex128DType -> ArrayND[np.complex128]
 assert_type(labeled_comprehension(f64_2d, label_1d, index_1d, _stat_func, np.complex128, 0.0), onp.ArrayND[np.complex128])
+
+# labels=None with a non-None index raises ValueError at runtime
+labeled_comprehension(f64_2d, None, 1, _stat_func, np.float64, 0.0)  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType, reportCallIssue]  # pyrefly: ignore[no-matching-overload]
+labeled_comprehension(f64_2d, None, index_1d, _stat_func, np.float64, 0.0)  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType, reportCallIssue]  # pyrefly: ignore[no-matching-overload]
 
 ###
 # sum / sum_labels / mean / variance / standard_deviation / median


### PR DESCRIPTION
follow up #1964 

> Hmm, it turns out that when index=None, the out_dtype is completely ignored (only for None; int scalar index respects out_dtype). So although this issue was pre-existing, we might as well fix this as well here by splitting this overload into two.

>Another pre-existing issue here is that when index is not None and labels is None, a ValueError is raised at runtime. So it might be nice to prevent that by removing | None for the not-None index overloads like this one.