### PR TITLE
✨ `linalg.matrix_balance`: improved shape-typing and dtype propagation

### DIFF
--- a/scipy-stubs/linalg/_basic.pyi
+++ b/scipy-stubs/linalg/_basic.pyi
@@ -2090,31 +2090,139 @@ def pinvh(
     check_finite: bool = True,
 ) -> tuple[onp.ArrayND[Any], int | Any]: ...
 
-# TODO(jorenham): improve this
-@overload  # (float[:, :], separate=True) -> (float[:, :], float[:, :])
+type _ScalePerm1D = tuple[onp.Array1D[np.float64], onp.Array1D[np.intp]]
+
+# NOTE: `separate=True` 2nd return type is only a tuple for 2d input, otherwise it's (also) Nd
+@overload  # >=2d, T
+def matrix_balance[
+    ScalarT: npc.inexact64 | npc.inexact32,
+    ShapeT: onp.AtLeast2D | tuple[Any, ...],  # the strange ShapeT upper bound is a pyrefly workaround
+](
+    A: onp.ArrayND[ScalarT, ShapeT],
+    permute: bool = True,
+    scale: bool = True,
+    separate: Literal[False] = False,
+    overwrite_a: bool = False,
+) -> tuple[onp.ArrayND[ScalarT, ShapeT], onp.ArrayND[np.float64, ShapeT]]: ...
+@overload  # Nd, +f64
+def matrix_balance[ShapeT: onp.AtLeast2D | tuple[Any, ...]](
+    A: onp.ArrayND[npc.integer64 | npc.integer32, ShapeT],
+    permute: bool = True,
+    scale: bool = True,
+    separate: Literal[False] = False,
+    overwrite_a: bool = False,
+) -> tuple[onp.ArrayND[np.float64, ShapeT], onp.ArrayND[np.float64, ShapeT]]: ...
+@overload  # Nd, +f32
+def matrix_balance[ShapeT: onp.AtLeast2D | tuple[Any, ...]](
+    A: onp.ArrayND[npc.integer16 | npc.integer8, ShapeT],
+    permute: bool = True,
+    scale: bool = True,
+    separate: Literal[False] = False,
+    overwrite_a: bool = False,
+) -> tuple[onp.ArrayND[np.float32, ShapeT], onp.ArrayND[np.float64, ShapeT]]: ...
+@overload  # 2d, +float
 def matrix_balance(
-    A: onp.ToFloatND, permute: bool = True, scale: bool = True, separate: Literal[False] = False, overwrite_a: bool = False
-) -> _Tuple2[_FloatND]: ...
-@overload  # (float[:, :], separate=False, /) -> (float[:, :], (float[:], float[:]))
+    A: Sequence[Sequence[float]],
+    permute: bool = True,
+    scale: bool = True,
+    separate: Literal[False] = False,
+    overwrite_a: bool = False,
+) -> tuple[onp.Array2D[np.float64], onp.Array2D[np.float64]]: ...
+@overload  # 3d, +float
 def matrix_balance(
-    A: onp.ToFloatND, permute: bool, scale: bool, separate: Literal[True], overwrite_a: bool = False
-) -> tuple[_FloatND, _Tuple2[_FloatND]]: ...
-@overload  # (float[:, :], *, separate=False) -> (float[:, :], (float[:], float[:]))
+    A: Sequence[Sequence[Sequence[float]]],
+    permute: bool = True,
+    scale: bool = True,
+    separate: Literal[False] = False,
+    overwrite_a: bool = False,
+) -> tuple[onp.Array3D[np.float64], onp.Array3D[np.float64]]: ...
+@overload  # 2d, ~c128
 def matrix_balance(
-    A: onp.ToFloatND, permute: bool = True, scale: bool = True, *, separate: Literal[True], overwrite_a: bool = False
-) -> tuple[_FloatND, _Tuple2[_FloatND]]: ...
-@overload  # (complex[:, :], separate=True) -> (complex[:, :], complex[:, :])
+    A: Sequence[list[complex]],
+    permute: bool = True,
+    scale: bool = True,
+    separate: Literal[False] = False,
+    overwrite_a: bool = False,
+) -> tuple[onp.Array2D[np.complex128], onp.Array2D[np.float64]]: ...
+@overload  # 3d, ~c128
+def matrix_balance(
+    A: Sequence[Sequence[list[complex]]],
+    permute: bool = True,
+    scale: bool = True,
+    separate: bool = False,
+    overwrite_a: bool = False,
+) -> tuple[onp.Array3D[np.complex128], onp.Array3D[np.float64]]: ...
+@overload  # Nd, ?, fallback
 def matrix_balance(
     A: onp.ToComplexND, permute: bool = True, scale: bool = True, separate: Literal[False] = False, overwrite_a: bool = False
-) -> _Tuple2[_InexactND]: ...
-@overload  # (complex[:, :], separate=False, /) -> (complex[:, :], (complex[:], complex[:]))
+) -> tuple[onp.ArrayND[Any, tuple[int, int] | tuple[Any, ...]], onp.ArrayND[np.float64, tuple[int, int] | tuple[Any, ...]]]: ...
+@overload  # 2d, T, separate=True
+def matrix_balance[ScalarT: npc.inexact64 | npc.inexact32](
+    A: onp.Array2D[ScalarT], permute: bool = True, scale: bool = True, *, separate: Literal[True], overwrite_a: bool = False
+) -> tuple[onp.Array2D[ScalarT], _ScalePerm1D]: ...
+@overload  # >=3d, T, separate=True
+def matrix_balance[ScalarT: npc.inexact64 | npc.inexact32, ShapeT: onp.AtLeast3D](
+    A: onp.ArrayND[ScalarT, ShapeT],
+    permute: bool = True,
+    scale: bool = True,
+    *,
+    separate: Literal[True],
+    overwrite_a: bool = False,
+) -> tuple[onp.ArrayND[ScalarT, ShapeT], onp.ArrayND[np.float64, ShapeT]]: ...
+@overload  # 2d, +f64, separate=True
 def matrix_balance(
-    A: onp.ToComplexND, permute: bool, scale: bool, separate: Literal[True], overwrite_a: bool = False
-) -> tuple[_InexactND, _Tuple2[_InexactND]]: ...
-@overload  # (complex[:, :], *, separate=False) -> (complex[:, :], (complex[:], complex[:]))
+    A: onp.ToArrayStrict2D[float, npc.floating64 | npc.integer64 | npc.integer32],
+    permute: bool = True,
+    scale: bool = True,
+    *,
+    separate: Literal[True],
+    overwrite_a: bool = False,
+) -> tuple[onp.Array2D[np.float64], _ScalePerm1D]: ...
+@overload  # 3d, +f64, separate=True
+def matrix_balance(
+    A: onp.ToArrayStrict3D[float, npc.floating64 | npc.integer64 | npc.integer32],
+    permute: bool = True,
+    scale: bool = True,
+    *,
+    separate: Literal[True],
+    overwrite_a: bool = False,
+) -> tuple[onp.Array3D[np.float64], onp.Array3D[np.float64]]: ...
+@overload  # 2d, +f32
+def matrix_balance(
+    A: onp.ToArrayStrict2D[np.float32, npc.floating32 | npc.integer16 | npc.integer8],
+    permute: bool = True,
+    scale: bool = True,
+    *,
+    separate: Literal[True],
+    overwrite_a: bool = False,
+) -> tuple[onp.Array2D[np.float32], _ScalePerm1D]: ...
+@overload  # 3d, +f32
+def matrix_balance(
+    A: onp.ToArrayStrict3D[np.float32, npc.floating32 | npc.integer16 | npc.integer8],
+    permute: bool = True,
+    scale: bool = True,
+    *,
+    separate: Literal[True],
+    overwrite_a: bool = False,
+) -> tuple[onp.Array3D[np.float32], onp.Array3D[np.float64]]: ...
+@overload  # 2d, ~complex, separate=True
+def matrix_balance(
+    A: Sequence[list[complex]], permute: bool = True, scale: bool = True, *, separate: Literal[True], overwrite_a: bool = False
+) -> tuple[onp.Array2D[np.complex128], _ScalePerm1D]: ...
+@overload  # 2d, ?, separate=True  (fallback)
+def matrix_balance(
+    A: onp.ToComplexStrict2D, permute: bool = True, scale: bool = True, *, separate: Literal[True], overwrite_a: bool = False
+) -> tuple[onp.Array2D[Any], _ScalePerm1D]: ...
+@overload  # 3d, ?, separate=True  (fallback)
+def matrix_balance(
+    A: onp.ToComplexStrict3D, permute: bool = True, scale: bool = True, *, separate: Literal[True], overwrite_a: bool = False
+) -> tuple[onp.Array3D[Any], onp.Array3D[np.float64]]: ...
+@overload  # Nd, ?, separate=True  (fallback)
 def matrix_balance(
     A: onp.ToComplexND, permute: bool = True, scale: bool = True, *, separate: Literal[True], overwrite_a: bool = False
-) -> tuple[_InexactND, _Tuple2[_InexactND]]: ...
+) -> tuple[
+    onp.ArrayND[Any, tuple[int, int] | tuple[Any, ...]], onp.ArrayND[np.float64, tuple[int, int] | tuple[Any, ...]] | Any
+]: ...
 
 # TODO(jorenham): improve this
 @overload  # floating 1d, 1d

--- a/tests/linalg/test__basic.pyi
+++ b/tests/linalg/test__basic.pyi
@@ -683,24 +683,49 @@ assert_type(pinvh(c160_nd, return_rank=True), tuple[onp.ArrayND[np.complex128], 
 ###
 # matrix_balance
 
-assert_type(matrix_balance(f64_nd), tuple[onp.ArrayND[npc.floating], onp.ArrayND[npc.floating]])
-assert_type(
-    matrix_balance(f64_nd, True, True, True),
-    tuple[onp.ArrayND[npc.floating], tuple[onp.ArrayND[npc.floating], onp.ArrayND[npc.floating]]],
-)
-assert_type(
-    matrix_balance(f64_nd, separate=True),
-    tuple[onp.ArrayND[npc.floating], tuple[onp.ArrayND[npc.floating], onp.ArrayND[npc.floating]]],
-)
-assert_type(matrix_balance(c128_nd), tuple[onp.ArrayND[npc.inexact], onp.ArrayND[npc.inexact]])
-assert_type(
-    matrix_balance(c128_nd, True, True, True),
-    tuple[onp.ArrayND[npc.inexact], tuple[onp.ArrayND[npc.inexact], onp.ArrayND[npc.inexact]]],
-)
-assert_type(
-    matrix_balance(c128_nd, separate=True),
-    tuple[onp.ArrayND[npc.inexact], tuple[onp.ArrayND[npc.inexact], onp.ArrayND[npc.inexact]]],
-)
+assert_type(matrix_balance(py_f_2d), tuple[onp.Array2D[np.float64], onp.Array2D[np.float64]])
+assert_type(matrix_balance(py_c_2d), tuple[onp.Array2D[np.complex128], onp.Array2D[np.float64]])
+assert_type(matrix_balance(i8_2d), tuple[onp.Array2D[np.float32], onp.Array2D[np.float64]])
+assert_type(matrix_balance(i32_2d), tuple[onp.Array2D[np.float64], onp.Array2D[np.float64]])
+assert_type(matrix_balance(f32_2d), tuple[onp.Array2D[np.float32], onp.Array2D[np.float64]])
+assert_type(matrix_balance(f64_2d), tuple[onp.Array2D[np.float64], onp.Array2D[np.float64]])
+assert_type(matrix_balance(c64_2d), tuple[onp.Array2D[np.complex64], onp.Array2D[np.float64]])
+assert_type(matrix_balance(c128_2d), tuple[onp.Array2D[np.complex128], onp.Array2D[np.float64]])
+
+assert_type(matrix_balance(py_f_3d), tuple[onp.Array3D[np.float64], onp.Array3D[np.float64]])
+assert_type(matrix_balance(py_c_3d), tuple[onp.Array3D[np.complex128], onp.Array3D[np.float64]])
+assert_type(matrix_balance(i8_3d), tuple[onp.Array3D[np.float32], onp.Array3D[np.float64]])
+assert_type(matrix_balance(i32_3d), tuple[onp.Array3D[np.float64], onp.Array3D[np.float64]])
+assert_type(matrix_balance(f32_3d), tuple[onp.Array3D[np.float32], onp.Array3D[np.float64]])
+assert_type(matrix_balance(f64_3d), tuple[onp.Array3D[np.float64], onp.Array3D[np.float64]])
+assert_type(matrix_balance(c64_3d), tuple[onp.Array3D[np.complex64], onp.Array3D[np.float64]])
+assert_type(matrix_balance(c128_3d), tuple[onp.Array3D[np.complex128], onp.Array3D[np.float64]])
+
+assert_type(matrix_balance(i8_nd), tuple[onp.ArrayND[np.float32], onp.ArrayND[np.float64]])
+assert_type(matrix_balance(i32_nd), tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64]])
+assert_type(matrix_balance(f32_nd), tuple[onp.ArrayND[np.float32], onp.ArrayND[np.float64]])
+assert_type(matrix_balance(f64_nd), tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64]])
+assert_type(matrix_balance(c64_nd), tuple[onp.ArrayND[np.complex64], onp.ArrayND[np.float64]])
+assert_type(matrix_balance(c128_nd), tuple[onp.ArrayND[np.complex128], onp.ArrayND[np.float64]])
+
+type _ScalePerm1D = tuple[onp.Array1D[np.float64], onp.Array1D[np.intp]]
+assert_type(matrix_balance(py_f_2d, separate=True), tuple[onp.Array2D[np.float64], _ScalePerm1D])
+assert_type(matrix_balance(py_c_2d, separate=True), tuple[onp.Array2D[np.complex128], _ScalePerm1D])
+assert_type(matrix_balance(i8_2d, separate=True), tuple[onp.Array2D[np.float32], _ScalePerm1D])
+assert_type(matrix_balance(i32_2d, separate=True), tuple[onp.Array2D[np.float64], _ScalePerm1D])
+assert_type(matrix_balance(f32_2d, separate=True), tuple[onp.Array2D[np.float32], _ScalePerm1D])
+assert_type(matrix_balance(f64_2d, separate=True), tuple[onp.Array2D[np.float64], _ScalePerm1D])
+assert_type(matrix_balance(c64_2d, separate=True), tuple[onp.Array2D[np.complex64], _ScalePerm1D])
+assert_type(matrix_balance(c128_2d, separate=True), tuple[onp.Array2D[np.complex128], _ScalePerm1D])
+
+assert_type(matrix_balance(py_f_3d, separate=True), tuple[onp.Array3D[np.float64], onp.Array3D[np.float64]])
+assert_type(matrix_balance(py_c_3d, separate=True), tuple[onp.Array3D[np.complex128], onp.Array3D[np.float64]])
+assert_type(matrix_balance(i8_3d, separate=True), tuple[onp.Array3D[np.float32], onp.Array3D[np.float64]])
+assert_type(matrix_balance(i32_3d, separate=True), tuple[onp.Array3D[np.float64], onp.Array3D[np.float64]])
+assert_type(matrix_balance(f32_3d, separate=True), tuple[onp.Array3D[np.float32], onp.Array3D[np.float64]])
+assert_type(matrix_balance(f64_3d, separate=True), tuple[onp.Array3D[np.float64], onp.Array3D[np.float64]])
+assert_type(matrix_balance(c64_3d, separate=True), tuple[onp.Array3D[np.complex64], onp.Array3D[np.float64]])
+assert_type(matrix_balance(c128_3d, separate=True), tuple[onp.Array3D[np.complex128], onp.Array3D[np.float64]])
 
 ###
 # matmul_toeplitz


### PR DESCRIPTION
The awkward thing with `linalg.matrix_balance` is that, for 2d input, `separate=True` will have a tuple of 2 1d arrays as 2nd return type, but for 3d input and `separate=True`, this will be be an Nd array instead. This behavior is now accurately encode this behavior in the stubs, and it now also correctly propagates/promotes the 4 supported dtypes (`f64`/`f32`/`c128`/`c64`). It's now also transparent w.r.t. its input shape-type, and special-cases the 2d and 3d shape-types in case of array-like (nested sequences and such).

towards #1940