### PR TITLE
🐛 `interpolate._rbfinterp_pythran`: fix names of functions

### DIFF
--- a/scipy-stubs/interpolate/_rbfinterp_pythran.pyi
+++ b/scipy-stubs/interpolate/_rbfinterp_pythran.pyi
@@ -9,10 +9,10 @@ type _Float2D = onp.Array2D[np.float64]
 
 ###
 
-__pythran__: tuple[str, str]
+__pythran__: tuple[str, str] = ...
 
-def _pythran_polynomial_matrix(x: _Float2D, powers: _Int2D, /) -> _Float2D: ...
-def _pythran_build_system(
+def _polynomial_matrix(x: _Float2D, powers: _Int2D, /) -> _Float2D: ...
+def _build_system(
     y: _Float2D, d: _Float2D, smoothing: _Float1D, kernel: str, epsilon: float, powers: _Int2D, /
 ) -> tuple[_Float2D, _Float2D, _Float1D, _Float1D]: ...
 def _build_evaluation_coefficients(


### PR DESCRIPTION
Somewhere along the road these private function names lost their `_pythran` prefixes :shrug: :

- `_pythran_polynomial_matrix` -> `_polynomial_matrix`
- `_pythran_build_system` -> `_build_system`

Kinda annoying that stubtest didn't report this...

This does not affect anything user-facing; it only affects private SciPy internals.

fixes #2014