### PR TITLE
🦖 `stats`: `rvs` fallback overloads for compatibility with legacy type-checkers

### DIFF
--- a/scipy-stubs/stats/_multivariate.pyi
+++ b/scipy-stubs/stats/_multivariate.pyi
@@ -980,6 +980,10 @@ class dirichlet_gen(multi_rv_generic):
         size: tuple[SupportsIndex, SupportsIndex, SupportsIndex, *tuple[SupportsIndex, ...]],
         random_state: onp.random.ToRNG | None = None,
     ) -> _Array3ND[np.float64]: ...
+    @overload
+    def rvs(
+        self, /, alpha: onp.ToFloat1D, size: tuple[SupportsIndex, ...], random_state: onp.random.ToRNG | None = None
+    ) -> _Array1ND[np.float64]: ...
 
 class dirichlet_frozen(multi_rv_frozen[dirichlet_gen]):
     # pyrefly: ignore [bad-override]
@@ -1011,6 +1015,8 @@ class dirichlet_frozen(multi_rv_frozen[dirichlet_gen]):
         size: tuple[SupportsIndex, SupportsIndex, SupportsIndex, *tuple[SupportsIndex, ...]],
         random_state: onp.random.ToRNG | None = None,
     ) -> _Array3ND[np.float64]: ...
+    @overload
+    def rvs(self, /, size: tuple[SupportsIndex, ...], random_state: onp.random.ToRNG | None = None) -> _Array1ND[np.float64]: ...
 
 class wishart_gen(multi_rv_generic):
     def __call__(
@@ -1563,6 +1569,8 @@ class uniform_direction_gen(multi_rv_generic):
     ) -> onp.Array2D[np.float64]: ...
     @overload
     def rvs(self, /, dim: int, size: onp.AtLeast2D, random_state: onp.random.ToRNG | None = None) -> _Array3ND[np.float64]: ...
+    @overload
+    def rvs(self, /, dim: int, size: tuple[int, ...], random_state: onp.random.ToRNG | None = None) -> _Array2ND[np.float64]: ...
 
 class uniform_direction_frozen(multi_rv_frozen[uniform_direction_gen]):
     dim: Final[int]
@@ -1575,7 +1583,7 @@ class uniform_direction_frozen(multi_rv_frozen[uniform_direction_gen]):
     @overload
     def rvs(self, /, size: int | tuple[int], random_state: onp.random.ToRNG | None = None) -> onp.Array2D[np.float64]: ...
     @overload
-    def rvs(self, /, size: onp.AtLeast2D, random_state: onp.random.ToRNG | None = None) -> _Array2ND[np.float64]: ...
+    def rvs(self, /, size: tuple[int, ...], random_state: onp.random.ToRNG | None = None) -> _Array2ND[np.float64]: ...
 
 class random_correlation_gen(multi_rv_generic):
     def __call__(
@@ -1797,9 +1805,9 @@ class multivariate_hypergeom_frozen(multi_rv_frozen[multivariate_hypergeom_gen])
 
     #
     @overload
-    def rvs(self, /, size: tuple[()], random_state: onp.random.ToRNG | None = None) -> _Array1ND[np.int_]: ...
-    @overload
     def rvs(self, /, size: int | tuple[int] = 1, random_state: onp.random.ToRNG | None = None) -> _Array2ND[np.int_]: ...
+    @overload
+    def rvs(self, /, size: tuple[int, ...], random_state: onp.random.ToRNG | None = None) -> _Array1ND[np.int_]: ...
 
 type _RandomTableRVSMethod = Literal["boyett", "patefield"]
 
@@ -1845,7 +1853,7 @@ class random_table_gen(multi_rv_generic):
         row: onp.ToJustIntND,
         col: onp.ToJustIntND,
         *,
-        size: onp.AtLeast1D,
+        size: tuple[int, ...],
         method: _RandomTableRVSMethod | None = None,
         random_state: onp.random.ToRNG | None = None,
     ) -> _Array3ND[np.int_]: ...
@@ -1874,7 +1882,7 @@ class random_table_frozen(multi_rv_frozen[random_table_gen]):
     ) -> onp.Array3D[np.int_]: ...
     @overload
     def rvs(
-        self, /, size: onp.AtLeast1D, method: _RandomTableRVSMethod | None = None, random_state: onp.random.ToRNG | None = None
+        self, /, size: tuple[int, ...], method: _RandomTableRVSMethod | None = None, random_state: onp.random.ToRNG | None = None
     ) -> _Array3ND[np.int_]: ...
 
 class dirichlet_multinomial_gen(multi_rv_generic):
@@ -1910,7 +1918,7 @@ class vonmises_fisher_gen(multi_rv_generic):
         /,
         mu: onp.ToFloat1D | None = None,
         kappa: onp.ToFloat = 1,
-        size: SupportsIndex | tuple[SupportsIndex, *tuple[SupportsIndex, ...]] = 1,
+        size: SupportsIndex | tuple[SupportsIndex, ...] = 1,
         random_state: onp.random.ToRNG | None = None,
     ) -> _Array2ND[np.float64]: ...
     def fit(self, /, x: onp.ToFloatND) -> tuple[onp.Array1D[np.float64], float]: ...
@@ -1923,10 +1931,7 @@ class vonmises_fisher_frozen(multi_rv_frozen[vonmises_fisher_gen]):
     def pdf(self, /, x: onp.ToFloatND) -> _ScalarOrArray_f8: ...
     def entropy(self, /) -> np.float64: ...
     def rvs(
-        self,
-        /,
-        size: SupportsIndex | tuple[SupportsIndex, *tuple[SupportsIndex, ...]] = 1,
-        random_state: onp.random.ToRNG | None = None,
+        self, /, size: SupportsIndex | tuple[SupportsIndex, ...] = 1, random_state: onp.random.ToRNG | None = None
     ) -> _Array2ND[np.float64]: ...
 
 class normal_inverse_gamma_gen(multi_rv_generic):

--- a/tests/stats/test_multivariate.pyi
+++ b/tests/stats/test_multivariate.pyi
@@ -39,6 +39,8 @@ _f64_1d: onp.Array1D[np.float64]
 _f64_2d: onp.Array2D[np.float64]
 _f64_nd: onp.ArrayND[np.float64]
 
+_shape: tuple[int, ...]
+
 ###
 
 # multivariate_normal
@@ -118,6 +120,7 @@ assert_type(multivariate_normal(_f_1d).cdf(_f_nd), np.float64 | onp.ArrayND[np.f
 assert_type(multivariate_normal(_f_1d).rvs(size=()), onp.Array1D[np.float64])
 assert_type(multivariate_normal(_f_1d).rvs(size=(2,)), onp.Array2D[np.float64])
 assert_type(multivariate_normal(_f_1d).rvs(size=(2, 3)), onp.ArrayND[np.float64])
+assert_type(multivariate_normal(_f_1d).rvs(size=_shape), onp.ArrayND[np.float64])
 
 # matrix_normal
 
@@ -128,6 +131,12 @@ assert_type(matrix_normal().rvs().dtype, np.dtype[np.float64])
 
 assert_type(dirichlet.rvs([1, 2]).dtype, np.dtype[np.float64])
 assert_type(dirichlet([1, 2]).rvs().dtype, np.dtype[np.float64])
+
+assert_type(dirichlet([1, 2]).rvs(size=()), onp.Array1D[np.float64])
+assert_type(dirichlet([1, 2]).rvs(size=2), onp.Array2D[np.float64])
+assert_type(dirichlet([1, 2]).rvs(size=(2, 3)), onp.Array3D[np.float64])
+assert_type(dirichlet.rvs([1, 2], size=_shape), onp.Array[tuple[int, *tuple[Any, ...]], np.float64])
+assert_type(dirichlet([1, 2]).rvs(size=_shape), onp.Array[tuple[int, *tuple[Any, ...]], np.float64])
 
 # wishart
 
@@ -359,6 +368,10 @@ assert_type(unitary_group().rvs(3).dtype, np.dtype[np.complex128])
 assert_type(uniform_direction.rvs(2).dtype, np.dtype[np.float64])
 assert_type(uniform_direction(2).rvs().dtype, np.dtype[np.float64])
 
+assert_type(uniform_direction.rvs(2, size=_shape), onp.Array[tuple[int, int, *tuple[Any, ...]], np.float64])
+assert_type(uniform_direction(2).rvs(size=(2,)), onp.Array2D[np.float64])
+assert_type(uniform_direction(2).rvs(size=_shape), onp.Array[tuple[int, int, *tuple[Any, ...]], np.float64])
+
 # random_correlation
 
 assert_type(random_correlation.rvs([1, 1]).dtype, np.dtype[np.float64])
@@ -378,10 +391,17 @@ assert_type(multivariate_t().rvs().dtype, np.dtype[np.float64])
 assert_type(multivariate_hypergeom.rvs([1], 1).dtype, np.dtype[np.int_])
 assert_type(multivariate_hypergeom([1], 1).rvs().dtype, np.dtype[np.int_])
 
+assert_type(multivariate_hypergeom([1], 1).rvs(size=(2, 3)), onp.Array[tuple[int, *tuple[Any, ...]], np.int_])
+assert_type(multivariate_hypergeom([1], 1).rvs(size=_shape), onp.Array[tuple[int, *tuple[Any, ...]], np.int_])
+
 # random_table
 
 assert_type(random_table.rvs([1, 2], [2, 1]).dtype, np.dtype[np.int_])
 assert_type(random_table([1, 2], [2, 1]).rvs().dtype, np.dtype[np.int_])
+
+assert_type(random_table.rvs([1, 2], [2, 1], size=_shape), onp.Array[tuple[int, int, int, *tuple[Any, ...]], np.int_])
+assert_type(random_table([1, 2], [2, 1]).rvs(size=(2,)), onp.Array3D[np.int_])
+assert_type(random_table([1, 2], [2, 1]).rvs(size=_shape), onp.Array[tuple[int, int, int, *tuple[Any, ...]], np.int_])
 
 # dirichlet_multinomial
 
@@ -397,6 +417,9 @@ assert_type(matrix_t(df=1).rvs().dtype, np.dtype[np.float64])
 
 assert_type(vonmises_fisher.rvs([0.8, 0.6]).dtype, np.dtype[np.float64])
 assert_type(vonmises_fisher([0.8, 0.6]).rvs().dtype, np.dtype[np.float64])
+
+assert_type(vonmises_fisher.rvs([0.8, 0.6], size=_shape), onp.Array[tuple[int, int, *tuple[Any, ...]], np.float64])
+assert_type(vonmises_fisher([0.8, 0.6]).rvs(size=_shape), onp.Array[tuple[int, int, *tuple[Any, ...]], np.float64])
 
 assert_type(vonmises_fisher([0.8, 0.6], kappa=0.5).rvs().dtype, np.dtype[np.float64])
 assert_type(vonmises_fisher([0.8, 0.6], kappa=1.5).rvs().dtype, np.dtype[np.float64])


### PR DESCRIPTION
Turns out my worries about overlapping overloads leading leading to `Any` results were unfounded; adding fallback overloads for `size` doesn't seem to cause problems :tada:.

Closes #1702