### PR TITLE
🐛 `stats.multivariate_normal`: fix `[log]{pdf,.cdf}` shape-typing

### DIFF
--- a/scipy-stubs/stats/_multivariate.pyi
+++ b/scipy-stubs/stats/_multivariate.pyi
@@ -1,4 +1,4 @@
-# there are `overload-overlap` false positivies on `numpy<2.1` that can't selectively be ignored or worked around
+# there are `overload-overlap` false positives on `numpy<2.1` that can't selectively be ignored or worked around
 # mypy: disable-error-code=overload-overlap
 
 import types
@@ -42,7 +42,7 @@ type _Array2ND[ScalarT: np.generic] = onp.Array[tuple[int, int, *tuple[Any, ...]
 type _Array3ND[ScalarT: np.generic] = onp.Array[tuple[int, int, int, *tuple[Any, ...]], ScalarT]
 
 type _ScalarOrArray_f8 = np.float64 | _Array1ND[np.float64]
-type _AnyCov = Covariance | onp.ToFloat2D | onp.ToFloat
+type _ToCov = Covariance | onp.ToFloat2D | onp.ToFloat
 
 type _ToIntStrict1D = onp.ToArrayStrict1D[int, npc.integer]
 type _ToIntStrict2D = onp.ToArrayStrict2D[int, npc.integer]
@@ -91,102 +91,102 @@ class multivariate_normal_gen(multi_rv_generic):
         self,
         /,
         mean: onp.ToFloat | None = None,
-        cov: _AnyCov = 1,
+        cov: _ToCov = 1,
         allow_singular: bool = False,
         seed: onp.random.ToRNG | None = None,
     ) -> multivariate_normal_frozen[tuple[()]]: ...
     @overload
     def __call__(
-        self, /, mean: onp.ToFloat1D, cov: _AnyCov = 1, allow_singular: bool = False, seed: onp.random.ToRNG | None = None
+        self, /, mean: onp.ToFloat1D, cov: _ToCov = 1, allow_singular: bool = False, seed: onp.random.ToRNG | None = None
     ) -> multivariate_normal_frozen[tuple[int]]: ...
 
     #
     @overload
     def logpdf(
-        self, /, x: onp.ToFloat, mean: onp.ToFloat | onp.ToFloat1D | None = None, cov: _AnyCov = 1, allow_singular: bool = False
+        self, /, x: onp.ToFloat, mean: onp.ToFloat | onp.ToFloat1D | None = None, cov: _ToCov = 1, allow_singular: bool = False
     ) -> np.float64: ...
     @overload
-    def logpdf[ShapeT: tuple[int, ...]](
+    def logpdf(
         self,
         /,
-        x: onp.ArrayND[npc.floating | npc.integer, ShapeT],
+        x: onp.ArrayND[npc.floating | npc.integer, _JustAnyShape],
         mean: onp.ToFloat | None = None,
-        cov: _AnyCov = 1,
+        cov: _ToCov = 1,
         allow_singular: bool = False,
-    ) -> onp.ArrayND[np.float64, ShapeT]: ...
-    @overload
-    def logpdf(
-        self, /, x: onp.ToFloatND, mean: onp.ToFloat | None = None, cov: _AnyCov = 1, allow_singular: bool = False
-    ) -> onp.ArrayND[np.float64, _WorkaroundForPyright]: ...
+    ) -> onp.ArrayND[np.float64]: ...
     @overload
     def logpdf(
         self,
         /,
         x: onp.ArrayND[npc.floating | npc.integer, _JustAnyShape],
         mean: onp.ToFloat1D,
-        cov: _AnyCov = 1,
+        cov: _ToCov = 1,
         allow_singular: bool = False,
-    ) -> np.float64 | onp.ArrayND[np.float64]: ...
+    ) -> onp.ArrayND[np.float64] | np.float64: ...
     @overload
     def logpdf(
-        self, /, x: onp.ToFloatStrict1D, mean: onp.ToFloat1D, cov: _AnyCov = 1, allow_singular: bool = False
-    ) -> np.float64: ...
-    @overload
-    def logpdf(
-        self, /, x: onp.ToFloatStrict2D, mean: onp.ToFloat1D, cov: _AnyCov = 1, allow_singular: bool = False
+        self, /, x: onp.ToFloatStrict1D, mean: onp.ToFloat | None = None, cov: _ToCov = 1, allow_singular: bool = False
     ) -> onp.Array1D[np.float64]: ...
     @overload
     def logpdf(
-        self, /, x: onp.ToFloatStrict3D, mean: onp.ToFloat1D, cov: _AnyCov = 1, allow_singular: bool = False
+        self, /, x: onp.ToFloatStrict1D, mean: onp.ToFloat1D, cov: _ToCov = 1, allow_singular: bool = False
+    ) -> np.float64: ...
+    @overload
+    def logpdf(
+        self, /, x: onp.ToFloatStrict2D, mean: onp.ToFloat1D, cov: _ToCov = 1, allow_singular: bool = False
+    ) -> onp.Array1D[np.float64]: ...
+    @overload
+    def logpdf(
+        self, /, x: onp.ToFloatStrict3D, mean: onp.ToFloat1D, cov: _ToCov = 1, allow_singular: bool = False
     ) -> onp.Array2D[np.float64]: ...
     @overload
     def logpdf(
-        self, /, x: onp.ToFloatND, mean: onp.ToFloat1D, cov: _AnyCov = 1, allow_singular: bool = False
-    ) -> np.float64 | onp.ArrayND[np.float64]: ...
+        self, /, x: onp.ToFloatND, mean: onp.ToFloat1D, cov: _ToCov = 1, allow_singular: bool = False
+    ) -> onp.ArrayND[np.float64] | np.float64: ...
 
-    #
+    # keep in sync with `logpdf`
     @overload
     def pdf(
-        self, /, x: onp.ToFloat, mean: onp.ToFloat | onp.ToFloat1D | None = None, cov: _AnyCov = 1, allow_singular: bool = False
+        self, /, x: onp.ToFloat, mean: onp.ToFloat | onp.ToFloat1D | None = None, cov: _ToCov = 1, allow_singular: bool = False
     ) -> np.float64: ...
     @overload
-    def pdf[ShapeT: tuple[int, ...]](
+    def pdf(
         self,
         /,
-        x: onp.ArrayND[npc.floating | npc.integer, ShapeT],
+        x: onp.ArrayND[npc.floating | npc.integer, _JustAnyShape],
         mean: onp.ToFloat | None = None,
-        cov: _AnyCov = 1,
+        cov: _ToCov = 1,
         allow_singular: bool = False,
-    ) -> onp.ArrayND[np.float64, ShapeT]: ...
-    @overload
-    def pdf(
-        self, /, x: onp.ToFloatND, mean: onp.ToFloat | None = None, cov: _AnyCov = 1, allow_singular: bool = False
-    ) -> onp.ArrayND[np.float64, _WorkaroundForPyright]: ...
+    ) -> onp.ArrayND[np.float64]: ...
     @overload
     def pdf(
         self,
         /,
         x: onp.ArrayND[npc.floating | npc.integer, _JustAnyShape],
         mean: onp.ToFloat1D,
-        cov: _AnyCov = 1,
+        cov: _ToCov = 1,
         allow_singular: bool = False,
-    ) -> np.float64 | onp.ArrayND[np.float64]: ...
+    ) -> onp.ArrayND[np.float64] | np.float64: ...
     @overload
     def pdf(
-        self, /, x: onp.ToFloatStrict1D, mean: onp.ToFloat1D, cov: _AnyCov = 1, allow_singular: bool = False
-    ) -> np.float64: ...
-    @overload
-    def pdf(
-        self, /, x: onp.ToFloatStrict2D, mean: onp.ToFloat1D, cov: _AnyCov = 1, allow_singular: bool = False
+        self, /, x: onp.ToFloatStrict1D, mean: onp.ToFloat | None = None, cov: _ToCov = 1, allow_singular: bool = False
     ) -> onp.Array1D[np.float64]: ...
     @overload
     def pdf(
-        self, /, x: onp.ToFloatStrict3D, mean: onp.ToFloat1D, cov: _AnyCov = 1, allow_singular: bool = False
+        self, /, x: onp.ToFloatStrict1D, mean: onp.ToFloat1D, cov: _ToCov = 1, allow_singular: bool = False
+    ) -> np.float64: ...
+    @overload
+    def pdf(
+        self, /, x: onp.ToFloatStrict2D, mean: onp.ToFloat1D, cov: _ToCov = 1, allow_singular: bool = False
+    ) -> onp.Array1D[np.float64]: ...
+    @overload
+    def pdf(
+        self, /, x: onp.ToFloatStrict3D, mean: onp.ToFloat1D, cov: _ToCov = 1, allow_singular: bool = False
     ) -> onp.Array2D[np.float64]: ...
     @overload
     def pdf(
-        self, /, x: onp.ToFloatND, mean: onp.ToFloat1D, cov: _AnyCov = 1, allow_singular: bool = False
-    ) -> np.float64 | onp.ArrayND[np.float64]: ...
+        self, /, x: onp.ToFloatND, mean: onp.ToFloat1D, cov: _ToCov = 1, allow_singular: bool = False
+    ) -> onp.ArrayND[np.float64] | np.float64: ...
 
     #
     @overload
@@ -195,7 +195,7 @@ class multivariate_normal_gen(multi_rv_generic):
         /,
         x: onp.ToFloat,
         mean: onp.ToFloat | onp.ToFloat1D | None = None,
-        cov: _AnyCov = 1,
+        cov: _ToCov = 1,
         allow_singular: bool = False,
         maxpts: int | None = None,
         abseps: float = 1e-5,
@@ -205,27 +205,12 @@ class multivariate_normal_gen(multi_rv_generic):
         rng: onp.random.ToRNG | None = None,
     ) -> np.float64: ...
     @overload
-    def logcdf[ShapeT: tuple[int, ...]](
-        self,
-        /,
-        x: onp.ArrayND[npc.floating | npc.integer, ShapeT],
-        mean: onp.ToFloat | None = None,
-        cov: _AnyCov = 1,
-        allow_singular: bool = False,
-        maxpts: int | None = None,
-        abseps: float = 1e-5,
-        releps: float = 1e-5,
-        *,
-        lower_limit: onp.ToFloat | onp.ToFloatND | None = None,
-        rng: onp.random.ToRNG | None = None,
-    ) -> onp.ArrayND[np.float64, ShapeT]: ...
-    @overload
     def logcdf(
         self,
         /,
-        x: onp.ToFloatND,
+        x: onp.ArrayND[npc.floating | npc.integer, _JustAnyShape],
         mean: onp.ToFloat | None = None,
-        cov: _AnyCov = 1,
+        cov: _ToCov = 1,
         allow_singular: bool = False,
         maxpts: int | None = None,
         abseps: float = 1e-5,
@@ -233,14 +218,14 @@ class multivariate_normal_gen(multi_rv_generic):
         *,
         lower_limit: onp.ToFloat | onp.ToFloatND | None = None,
         rng: onp.random.ToRNG | None = None,
-    ) -> onp.ArrayND[np.float64, _WorkaroundForPyright]: ...
+    ) -> onp.ArrayND[np.float64]: ...
     @overload
     def logcdf(
         self,
         /,
         x: onp.ArrayND[npc.floating | npc.integer, _JustAnyShape],
         mean: onp.ToFloat1D,
-        cov: _AnyCov = 1,
+        cov: _ToCov = 1,
         allow_singular: bool = False,
         maxpts: int | None = None,
         abseps: float = 1e-5,
@@ -248,14 +233,29 @@ class multivariate_normal_gen(multi_rv_generic):
         *,
         lower_limit: onp.ToFloat | onp.ToFloatND | None = None,
         rng: onp.random.ToRNG | None = None,
-    ) -> np.float64 | onp.ArrayND[np.float64]: ...
+    ) -> onp.ArrayND[np.float64] | np.float64: ...
+    @overload
+    def logcdf(
+        self,
+        /,
+        x: onp.ToFloatStrict1D,
+        mean: onp.ToFloat | None = None,
+        cov: _ToCov = 1,
+        allow_singular: bool = False,
+        maxpts: int | None = None,
+        abseps: float = 1e-5,
+        releps: float = 1e-5,
+        *,
+        lower_limit: onp.ToFloat | onp.ToFloat1D | None = None,
+        rng: onp.random.ToRNG | None = None,
+    ) -> onp.Array1D[np.float64]: ...
     @overload
     def logcdf(
         self,
         /,
         x: onp.ToFloatStrict1D,
         mean: onp.ToFloat1D,
-        cov: _AnyCov = 1,
+        cov: _ToCov = 1,
         allow_singular: bool = False,
         maxpts: int | None = None,
         abseps: float = 1e-5,
@@ -270,7 +270,7 @@ class multivariate_normal_gen(multi_rv_generic):
         /,
         x: onp.ToFloatStrict2D,
         mean: onp.ToFloat1D,
-        cov: _AnyCov = 1,
+        cov: _ToCov = 1,
         allow_singular: bool = False,
         maxpts: int | None = None,
         abseps: float = 1e-5,
@@ -285,7 +285,7 @@ class multivariate_normal_gen(multi_rv_generic):
         /,
         x: onp.ToFloatStrict3D,
         mean: onp.ToFloat1D,
-        cov: _AnyCov = 1,
+        cov: _ToCov = 1,
         allow_singular: bool = False,
         maxpts: int | None = None,
         abseps: float = 1e-5,
@@ -300,7 +300,7 @@ class multivariate_normal_gen(multi_rv_generic):
         /,
         x: onp.ToFloatND,
         mean: onp.ToFloat1D,
-        cov: _AnyCov = 1,
+        cov: _ToCov = 1,
         allow_singular: bool = False,
         maxpts: int | None = None,
         abseps: float = 1e-5,
@@ -308,16 +308,16 @@ class multivariate_normal_gen(multi_rv_generic):
         *,
         lower_limit: onp.ToFloat | onp.ToFloatND | None = None,
         rng: onp.random.ToRNG | None = None,
-    ) -> np.float64 | onp.ArrayND[np.float64]: ...
+    ) -> onp.ArrayND[np.float64] | np.float64: ...
 
-    #
+    # keep in sync with `logcdf`
     @overload
     def cdf(
         self,
         /,
         x: onp.ToFloat,
         mean: onp.ToFloat | onp.ToFloat1D | None = None,
-        cov: _AnyCov = 1,
+        cov: _ToCov = 1,
         allow_singular: bool = False,
         maxpts: int | None = None,
         abseps: float = 1e-5,
@@ -327,27 +327,12 @@ class multivariate_normal_gen(multi_rv_generic):
         rng: onp.random.ToRNG | None = None,
     ) -> np.float64: ...
     @overload
-    def cdf[ShapeT: tuple[int, ...]](
-        self,
-        /,
-        x: onp.ArrayND[npc.floating | npc.integer, ShapeT],
-        mean: onp.ToFloat | None = None,
-        cov: _AnyCov = 1,
-        allow_singular: bool = False,
-        maxpts: int | None = None,
-        abseps: float = 1e-5,
-        releps: float = 1e-5,
-        *,
-        lower_limit: onp.ToFloat | onp.ToFloatND | None = None,
-        rng: onp.random.ToRNG | None = None,
-    ) -> onp.ArrayND[np.float64, ShapeT]: ...
-    @overload
     def cdf(
         self,
         /,
-        x: onp.ToFloatND,
+        x: onp.ArrayND[npc.floating | npc.integer, _JustAnyShape],
         mean: onp.ToFloat | None = None,
-        cov: _AnyCov = 1,
+        cov: _ToCov = 1,
         allow_singular: bool = False,
         maxpts: int | None = None,
         abseps: float = 1e-5,
@@ -355,14 +340,14 @@ class multivariate_normal_gen(multi_rv_generic):
         *,
         lower_limit: onp.ToFloat | onp.ToFloatND | None = None,
         rng: onp.random.ToRNG | None = None,
-    ) -> onp.ArrayND[np.float64, _WorkaroundForPyright]: ...
+    ) -> onp.ArrayND[np.float64]: ...
     @overload
     def cdf(
         self,
         /,
         x: onp.ArrayND[npc.floating | npc.integer, _JustAnyShape],
         mean: onp.ToFloat1D,
-        cov: _AnyCov = 1,
+        cov: _ToCov = 1,
         allow_singular: bool = False,
         maxpts: int | None = None,
         abseps: float = 1e-5,
@@ -370,14 +355,29 @@ class multivariate_normal_gen(multi_rv_generic):
         *,
         lower_limit: onp.ToFloat | onp.ToFloatND | None = None,
         rng: onp.random.ToRNG | None = None,
-    ) -> np.float64 | onp.ArrayND[np.float64]: ...
+    ) -> onp.ArrayND[np.float64] | np.float64: ...
+    @overload
+    def cdf(
+        self,
+        /,
+        x: onp.ToFloatStrict1D,
+        mean: onp.ToFloat | None = None,
+        cov: _ToCov = 1,
+        allow_singular: bool = False,
+        maxpts: int | None = None,
+        abseps: float = 1e-5,
+        releps: float = 1e-5,
+        *,
+        lower_limit: onp.ToFloat | onp.ToFloat1D | None = None,
+        rng: onp.random.ToRNG | None = None,
+    ) -> onp.Array1D[np.float64]: ...
     @overload
     def cdf(
         self,
         /,
         x: onp.ToFloatStrict1D,
         mean: onp.ToFloat1D,
-        cov: _AnyCov = 1,
+        cov: _ToCov = 1,
         allow_singular: bool = False,
         maxpts: int | None = None,
         abseps: float = 1e-5,
@@ -392,7 +392,7 @@ class multivariate_normal_gen(multi_rv_generic):
         /,
         x: onp.ToFloatStrict2D,
         mean: onp.ToFloat1D,
-        cov: _AnyCov = 1,
+        cov: _ToCov = 1,
         allow_singular: bool = False,
         maxpts: int | None = None,
         abseps: float = 1e-5,
@@ -407,7 +407,7 @@ class multivariate_normal_gen(multi_rv_generic):
         /,
         x: onp.ToFloatStrict3D,
         mean: onp.ToFloat1D,
-        cov: _AnyCov = 1,
+        cov: _ToCov = 1,
         allow_singular: bool = False,
         maxpts: int | None = None,
         abseps: float = 1e-5,
@@ -422,7 +422,7 @@ class multivariate_normal_gen(multi_rv_generic):
         /,
         x: onp.ToFloatND,
         mean: onp.ToFloat1D,
-        cov: _AnyCov = 1,
+        cov: _ToCov = 1,
         allow_singular: bool = False,
         maxpts: int | None = None,
         abseps: float = 1e-5,
@@ -430,7 +430,7 @@ class multivariate_normal_gen(multi_rv_generic):
         *,
         lower_limit: onp.ToFloat | onp.ToFloatND | None = None,
         rng: onp.random.ToRNG | None = None,
-    ) -> np.float64 | onp.ArrayND[np.float64]: ...
+    ) -> onp.ArrayND[np.float64] | np.float64: ...
 
     #
     @overload
@@ -463,14 +463,14 @@ class multivariate_normal_gen(multi_rv_generic):
     ) -> onp.ArrayND[np.float64]: ...
     @overload
     def rvs(
-        self, /, mean: onp.ToFloat1D | None, cov: _AnyCov, size: tuple[int, ...], random_state: onp.random.ToRNG | None = None
+        self, /, mean: onp.ToFloat1D | None, cov: _ToCov, size: tuple[int, ...], random_state: onp.random.ToRNG | None = None
     ) -> onp.ArrayND[np.float64]: ...
     @overload
     def rvs(
         self,
         /,
         mean: onp.ToFloat1D | None = None,
-        cov: _AnyCov = 1,
+        cov: _ToCov = 1,
         *,
         size: tuple[int, ...],
         random_state: onp.random.ToRNG | None = None,
@@ -480,13 +480,13 @@ class multivariate_normal_gen(multi_rv_generic):
         self,
         /,
         mean: onp.ToFloat1D | None = None,
-        cov: _AnyCov = 1,
+        cov: _ToCov = 1,
         size: int | tuple[int, ...] = 1,
         random_state: onp.random.ToRNG | None = None,
     ) -> np.float64 | onp.ArrayND[np.float64]: ...
 
     #
-    def entropy(self, /, mean: onp.ToFloat | onp.ToFloat1D | None = None, cov: _AnyCov = 1) -> np.float64: ...
+    def entropy(self, /, mean: onp.ToFloat | onp.ToFloat1D | None = None, cov: _ToCov = 1) -> np.float64: ...
 
     #
     def fit(
@@ -500,11 +500,11 @@ class multivariate_normal_gen(multi_rv_generic):
     #
     @overload
     def marginal(
-        self, dimensions: int, mean: onp.ToFloat | onp.ToFloat1D | None = None, cov: _AnyCov = 1, allow_singular: bool = False
+        self, dimensions: int, mean: onp.ToFloat | onp.ToFloat1D | None = None, cov: _ToCov = 1, allow_singular: bool = False
     ) -> multivariate_normal_frozen[tuple[()]]: ...
     @overload
     def marginal(
-        self, dimensions: onp.ToInt1D, mean: onp.ToFloat1D, cov: _AnyCov = 1, allow_singular: bool = False
+        self, dimensions: onp.ToInt1D, mean: onp.ToFloat1D, cov: _ToCov = 1, allow_singular: bool = False
     ) -> multivariate_normal_frozen[tuple[int]]: ...
 
 #
@@ -529,7 +529,7 @@ class multivariate_normal_frozen(multi_rv_frozen[multivariate_normal_gen], Gener
         self: multivariate_normal_frozen[tuple[()]],
         /,
         mean: onp.ToFloat | None = None,
-        cov: _AnyCov = 1,
+        cov: _ToCov = 1,
         allow_singular: bool = False,
         seed: onp.random.ToRNG | None = None,
         maxpts: int | None = None,
@@ -541,7 +541,7 @@ class multivariate_normal_frozen(multi_rv_frozen[multivariate_normal_gen], Gener
         self: multivariate_normal_frozen[tuple[int]],
         /,
         mean: onp.ToFloat1D,
-        cov: _AnyCov = 1,
+        cov: _ToCov = 1,
         allow_singular: bool = False,
         seed: onp.random.ToRNG | None = None,
         maxpts: int | None = None,

--- a/tests/stats/test_multivariate.pyi
+++ b/tests/stats/test_multivariate.pyi
@@ -45,13 +45,12 @@ _f64_nd: onp.ArrayND[np.float64]
 
 assert_type(multivariate_normal.logpdf(1.0), np.float64)
 assert_type(multivariate_normal.logpdf(_f64_1d), onp.Array1D[np.float64])
-assert_type(multivariate_normal.logpdf(_f64_2d), onp.Array2D[np.float64])
 assert_type(multivariate_normal.logpdf(_f64_nd), onp.ArrayND[np.float64])
 assert_type(multivariate_normal.logpdf(1.0, _f_1d), np.float64)
 assert_type(multivariate_normal.logpdf(_f_1d, _f_1d), np.float64)
 assert_type(multivariate_normal.logpdf(_f_2d, _f_1d), onp.Array1D[np.float64])
 assert_type(multivariate_normal.logpdf(_f_3d, _f_1d), onp.Array2D[np.float64])
-assert_type(multivariate_normal.logpdf(_f_nd, _f_1d), np.float64 | onp.ArrayND[np.float64])
+assert_type(multivariate_normal.logpdf(_f_nd, _f_1d), onp.ArrayND[np.float64] | np.float64)
 assert_type(multivariate_normal().logpdf(1.0), np.float64)
 assert_type(multivariate_normal().logpdf(_f64_1d), onp.Array1D[np.float64])
 assert_type(multivariate_normal().logpdf(_f64_2d), onp.Array2D[np.float64])
@@ -64,7 +63,6 @@ assert_type(multivariate_normal(_f_1d).logpdf(_f_nd), np.float64 | onp.ArrayND[n
 
 assert_type(multivariate_normal.pdf(1.0), np.float64)
 assert_type(multivariate_normal.pdf(_f64_1d), onp.Array1D[np.float64])
-assert_type(multivariate_normal.pdf(_f64_2d), onp.Array2D[np.float64])
 assert_type(multivariate_normal.pdf(_f64_nd), onp.ArrayND[np.float64])
 assert_type(multivariate_normal.pdf(1.0, _f_1d), np.float64)
 assert_type(multivariate_normal.pdf(_f_1d, _f_1d), np.float64)
@@ -83,7 +81,6 @@ assert_type(multivariate_normal(_f_1d).pdf(_f_nd), np.float64 | onp.ArrayND[np.f
 
 assert_type(multivariate_normal.logcdf(1.0), np.float64)
 assert_type(multivariate_normal.logcdf(_f64_1d), onp.Array1D[np.float64])
-assert_type(multivariate_normal.logcdf(_f64_2d), onp.Array2D[np.float64])
 assert_type(multivariate_normal.logcdf(_f64_nd), onp.ArrayND[np.float64])
 assert_type(multivariate_normal.logcdf(1.0, _f_1d), np.float64)
 assert_type(multivariate_normal.logcdf(_f_1d, _f_1d), np.float64)
@@ -102,7 +99,6 @@ assert_type(multivariate_normal(_f_1d).logcdf(_f_nd), np.float64 | onp.ArrayND[n
 
 assert_type(multivariate_normal.cdf(1.0), np.float64)
 assert_type(multivariate_normal.cdf(_f64_1d), onp.Array1D[np.float64])
-assert_type(multivariate_normal.cdf(_f64_2d), onp.Array2D[np.float64])
 assert_type(multivariate_normal.cdf(_f64_nd), onp.ArrayND[np.float64])
 assert_type(multivariate_normal.cdf(1.0, _f_1d), np.float64)
 assert_type(multivariate_normal.cdf(_f_1d, _f_1d), np.float64)


### PR DESCRIPTION
fixes #1791