### PR TITLE
✨ `linalg` : improve return dtypes of `ldl`

### DIFF
--- a/scipy-stubs/linalg/_decomp_ldl.pyi
+++ b/scipy-stubs/linalg/_decomp_ldl.pyi
@@ -2,37 +2,99 @@ from typing import overload
 
 import numpy as np
 import optype.numpy as onp
-import optype.numpy.compat as npc
 
 __all__ = ["ldl"]
 
 type _ISize1D = onp.Array1D[np.intp]
 type _ISizeND = onp.ArrayND[np.intp]
-type _Float2D = onp.Array2D[npc.floating]
-type _FloatND = onp.ArrayND[npc.floating]
-type _Complex2D = onp.Array2D[npc.complexfloating]
-type _ComplexND = onp.ArrayND[npc.complexfloating]
-type _InexactND = onp.ArrayND[npc.inexact]
+
+type _Float32_2D = onp.Array2D[np.float32]
+type _Float32ND = onp.ArrayND[np.float32]
+type _Float64_2D = onp.Array2D[np.float64]
+type _Float64ND = onp.ArrayND[np.float64]
+type _Float2D = onp.Array2D[np.float32 | np.float64]
+type _FloatND = onp.ArrayND[np.float32 | np.float64]
+
+type _Complex64_2D = onp.Array2D[np.complex64]
+type _Complex64ND = onp.ArrayND[np.complex64]
+type _Complex128_2D = onp.Array2D[np.complex128]
+type _Complex128ND = onp.ArrayND[np.complex128]
+type _Complex2D = onp.Array2D[np.complex64 | np.complex128]
+type _ComplexND = onp.ArrayND[np.complex64 | np.complex128]
+
+type _InexactND = onp.ArrayND[np.float32 | np.float64 | np.complex64 | np.complex128]
 
 ###
 
-@overload
+@overload  # 2d: float32 -> float32
+def ldl(  # type: ignore[overload-overlap]  # pyright: ignore[reportOverlappingOverload]
+    A: onp.ToArrayStrict2D[np.float32, np.float32],
+    lower: bool = True,
+    hermitian: bool = True,
+    overwrite_a: bool = False,
+    check_finite: bool = True,
+) -> tuple[_Float32_2D, _Float32_2D, _ISize1D]: ...
+@overload  # 2d: -> float64
+def ldl(
+    A: onp.ToFloat64Strict2D, lower: bool = True, hermitian: bool = True, overwrite_a: bool = False, check_finite: bool = True
+) -> tuple[_Float64_2D, _Float64_2D, _ISize1D]: ...
+@overload  # 2d: real -> float32 | float64
 def ldl(
     A: onp.ToFloatStrict2D, lower: bool = True, hermitian: bool = True, overwrite_a: bool = False, check_finite: bool = True
 ) -> tuple[_Float2D, _Float2D, _ISize1D]: ...
-@overload
+@overload  # nd: float32 -> float32
+def ldl(  # type: ignore[overload-overlap] # pyright: ignore[reportOverlappingOverload]
+    A: onp.ToArrayND[np.float32, np.float32],
+    lower: bool = True,
+    hermitian: bool = True,
+    overwrite_a: bool = False,
+    check_finite: bool = True,
+) -> tuple[_Float32ND, _Float32ND, _ISizeND]: ...
+@overload  # nd: -> float64
+def ldl(
+    A: onp.ToFloat64_ND, lower: bool = True, hermitian: bool = True, overwrite_a: bool = False, check_finite: bool = True
+) -> tuple[_Float64ND, _Float64ND, _ISizeND]: ...
+@overload  # nd: real -> float32 | float64
 def ldl(
     A: onp.ToFloatND, lower: bool = True, hermitian: bool = True, overwrite_a: bool = False, check_finite: bool = True
 ) -> tuple[_FloatND, _FloatND, _ISizeND]: ...
-@overload
+@overload  # 2d: complex64 -> complex64
+def ldl(  # type: ignore[overload-overlap]
+    A: onp.ToArrayStrict2D[np.complex64, np.complex64],
+    lower: bool = True,
+    hermitian: bool = True,
+    overwrite_a: bool = False,
+    check_finite: bool = True,
+) -> tuple[_Complex64_2D, _Complex64_2D, _ISize1D]: ...
+@overload  # 2d: -> complex128
+def ldl(
+    A: onp.ToJustComplex128Strict2D,
+    lower: bool = True,
+    hermitian: bool = True,
+    overwrite_a: bool = False,
+    check_finite: bool = True,
+) -> tuple[_Complex128_2D, _Complex128_2D, _ISize1D]: ...
+@overload  # 2d:complex -> complex64 | complex128
 def ldl(
     A: onp.ToJustComplexStrict2D, lower: bool = True, hermitian: bool = True, overwrite_a: bool = False, check_finite: bool = True
 ) -> tuple[_Complex2D, _Complex2D, _ISize1D]: ...
-@overload
+@overload  # nd: complex64 -> complex64
+def ldl(  # type: ignore[overload-overlap]
+    A: onp.ToArrayND[np.complex64, np.complex64],
+    lower: bool = True,
+    hermitian: bool = True,
+    overwrite_a: bool = False,
+    check_finite: bool = True,
+) -> tuple[_Complex64ND, _Complex64ND, _ISizeND]: ...
+@overload  # nd: -> complex128
+def ldl(
+    A: onp.ToJustComplex128_ND, lower: bool = True, hermitian: bool = True, overwrite_a: bool = False, check_finite: bool = True
+) -> tuple[_Complex128ND, _Complex128ND, _ISizeND]: ...
+@overload  # nd: complex -> complex64 | complex128
 def ldl(
     A: onp.ToJustComplexND, lower: bool = True, hermitian: bool = True, overwrite_a: bool = False, check_finite: bool = True
 ) -> tuple[_ComplexND, _ComplexND, _ISizeND]: ...
-@overload
+@overload  # nd: -> f32 | f64 | c64 | c128
 def ldl(
     A: onp.ToComplexND, lower: bool = True, hermitian: bool = True, overwrite_a: bool = False, check_finite: bool = True
 ) -> tuple[_InexactND, _InexactND, _ISizeND]: ...

--- a/scipy-stubs/linalg/_decomp_ldl.pyi
+++ b/scipy-stubs/linalg/_decomp_ldl.pyi
@@ -1,3 +1,9 @@
+# `onp.ToArrayND[np.float32, np.float32]` / `onp.ToJustFloat64_ND` (and the complex64/complex128
+# equivalents) are disjoint by definition, but mypy's overlap checker reports false-positive
+# overlaps between them on some numpy versions (not on numpy==2.1, for example). Since this is
+# numpy-version-dependent, per-line `type: ignore` comments would trip `unused-ignore` on the
+# versions where the false positive doesn't occur, so it's disabled for the whole module instead.
+# mypy: disable-error-code="overload-overlap"
 from typing import overload
 
 import numpy as np
@@ -32,6 +38,10 @@ def ldl(
 def ldl(
     A: onp.ToFloatStrict2D, lower: bool = True, hermitian: bool = True, overwrite_a: bool = False, check_finite: bool = True
 ) -> tuple[_Float2D, _Float2D, _ISize1D]: ...
+@overload  # nd: -> float64
+def ldl(
+    A: onp.ToJustFloat64_ND, lower: bool = True, hermitian: bool = True, overwrite_a: bool = False, check_finite: bool = True
+) -> tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64], _ISizeND]: ...
 @overload  # nd: float32 -> float32
 def ldl(
     A: onp.ToArrayND[np.float32, np.float32],
@@ -40,10 +50,6 @@ def ldl(
     overwrite_a: bool = False,
     check_finite: bool = True,
 ) -> tuple[onp.ArrayND[np.float32], onp.ArrayND[np.float32], _ISizeND]: ...
-@overload  # nd: -> float64
-def ldl(
-    A: onp.ToJustFloat64_ND, lower: bool = True, hermitian: bool = True, overwrite_a: bool = False, check_finite: bool = True
-) -> tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64], _ISizeND]: ...
 @overload  # nd: real -> float32 | float64
 def ldl(
     A: onp.ToFloatND, lower: bool = True, hermitian: bool = True, overwrite_a: bool = False, check_finite: bool = True
@@ -68,6 +74,10 @@ def ldl(
 def ldl(
     A: onp.ToJustComplexStrict2D, lower: bool = True, hermitian: bool = True, overwrite_a: bool = False, check_finite: bool = True
 ) -> tuple[_Complex2D, _Complex2D, _ISize1D]: ...
+@overload  # nd: -> complex128
+def ldl(
+    A: onp.ToJustComplex128_ND, lower: bool = True, hermitian: bool = True, overwrite_a: bool = False, check_finite: bool = True
+) -> tuple[onp.ArrayND[np.complex128], onp.ArrayND[np.complex128], _ISizeND]: ...
 @overload  # nd: complex64 -> complex64
 def ldl(
     A: onp.ToArrayND[np.complex64, np.complex64],
@@ -76,10 +86,6 @@ def ldl(
     overwrite_a: bool = False,
     check_finite: bool = True,
 ) -> tuple[onp.ArrayND[np.complex64], onp.ArrayND[np.complex64], _ISizeND]: ...
-@overload  # nd: -> complex128
-def ldl(
-    A: onp.ToJustComplex128_ND, lower: bool = True, hermitian: bool = True, overwrite_a: bool = False, check_finite: bool = True
-) -> tuple[onp.ArrayND[np.complex128], onp.ArrayND[np.complex128], _ISizeND]: ...
 @overload  # nd: complex -> complex64 | complex128
 def ldl(
     A: onp.ToJustComplexND, lower: bool = True, hermitian: bool = True, overwrite_a: bool = False, check_finite: bool = True

--- a/scipy-stubs/linalg/_decomp_ldl.pyi
+++ b/scipy-stubs/linalg/_decomp_ldl.pyi
@@ -16,7 +16,6 @@ type _ISizeND = onp.ArrayND[np.intp]
 
 type _Float2D = onp.Array2D[np.float32 | np.float64]
 type _FloatND = onp.ArrayND[np.float32 | np.float64]
-type _Complex2D = onp.Array2D[np.complex64 | np.complex128]
 type _ComplexND = onp.ArrayND[np.complex64 | np.complex128]
 type _InexactND = onp.ArrayND[np.float32 | np.float64 | np.complex64 | np.complex128]
 
@@ -70,10 +69,6 @@ def ldl(
     overwrite_a: bool = False,
     check_finite: bool = True,
 ) -> tuple[onp.Array2D[np.complex64], onp.Array2D[np.complex64], _ISize1D]: ...
-@overload  # 2d: complex -> complex64 | complex128
-def ldl(
-    A: onp.ToJustComplexStrict2D, lower: bool = True, hermitian: bool = True, overwrite_a: bool = False, check_finite: bool = True
-) -> tuple[_Complex2D, _Complex2D, _ISize1D]: ...
 @overload  # nd: -> complex128
 def ldl(
     A: onp.ToJustComplex128_ND, lower: bool = True, hermitian: bool = True, overwrite_a: bool = False, check_finite: bool = True

--- a/scipy-stubs/linalg/_decomp_ldl.pyi
+++ b/scipy-stubs/linalg/_decomp_ldl.pyi
@@ -1,8 +1,4 @@
-# `onp.ToArrayND[np.float32, np.float32]` / `onp.ToJustFloat64_ND` (and the complex64/complex128
-# equivalents) are disjoint by definition, but mypy's overlap checker reports false-positive
-# overlaps between them on some numpy versions (not on numpy==2.1, for example). Since this is
-# numpy-version-dependent, per-line `type: ignore` comments would trip `unused-ignore` on the
-# versions where the false positive doesn't occur, so it's disabled for the whole module instead.
+# turned off for this file: mypy wrongly flags these types as overlapping
 # mypy: disable-error-code="overload-overlap"
 from typing import overload
 

--- a/scipy-stubs/linalg/_decomp_ldl.pyi
+++ b/scipy-stubs/linalg/_decomp_ldl.pyi
@@ -33,7 +33,7 @@ def ldl(
     A: onp.ToFloatStrict2D, lower: bool = True, hermitian: bool = True, overwrite_a: bool = False, check_finite: bool = True
 ) -> tuple[_Float2D, _Float2D, _ISize1D]: ...
 @overload  # nd: float32 -> float32
-def ldl(  # type: ignore[overload-overlap]
+def ldl(
     A: onp.ToArrayND[np.float32, np.float32],
     lower: bool = True,
     hermitian: bool = True,
@@ -69,7 +69,7 @@ def ldl(
     A: onp.ToJustComplexStrict2D, lower: bool = True, hermitian: bool = True, overwrite_a: bool = False, check_finite: bool = True
 ) -> tuple[_Complex2D, _Complex2D, _ISize1D]: ...
 @overload  # nd: complex64 -> complex64
-def ldl(  # type: ignore[overload-overlap]
+def ldl(
     A: onp.ToArrayND[np.complex64, np.complex64],
     lower: bool = True,
     hermitian: bool = True,

--- a/scipy-stubs/linalg/_decomp_ldl.pyi
+++ b/scipy-stubs/linalg/_decomp_ldl.pyi
@@ -8,64 +8,46 @@ __all__ = ["ldl"]
 type _ISize1D = onp.Array1D[np.intp]
 type _ISizeND = onp.ArrayND[np.intp]
 
-type _Float32_2D = onp.Array2D[np.float32]
-type _Float32ND = onp.ArrayND[np.float32]
-type _Float64_2D = onp.Array2D[np.float64]
-type _Float64ND = onp.ArrayND[np.float64]
 type _Float2D = onp.Array2D[np.float32 | np.float64]
 type _FloatND = onp.ArrayND[np.float32 | np.float64]
-
-type _Complex64_2D = onp.Array2D[np.complex64]
-type _Complex64ND = onp.ArrayND[np.complex64]
-type _Complex128_2D = onp.Array2D[np.complex128]
-type _Complex128ND = onp.ArrayND[np.complex128]
 type _Complex2D = onp.Array2D[np.complex64 | np.complex128]
 type _ComplexND = onp.ArrayND[np.complex64 | np.complex128]
-
 type _InexactND = onp.ArrayND[np.float32 | np.float64 | np.complex64 | np.complex128]
 
 ###
 
+@overload  # 2d: -> float64
+def ldl(
+    A: onp.ToJustFloat64Strict2D, lower: bool = True, hermitian: bool = True, overwrite_a: bool = False, check_finite: bool = True
+) -> tuple[onp.Array2D[np.float64], onp.Array2D[np.float64], _ISize1D]: ...
 @overload  # 2d: float32 -> float32
-def ldl(  # type: ignore[overload-overlap]  # pyright: ignore[reportOverlappingOverload]
+def ldl(
     A: onp.ToArrayStrict2D[np.float32, np.float32],
     lower: bool = True,
     hermitian: bool = True,
     overwrite_a: bool = False,
     check_finite: bool = True,
-) -> tuple[_Float32_2D, _Float32_2D, _ISize1D]: ...
-@overload  # 2d: -> float64
-def ldl(
-    A: onp.ToFloat64Strict2D, lower: bool = True, hermitian: bool = True, overwrite_a: bool = False, check_finite: bool = True
-) -> tuple[_Float64_2D, _Float64_2D, _ISize1D]: ...
+) -> tuple[onp.Array2D[np.float32], onp.Array2D[np.float32], _ISize1D]: ...
 @overload  # 2d: real -> float32 | float64
 def ldl(
     A: onp.ToFloatStrict2D, lower: bool = True, hermitian: bool = True, overwrite_a: bool = False, check_finite: bool = True
 ) -> tuple[_Float2D, _Float2D, _ISize1D]: ...
 @overload  # nd: float32 -> float32
-def ldl(  # type: ignore[overload-overlap] # pyright: ignore[reportOverlappingOverload]
+def ldl(  # type: ignore[overload-overlap]
     A: onp.ToArrayND[np.float32, np.float32],
     lower: bool = True,
     hermitian: bool = True,
     overwrite_a: bool = False,
     check_finite: bool = True,
-) -> tuple[_Float32ND, _Float32ND, _ISizeND]: ...
+) -> tuple[onp.ArrayND[np.float32], onp.ArrayND[np.float32], _ISizeND]: ...
 @overload  # nd: -> float64
 def ldl(
-    A: onp.ToFloat64_ND, lower: bool = True, hermitian: bool = True, overwrite_a: bool = False, check_finite: bool = True
-) -> tuple[_Float64ND, _Float64ND, _ISizeND]: ...
+    A: onp.ToJustFloat64_ND, lower: bool = True, hermitian: bool = True, overwrite_a: bool = False, check_finite: bool = True
+) -> tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64], _ISizeND]: ...
 @overload  # nd: real -> float32 | float64
 def ldl(
     A: onp.ToFloatND, lower: bool = True, hermitian: bool = True, overwrite_a: bool = False, check_finite: bool = True
 ) -> tuple[_FloatND, _FloatND, _ISizeND]: ...
-@overload  # 2d: complex64 -> complex64
-def ldl(  # type: ignore[overload-overlap]
-    A: onp.ToArrayStrict2D[np.complex64, np.complex64],
-    lower: bool = True,
-    hermitian: bool = True,
-    overwrite_a: bool = False,
-    check_finite: bool = True,
-) -> tuple[_Complex64_2D, _Complex64_2D, _ISize1D]: ...
 @overload  # 2d: -> complex128
 def ldl(
     A: onp.ToJustComplex128Strict2D,
@@ -73,8 +55,16 @@ def ldl(
     hermitian: bool = True,
     overwrite_a: bool = False,
     check_finite: bool = True,
-) -> tuple[_Complex128_2D, _Complex128_2D, _ISize1D]: ...
-@overload  # 2d:complex -> complex64 | complex128
+) -> tuple[onp.Array2D[np.complex128], onp.Array2D[np.complex128], _ISize1D]: ...
+@overload  # 2d: complex64 -> complex64
+def ldl(
+    A: onp.ToArrayStrict2D[np.complex64, np.complex64],
+    lower: bool = True,
+    hermitian: bool = True,
+    overwrite_a: bool = False,
+    check_finite: bool = True,
+) -> tuple[onp.Array2D[np.complex64], onp.Array2D[np.complex64], _ISize1D]: ...
+@overload  # 2d: complex -> complex64 | complex128
 def ldl(
     A: onp.ToJustComplexStrict2D, lower: bool = True, hermitian: bool = True, overwrite_a: bool = False, check_finite: bool = True
 ) -> tuple[_Complex2D, _Complex2D, _ISize1D]: ...
@@ -85,11 +75,11 @@ def ldl(  # type: ignore[overload-overlap]
     hermitian: bool = True,
     overwrite_a: bool = False,
     check_finite: bool = True,
-) -> tuple[_Complex64ND, _Complex64ND, _ISizeND]: ...
+) -> tuple[onp.ArrayND[np.complex64], onp.ArrayND[np.complex64], _ISizeND]: ...
 @overload  # nd: -> complex128
 def ldl(
     A: onp.ToJustComplex128_ND, lower: bool = True, hermitian: bool = True, overwrite_a: bool = False, check_finite: bool = True
-) -> tuple[_Complex128ND, _Complex128ND, _ISizeND]: ...
+) -> tuple[onp.ArrayND[np.complex128], onp.ArrayND[np.complex128], _ISizeND]: ...
 @overload  # nd: complex -> complex64 | complex128
 def ldl(
     A: onp.ToJustComplexND, lower: bool = True, hermitian: bool = True, overwrite_a: bool = False, check_finite: bool = True

--- a/tests/linalg/test__decomp_ldl.pyi
+++ b/tests/linalg/test__decomp_ldl.pyi
@@ -3,6 +3,7 @@
 from typing import assert_type
 
 import numpy as np
+import optype as op
 import optype.numpy as onp
 import optype.numpy.compat as npc
 
@@ -11,15 +12,52 @@ from scipy.linalg import ldl
 ###
 # Input arrays
 
+py_int_2d: list[list[int]]
+py_float_2d: list[list[float]]
+py_complex_2d: list[list[op.JustComplex]]
+
+i64_2d: onp.Array2D[np.int64]
+f32_2d: onp.Array2D[np.float32]
+f32_3d: onp.Array3D[np.float32]
 f64_2d: onp.Array2D[np.float64]
 f64_3d: onp.Array3D[np.float64]
+
+c64_2d: onp.Array2D[np.complex64]
+c64_3d: onp.Array3D[np.complex64]
 c128_2d: onp.Array2D[np.complex128]
 c128_3d: onp.Array3D[np.complex128]
+
+inexact_3d: onp.Array3D[npc.inexact]
 
 ###
 # ldl
 
-assert_type(ldl(f64_2d), tuple[onp.Array2D[npc.floating], onp.Array2D[npc.floating], onp.Array1D[np.intp]])
-assert_type(ldl(f64_3d), tuple[onp.ArrayND[npc.floating], onp.ArrayND[npc.floating], onp.ArrayND[np.intp]])
-assert_type(ldl(c128_2d), tuple[onp.Array2D[npc.complexfloating], onp.Array2D[npc.complexfloating], onp.Array1D[np.intp]])
-assert_type(ldl(c128_3d), tuple[onp.ArrayND[npc.complexfloating], onp.ArrayND[npc.complexfloating], onp.ArrayND[np.intp]])
+# -> float32
+assert_type(ldl(f32_2d), tuple[onp.Array2D[np.float32], onp.Array2D[np.float32], onp.Array1D[np.intp]])
+assert_type(ldl(f32_3d), tuple[onp.ArrayND[np.float32], onp.ArrayND[np.float32], onp.ArrayND[np.intp]])
+
+# -> float64
+assert_type(ldl(py_int_2d), tuple[onp.Array2D[np.float64], onp.Array2D[np.float64], onp.Array1D[np.intp]])
+assert_type(ldl(py_float_2d), tuple[onp.Array2D[np.float64], onp.Array2D[np.float64], onp.Array1D[np.intp]])
+assert_type(ldl(i64_2d), tuple[onp.Array2D[np.float64], onp.Array2D[np.float64], onp.Array1D[np.intp]])
+assert_type(ldl(f64_2d), tuple[onp.Array2D[np.float64], onp.Array2D[np.float64], onp.Array1D[np.intp]])
+assert_type(ldl(f64_3d), tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64], onp.ArrayND[np.intp]])
+
+# -> complex64
+assert_type(ldl(c64_2d), tuple[onp.Array2D[np.complex64], onp.Array2D[np.complex64], onp.Array1D[np.intp]])
+assert_type(ldl(c64_3d), tuple[onp.ArrayND[np.complex64], onp.ArrayND[np.complex64], onp.ArrayND[np.intp]])
+
+# -> complex128
+assert_type(ldl(py_complex_2d), tuple[onp.Array2D[np.complex128], onp.Array2D[np.complex128], onp.Array1D[np.intp]])
+assert_type(ldl(c128_2d), tuple[onp.Array2D[np.complex128], onp.Array2D[np.complex128], onp.Array1D[np.intp]])
+assert_type(ldl(c128_3d), tuple[onp.ArrayND[np.complex128], onp.ArrayND[np.complex128], onp.ArrayND[np.intp]])
+
+# -> f32 | f64 | c64 | c128
+assert_type(
+    ldl(inexact_3d),
+    tuple[
+        onp.ArrayND[np.float32 | np.float64 | np.complex64 | np.complex128],
+        onp.ArrayND[np.float32 | np.float64 | np.complex64 | np.complex128],
+        onp.ArrayND[np.intp],
+    ],
+)

--- a/tests/linalg/test__decomp_ldl.pyi
+++ b/tests/linalg/test__decomp_ldl.pyi
@@ -37,11 +37,15 @@ assert_type(ldl(f32_2d), tuple[onp.Array2D[np.float32], onp.Array2D[np.float32],
 assert_type(ldl(f32_3d), tuple[onp.ArrayND[np.float32], onp.ArrayND[np.float32], onp.ArrayND[np.intp]])
 
 # -> float64
-assert_type(ldl(py_int_2d), tuple[onp.Array2D[np.float64], onp.Array2D[np.float64], onp.Array1D[np.intp]])
 assert_type(ldl(py_float_2d), tuple[onp.Array2D[np.float64], onp.Array2D[np.float64], onp.Array1D[np.intp]])
-assert_type(ldl(i64_2d), tuple[onp.Array2D[np.float64], onp.Array2D[np.float64], onp.Array1D[np.intp]])
 assert_type(ldl(f64_2d), tuple[onp.Array2D[np.float64], onp.Array2D[np.float64], onp.Array1D[np.intp]])
 assert_type(ldl(f64_3d), tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64], onp.ArrayND[np.intp]])
+
+# -> float32 | float64
+assert_type(
+    ldl(py_int_2d), tuple[onp.Array2D[np.float32 | np.float64], onp.Array2D[np.float32 | np.float64], onp.Array1D[np.intp]]
+)
+assert_type(ldl(i64_2d), tuple[onp.Array2D[np.float32 | np.float64], onp.Array2D[np.float32 | np.float64], onp.Array1D[np.intp]])
 
 # -> complex64
 assert_type(ldl(c64_2d), tuple[onp.Array2D[np.complex64], onp.Array2D[np.complex64], onp.Array1D[np.intp]])


### PR DESCRIPTION
Towards #1320 

Added overload so that:
- `float32` and `complex64` arrays keep their dtype
- anything converted to `float64` return `float64` and likewise for `complex128`
- other real/complex input falls back to `float32 | float64` and `complex64 | complex128`
- input of unkown kind returns the union of all four

