### PR TITLE
🐛 `stats._stats_pythran`: fix internal function signatures and add missing private function stubs

### DIFF
--- a/scipy-stubs/stats/_stats_pythran.pyi
+++ b/scipy-stubs/stats/_stats_pythran.pyi
@@ -1,17 +1,48 @@
-from typing import Final, Literal
+from typing import Final, overload
 
+import numpy as np
 import optype.numpy as onp
 
-from ._stats_mstats_common import SiegelslopesResult
-
 ###
 
-type _Method = Literal["hierarchical", "separate"]
+# undocumented
+__pythran__: Final[tuple[str, str]] = ...
 
-###
+# undocumented
+@overload
+def _Aij(A: onp.Array2D[np.int_], i: int, j: int) -> int: ...
+@overload
+def _Aij(A: onp.Array2D[np.float64], i: int, j: int) -> float: ...
 
-__pythran__: Final[tuple[str, str]] = ...  # undocumented
+# undocumented
+@overload
+def _Dij(A: onp.Array2D[np.int_], i: int, j: int) -> int: ...
+@overload
+def _Dij(A: onp.Array2D[np.float64], i: int, j: int) -> float: ...
 
-def siegelslopes(
-    y: onp.ToFloatND, x: onp.ToFloatND | None = None, method: _Method = "hierarchical"
-) -> SiegelslopesResult: ...  # undocumented
+# undocumented
+@overload
+def _concordant_pairs(A: onp.Array2D[np.int_]) -> int: ...
+@overload
+def _concordant_pairs(A: onp.Array2D[np.float64]) -> float: ...
+
+# undocumented
+@overload
+def _discordant_pairs(A: onp.Array2D[np.int_]) -> int: ...
+@overload
+def _discordant_pairs(A: onp.Array2D[np.float64]) -> float: ...
+
+# undocumented
+@overload
+def _a_ij_Aij_Dij2(A: onp.Array2D[np.int_]) -> int: ...
+@overload
+def _a_ij_Aij_Dij2(A: onp.Array2D[np.float64]) -> float: ...
+
+# undocumented
+def _compute_outer_prob_inside_method(m: int, n: int, g: int, h: int) -> float: ...
+
+# undocumented
+@overload
+def siegelslopes(y: onp.Array1D[np.float64], x: onp.Array1D[np.float64], method: str) -> tuple[float, float]: ...
+@overload
+def siegelslopes(y: onp.Array1D[np.float32], x: onp.Array1D[np.float32], method: str) -> tuple[float, float]: ...


### PR DESCRIPTION
This only affects SciPy's internal and private functions; nothing affecting end users.

fixes #2015