### PR TITLE
🐛 `optimize.leastsq`: fix `full_output=True` 2nd return type

### DIFF
--- a/scipy-stubs/optimize/_minpack_py.pyi
+++ b/scipy-stubs/optimize/_minpack_py.pyi
@@ -157,7 +157,7 @@ def leastsq(
     epsfcn: float | None = None,
     factor: float | None = 100,
     diag: onp.ToFloat1D | None = None,
-) -> tuple[_Float1D, _Float2D, _InfoDictLSQ, str, _IERFlag]: ...
+) -> tuple[_Float1D, _Float2D | None, _InfoDictLSQ, str, _IERFlag]: ...
 @overload  # full_output=True (keyword)
 def leastsq(
     func: _Fun1D,
@@ -174,7 +174,7 @@ def leastsq(
     epsfcn: float | None = None,
     factor: float | None = 100,
     diag: onp.ToFloat1D | None = None,
-) -> tuple[_Float1D, _Float2D, _InfoDictLSQ, str, _IERFlag]: ...
+) -> tuple[_Float1D, _Float2D | None, _InfoDictLSQ, str, _IERFlag]: ...
 
 #
 @overload  # 1-d `x`, full-output=False

--- a/tests/optimize/test__minpack_py.pyi
+++ b/tests/optimize/test__minpack_py.pyi
@@ -29,8 +29,8 @@ assert_type(fsolve(_func, [1.0, 2.0], full_output=True), tuple[_Float1D, _InfoDi
 # leastsq
 
 assert_type(leastsq(_func, [1.0, 2.0]), tuple[_Float1D, _IERFlag])
-assert_type(leastsq(_func, [1.0, 2.0], (), None, True), tuple[_Float1D, _Float2D, _InfoDictLSQ, str, _IERFlag])
-assert_type(leastsq(_func, [1.0, 2.0], full_output=True), tuple[_Float1D, _Float2D, _InfoDictLSQ, str, _IERFlag])
+assert_type(leastsq(_func, [1.0, 2.0], (), None, True), tuple[_Float1D, _Float2D | None, _InfoDictLSQ, str, _IERFlag])
+assert_type(leastsq(_func, [1.0, 2.0], full_output=True), tuple[_Float1D, _Float2D | None, _InfoDictLSQ, str, _IERFlag])
 
 ###
 # curve_fit, 1-d xdata


### PR DESCRIPTION
fixes #1794