### PR TITLE
⬆️ ruff 0.16.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ ci = ["packaging>=26.2"]
 lint = [
   { include-group = "extras" },
   "dprint-py==0.55.2.0",
-  "ruff==0.15.21",
+  "ruff==0.16.0",
   "sp-repo-review[cli]==2026.6.18",
 ]
 type = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -256,11 +256,30 @@ skip-magic-trailing-comma = true
 
 [tool.ruff.lint]
 select = ["ALL"]
-ignore = ["D", "FBT", "ANN401", "COM812", "CPY", "EM", "TD", "FIX", "DOC"]
-extend-safe-fixes = ["UP047"]
+ignore = [
+  "D",
+  "FBT",
+  "CPY",
+  "EM",
+  "TD",
+  "FIX",
+  "DOC",
+  "any-type",
+  "missing-trailing-comma",
+]
 
 [tool.ruff.lint.per-file-ignores]
-"*.pyi" = ["F", "E741", "N", "A", "PYI054", "PLC2701", "PLW3201", "PLR", "FURB"]
+"*.pyi" = [
+  "F",
+  "N",
+  "A",
+  "PLR",
+  "FURB",
+  "ambiguous-variable-name",
+  "numeric-literal-too-long",
+  "import-private-name",
+  "bad-dunder-method-name",
+]
 
 [tool.ruff.lint.flake8-import-conventions]
 banned-from = ["numpy", "numpy.typing", "optype", "optype.numpy", "optype.typing"]

--- a/scipy-stubs/__init__.pyi
+++ b/scipy-stubs/__init__.pyi
@@ -1,7 +1,7 @@
 from collections.abc import Sequence
 from typing import Final, Literal
 
-from numpy import __version__ as __numpy_version__  # noqa: ICN003
+from numpy import __version__ as __numpy_version__  # ruff: ignore[banned-import-from]
 
 from . import (
     cluster,

--- a/scipy-stubs/_lib/_docscrape.pyi
+++ b/scipy-stubs/_lib/_docscrape.pyi
@@ -56,7 +56,7 @@ class FunctionDoc(NumpyDocString, Generic[_FunctionT]):
     ) -> None: ...
     @override
     # pyrefly: ignore [bad-override]
-    def __str__(self, /) -> str: ...  # type: ignore[override] # pyright: ignore[reportIncompatibleMethodOverride]  # ty: ignore[invalid-method-override]  # noqa: PYI029
+    def __str__(self, /) -> str: ...  # type: ignore[override] # pyright: ignore[reportIncompatibleMethodOverride]  # ty: ignore[invalid-method-override]  # ruff: ignore[str-or-repr-defined-in-stub]
     def get_func(self, /) -> _FunctionT: ...
 
 class ClassDoc(NumpyDocString):

--- a/scipy-stubs/_lib/_util.pyi
+++ b/scipy-stubs/_lib/_util.pyi
@@ -28,7 +28,7 @@ type _RNG = Any
 type SeedType = Any
 
 # see https://github.com/scipy/scipy/pull/25225
-GeneratorType = TypeVar("GeneratorType", bound=_RNG)  # noqa: PYI001
+GeneratorType = TypeVar("GeneratorType", bound=_RNG)  # ruff: ignore[unprefixed-type-param]
 
 if sys.version_info >= (3, 14):
     def wrapped_inspect_signature(callable: Callable[..., object]) -> inspect.Signature: ...

--- a/scipy-stubs/integrate/_tanhsinh.pyi
+++ b/scipy-stubs/integrate/_tanhsinh.pyi
@@ -27,7 +27,7 @@ _MaxLevelT_co = TypeVar("_MaxLevelT_co", covariant=True)
 @type_check_only
 class _TanhSinhResult(
     _RichResult[_ResultT_co | _SuccessT_co | _StatusT_co | _MaxLevelT_co],
-    Generic[_ResultT_co, _SuccessT_co, _StatusT_co, _MaxLevelT_co],  # noqa: UP046
+    Generic[_ResultT_co, _SuccessT_co, _StatusT_co, _MaxLevelT_co],  # ruff: ignore[non-pep695-generic-class]
 ):
     integral: _ResultT_co
     error: _ResultT_co

--- a/scipy-stubs/interpolate/_interpolate.pyi
+++ b/scipy-stubs/interpolate/_interpolate.pyi
@@ -41,7 +41,7 @@ For scattered data, prefer `LinearNDInterpolator` or
 
 For more details see
 https://scipy.github.io/devdocs/tutorial/interpolate/interp_transition_guide.html
-"""  # noqa: PYI053  # undocumented
+"""  # ruff: ignore[string-or-bytes-too-long]  # undocumented
 
 @deprecated(err_mesg)
 class interp2d:

--- a/scipy-stubs/io/_fortran.pyi
+++ b/scipy-stubs/io/_fortran.pyi
@@ -20,7 +20,7 @@ class FortranFile(ExitMixin):
         /,
         filename: FileLike[bytes],
         mode: Literal["r", "w"] = "r",
-        header_dtype: onp.AnyDType = np.uint32,  # noqa: PYI011
+        header_dtype: onp.AnyDType = np.uint32,  # ruff: ignore[typed-argument-default-in-stub]
     ) -> None: ...
 
     #

--- a/scipy-stubs/io/matlab/_mio5_utils.pyi
+++ b/scipy-stubs/io/matlab/_mio5_utils.pyi
@@ -11,7 +11,7 @@ import optype.numpy.compat as npc
 from ._miobase import MatVarReader
 from ._streams import GenericStream, _FileLike
 
-type _bint = Literal[0, 1] | bool  # noqa: PYI042
+type _bint = Literal[0, 1] | bool  # ruff: ignore[snake-case-type-alias]
 
 ###
 

--- a/scipy-stubs/linalg/_decomp_cholesky.pyi
+++ b/scipy-stubs/linalg/_decomp_cholesky.pyi
@@ -10,10 +10,10 @@ __all__ = ["cho_factor", "cho_solve", "cho_solve_banded", "cholesky", "cholesky_
 
 ###
 
-type _as_f32 = np.float32 | np.float16 | npc.integer16 | npc.integer8 | np.bool  # noqa: PYI042
-type _as_f64 = npc.floating64 | npc.floating80 | npc.integer64 | npc.integer32  # noqa: PYI042
-type _as_c64 = np.complex64  # noqa: PYI042
-type _as_c128 = npc.complexfloating160 | npc.complexfloating128  # noqa: PYI042
+type _as_f32 = np.float32 | np.float16 | npc.integer16 | npc.integer8 | np.bool  # ruff: ignore[snake-case-type-alias]
+type _as_f64 = npc.floating64 | npc.floating80 | npc.integer64 | npc.integer32  # ruff: ignore[snake-case-type-alias]
+type _as_c64 = np.complex64  # ruff: ignore[snake-case-type-alias]
+type _as_c128 = npc.complexfloating160 | npc.complexfloating128  # ruff: ignore[snake-case-type-alias]
 
 type _Sequence2D[T] = Sequence[Sequence[T]]
 

--- a/scipy-stubs/linalg/_decomp_interpolative.pyi
+++ b/scipy-stubs/linalg/_decomp_interpolative.pyi
@@ -52,7 +52,7 @@ __all__ = [
 ]
 
 ###
-# ruff: noqa: PYI042
+# ruff: file-ignore[snake-case-type-alias]
 
 type _rng = onp.random.ToRNG
 

--- a/scipy-stubs/linalg/_decomp_lu.pyi
+++ b/scipy-stubs/linalg/_decomp_lu.pyi
@@ -9,9 +9,9 @@ __all__ = ["lu", "lu_factor", "lu_solve"]
 
 ###
 
-type _as_f32 = np.float32 | np.float16 | npc.integer16 | npc.integer8 | np.bool  # noqa: PYI042
-type _as_f64 = npc.floating64 | npc.floating80 | npc.integer64 | npc.integer32  # noqa: PYI042
-type _as_c128 = npc.complexfloating160 | npc.complexfloating128  # noqa: PYI042
+type _as_f32 = np.float32 | np.float16 | npc.integer16 | npc.integer8 | np.bool  # ruff: ignore[snake-case-type-alias]
+type _as_f64 = npc.floating64 | npc.floating80 | npc.integer64 | npc.integer32  # ruff: ignore[snake-case-type-alias]
+type _as_c128 = npc.complexfloating160 | npc.complexfloating128  # ruff: ignore[snake-case-type-alias]
 
 type _PivND = onp.ToArrayND[int, npc.integer]
 type _Trans = Literal[0, 1, 2]

--- a/scipy-stubs/linalg/_decomp_schur.pyi
+++ b/scipy-stubs/linalg/_decomp_schur.pyi
@@ -19,9 +19,9 @@ type _Output = Literal[_OutputReal, _OutputComplex]
 
 type _Sort = Literal["lhp", "rhp", "iuc", "ouc"] | Callable[[float, float], bool]
 
-type _as_f32 = np.float32 | np.float16 | np.bool  # noqa: PYI042
-type _as_f64 = npc.floating64 | npc.floating80 | npc.integer  # noqa: PYI042
-type _as_c128 = npc.complexfloating128 | npc.complexfloating160  # noqa: PYI042
+type _as_f32 = np.float32 | np.float16 | np.bool  # ruff: ignore[snake-case-type-alias]
+type _as_f64 = npc.floating64 | npc.floating80 | npc.integer  # ruff: ignore[snake-case-type-alias]
+type _as_c128 = npc.complexfloating128 | npc.complexfloating160  # ruff: ignore[snake-case-type-alias]
 
 ###
 

--- a/scipy-stubs/ndimage/_interpolation.pyi
+++ b/scipy-stubs/ndimage/_interpolation.pyi
@@ -30,7 +30,7 @@ def spline_filter1d(
     input: onp.ToFloatND,
     order: _Order = 3,
     axis: int = -1,
-    output: type[float | np.float64] = np.float64,  # noqa: PYI011
+    output: type[float | np.float64] = np.float64,  # ruff: ignore[typed-argument-default-in-stub]
     mode: _Mode = "mirror",
 ) -> onp.ArrayND[np.float64]: ...
 @overload
@@ -51,7 +51,7 @@ def spline_filter1d[ScalarT: np.generic](
 def spline_filter(
     input: onp.ToFloatND,
     order: _Order = 3,
-    output: type[float | np.float64] = np.float64,  # noqa: PYI011
+    output: type[float | np.float64] = np.float64,  # ruff: ignore[typed-argument-default-in-stub]
     mode: _Mode = "mirror",
 ) -> onp.ArrayND[np.float64]: ...
 @overload

--- a/scipy-stubs/ndimage/_ni_label.pyi
+++ b/scipy-stubs/ndimage/_ni_label.pyi
@@ -7,7 +7,7 @@ import optype.numpy.compat as npc
 ###
 
 # matches `ctypedef fused data_t`
-type _data_t = npc.integer | np.float32 | np.float64  # noqa: PYI042
+type _data_t = npc.integer | np.float32 | np.float64  # ruff: ignore[snake-case-type-alias]
 
 ###
 

--- a/scipy-stubs/odr/_odrpack.pyi
+++ b/scipy-stubs/odr/_odrpack.pyi
@@ -21,9 +21,9 @@ type _Float2D = onp.Array2D[np.float64]
 type _FloatND = onp.ArrayND[np.float64]
 type _FCN = Callable[Concatenate[_Float1D, _FloatND, ...], onp.ArrayND[_ToFloatScalar]]
 
-type _01 = Literal[0, 1]  # noqa: PYI042
-type _012 = Literal[0, 1, 2]  # noqa: PYI042
-type _0123 = Literal[0, 1, 2, 3]  # noqa: PYI042
+type _01 = Literal[0, 1]  # ruff: ignore[snake-case-type-alias]
+type _012 = Literal[0, 1, 2]  # ruff: ignore[snake-case-type-alias]
+type _0123 = Literal[0, 1, 2, 3]  # ruff: ignore[snake-case-type-alias]
 
 # return value of `__odrpack.odr` with `full_output=False`
 type _RawOutput = tuple[

--- a/scipy-stubs/signal/_delegators.pyi
+++ b/scipy-stubs/signal/_delegators.pyi
@@ -143,7 +143,7 @@ def savgol_coeffs_signature[ModuleT: ModuleType](
 ) -> ModuleT: ...
 
 #
-def unit_impulse_signature(shape: _, idx: _ = None, dtype: _ = float) -> _NumpyModule: ...  # noqa: PYI011
+def unit_impulse_signature(shape: _, idx: _ = None, dtype: _ = float) -> _NumpyModule: ...  # ruff: ignore[typed-argument-default-in-stub]
 
 #
 def buttord_signature[ArrayT](

--- a/scipy-stubs/signal/_filter_design.pyi
+++ b/scipy-stubs/signal/_filter_design.pyi
@@ -254,7 +254,7 @@ def normalize(b: onp.ToComplex128_ND, a: onp.ToJustComplex128_ND) -> _BaND[np.co
 @overload  # ~c128, +c128
 def normalize(b: onp.ToJustComplex128_ND, a: onp.ToComplex128_ND) -> _BaND[np.complex128]: ...
 @overload  # ~T, ~T
-def normalize(b: onp.ArrayND[_AnyInexactT], a: onp.ArrayND[_AnyInexactT]) -> _BaND[_AnyInexactT]: ...  # noqa: UP047
+def normalize(b: onp.ArrayND[_AnyInexactT], a: onp.ArrayND[_AnyInexactT]) -> _BaND[_AnyInexactT]: ...  # ruff: ignore[non-pep695-generic-function]
 @overload  # fallback
 def normalize(b: onp.ToComplexND, a: onp.ToComplexND) -> _BaND[Any]: ...
 

--- a/scipy-stubs/signal/_signaltools.pyi
+++ b/scipy-stubs/signal/_signaltools.pyi
@@ -54,9 +54,9 @@ __all__ = [
 
 ###
 
-type _1D = tuple[int]  # noqa: PYI042
-type _2D = tuple[int, int]  # noqa: PYI042
-type _3D = tuple[int, int]  # noqa: PYI042
+type _1D = tuple[int]  # ruff: ignore[snake-case-type-alias]
+type _2D = tuple[int, int]  # ruff: ignore[snake-case-type-alias]
+type _3D = tuple[int, int]  # ruff: ignore[snake-case-type-alias]
 
 type _Tuple2[_T] = tuple[_T, _T]
 

--- a/scipy-stubs/signal/_spectral_py.pyi
+++ b/scipy-stubs/signal/_spectral_py.pyi
@@ -13,13 +13,13 @@ __all__ = ["check_COLA", "check_NOLA", "coherence", "csd", "istft", "lombscargle
 
 ###
 
-type _float64_1d = onp.Array1D[np.float64]  # noqa: PYI042
-type _float32_nd = onp.ArrayND[np.float32]  # noqa: PYI042
-type _float64_nd = onp.ArrayND[np.float64]  # noqa: PYI042
-type _float80_nd = onp.ArrayND[np.float96 | np.float128]  # noqa: PYI042
-type _complex64_nd = onp.ArrayND[np.complex64]  # noqa: PYI042
-type _complex128_nd = onp.ArrayND[np.complex128]  # noqa: PYI042
-type _complex160_nd = onp.ArrayND[np.complex192 | np.complex256]  # noqa: PYI042
+type _float64_1d = onp.Array1D[np.float64]  # ruff: ignore[snake-case-type-alias]
+type _float32_nd = onp.ArrayND[np.float32]  # ruff: ignore[snake-case-type-alias]
+type _float64_nd = onp.ArrayND[np.float64]  # ruff: ignore[snake-case-type-alias]
+type _float80_nd = onp.ArrayND[np.float96 | np.float128]  # ruff: ignore[snake-case-type-alias]
+type _complex64_nd = onp.ArrayND[np.complex64]  # ruff: ignore[snake-case-type-alias]
+type _complex128_nd = onp.ArrayND[np.complex128]  # ruff: ignore[snake-case-type-alias]
+type _complex160_nd = onp.ArrayND[np.complex192 | np.complex256]  # ruff: ignore[snake-case-type-alias]
 
 type _ToInexact32ND = onp.ToArrayND[npc.inexact32, npc.inexact32 | npc.floating16]
 type _ToInexact64ND = onp.ToArrayND[complex, npc.inexact64 | npc.integer | np.bool]

--- a/scipy-stubs/signal/_upfirdn.pyi
+++ b/scipy-stubs/signal/_upfirdn.pyi
@@ -10,7 +10,7 @@ __all__ = ["_output_len", "upfirdn"]
 ###
 
 type _FIRMode = Literal["constant", "symmetric", "reflect", "wrap"]
-type _int64_t = int | np.int64  # noqa: PYI042
+type _int64_t = int | np.int64  # ruff: ignore[snake-case-type-alias]
 
 ###
 

--- a/scipy-stubs/sparse/_base.pyi
+++ b/scipy-stubs/sparse/_base.pyi
@@ -28,8 +28,8 @@ __all__ = ["SparseEfficiencyWarning", "SparseWarning", "issparse", "isspmatrix",
 ###
 
 type _Numeric = npc.number | np.bool
-type _1D = tuple[int]  # noqa: PYI042
-type _2D = tuple[int, int]  # noqa: PYI042
+type _1D = tuple[int]  # ruff: ignore[snake-case-type-alias]
+type _2D = tuple[int, int]  # ruff: ignore[snake-case-type-alias]
 
 type _FromInt = npc.number
 type _FromFloat = npc.inexact
@@ -868,7 +868,7 @@ class _spbase(SparseABC, Generic[_ScalarT_co, _ShapeT_co]):  # pyrefly: ignore[i
 
     #
     @property
-    def mT[SelfT: _spbase[Any, onp.AtLeast2D]](self: SelfT) -> SelfT: ...  # noqa: PYI019
+    def mT[SelfT: _spbase[Any, onp.AtLeast2D]](self: SelfT) -> SelfT: ...  # ruff: ignore[custom-type-var-for-self]
 
     #
     def diagonal(self, /, k: int = 0) -> onp.Array1D[_ScalarT_co]: ...  # only if 2-d

--- a/scipy-stubs/sparse/_csparsetools.pyi
+++ b/scipy-stubs/sparse/_csparsetools.pyi
@@ -31,7 +31,7 @@ _FusedScalarT = TypeVar(
 
 ###
 
-# ruff: noqa: UP047
+# ruff: file-ignore[non-pep695-generic-function]
 
 #
 def lil_get1(

--- a/scipy-stubs/sparse/_dok.pyi
+++ b/scipy-stubs/sparse/_dok.pyi
@@ -21,8 +21,8 @@ __all__ = ["dok_array", "dok_matrix", "isspmatrix_dok"]
 
 ###
 
-type _1D = tuple[int]  # noqa: PYI042
-type _2D = tuple[int, int]  # noqa: PYI042
+type _1D = tuple[int]  # ruff: ignore[snake-case-type-alias]
+type _2D = tuple[int, int]  # ruff: ignore[snake-case-type-alias]
 # workaround for the typing-spec non-conformance regarding overload behavior of mypy and pyright
 type _NoD = tuple[Never] | tuple[Never, Never]
 type _AnyD = tuple[Any, ...]

--- a/scipy-stubs/sparse/_index.pyi
+++ b/scipy-stubs/sparse/_index.pyi
@@ -15,8 +15,8 @@ from ._matrix import spmatrix
 
 type _ToNumber = SupportsIndex | SupportsInt | SupportsFloat | SupportsComplex | str | Buffer
 
-type _1D = tuple[int]  # noqa: PYI042
-type _2D = tuple[int, int]  # noqa: PYI042
+type _1D = tuple[int]  # ruff: ignore[snake-case-type-alias]
+type _2D = tuple[int, int]  # ruff: ignore[snake-case-type-alias]
 
 # 1d simple index
 type _ToIndex1 = int | tuple[int]

--- a/scipy-stubs/sparse/_sparsetools.pyi
+++ b/scipy-stubs/sparse/_sparsetools.pyi
@@ -22,8 +22,8 @@ import optype.numpy.compat as npc
 
 ###
 
-type _i = int | np.int32 | np.int64  # noqa: PYI042
-type _l = int | np.int64  # noqa: PYI042
+type _i = int | np.int32 | np.int64  # ruff: ignore[snake-case-type-alias]
+type _l = int | np.int64  # ruff: ignore[snake-case-type-alias]
 type _I = onp.ArrayND[np.int32 | np.int64]
 type _T = onp.ArrayND[npc.number | np.bool]
 type _V = Sequence[_i]

--- a/scipy-stubs/sparse/linalg/_interface.pyi
+++ b/scipy-stubs/sparse/linalg/_interface.pyi
@@ -57,6 +57,9 @@ class _HasShapeAndDTypeAndMatVec(Protocol[_SCT_co, _ShapeT_co]):
 
 ###
 
+# ruff: file-ignore[commented-out-code]
+# ^^^ needed for the commented-out `LinearOperator.__init__`  code below (mypy workaround)
+
 class LinearOperator(Generic[_SCT_co, _ShapeT_co]):
     __array_ufunc__: ClassVar[None] = None
 
@@ -198,8 +201,6 @@ class LinearOperator(Generic[_SCT_co, _ShapeT_co]):
 
     # NOTE: the `__init__` method cannot be annotated, because it will cause mypy to ignore `__new__`:
     # https://github.com/python/mypy/issues/17251
-
-    # ruff: noqa: ERA001
 
     # @overload
     # def __init__(self, /, dtype: onp.ToDType[_SCT_co], shape: _ShapeT_co) -> None: ...

--- a/scipy-stubs/spatial/_ckdtree.pyi
+++ b/scipy-stubs/spatial/_ckdtree.pyi
@@ -125,7 +125,7 @@ class cKDTree(_CythonMixin, Generic[_BoxSizeT_co, _BoxSizeDataT_co]):
         k: onp.ToInt | onp.ToInt1D = 1,
         eps: onp.ToFloat = 0.0,
         p: onp.ToFloat = 2.0,
-        distance_upper_bound: float = float("inf"),  # noqa: PYI011
+        distance_upper_bound: float = float("inf"),  # ruff: ignore[typed-argument-default-in-stub]
         workers: int | None = None,
     ) -> tuple[float, np.intp] | tuple[onp.ArrayND[np.float64], onp.ArrayND[np.intp]]: ...
 

--- a/scipy-stubs/spatial/_kdtree.pyi
+++ b/scipy-stubs/spatial/_kdtree.pyi
@@ -105,7 +105,7 @@ class KDTree(cKDTree[_BoxSizeT_co, _BoxSizeDataT_co], Generic[_BoxSizeT_co, _Box
         k: onp.ToInt | onp.ToInt1D = 1,
         eps: onp.ToFloat = 0.0,
         p: onp.ToFloat = 2.0,
-        distance_upper_bound: float = float("inf"),  # noqa: PYI011
+        distance_upper_bound: float = float("inf"),  # ruff: ignore[typed-argument-default-in-stub]
         workers: int | None = 1,
     ) -> tuple[float, np.intp] | tuple[onp.ArrayND[np.float64], onp.ArrayND[np.intp]]: ...
 

--- a/scipy-stubs/spatial/distance.pyi
+++ b/scipy-stubs/spatial/distance.pyi
@@ -88,7 +88,7 @@ type _MetricName = Literal[
 ###
 
 type _MetricFunc = Callable[[onp.Array1D[np.float64], onp.Array1D[np.float64]], onp.ToFloat | None]
-type _Metric = _MetricName | _MetricFunc  # noqa: PYI047
+type _Metric = _MetricName | _MetricFunc  # ruff: ignore[unused-private-type-alias]
 
 type _Force = Literal["NO", "No", "no", "TOMATRIX", "ToMatrix", "tomatrix", "TOVECTOR", "ToVector", "tovector"]
 

--- a/scipy-stubs/spatial/transform/_rigid_transform_cy.pyi
+++ b/scipy-stubs/spatial/transform/_rigid_transform_cy.pyi
@@ -6,11 +6,11 @@ import optype.numpy as onp
 
 ###
 
-type _bint = bool | Literal[0, 1]  # noqa: PYI042
+type _bint = bool | Literal[0, 1]  # ruff: ignore[snake-case-type-alias]
 
-type _f64_1d = onp.Array1D[np.float64]  # noqa: PYI042
-type _f64_2d = onp.Array2D[np.float64]  # noqa: PYI042
-type _f64_3d = onp.Array3D[np.float64]  # noqa: PYI042
+type _f64_1d = onp.Array1D[np.float64]  # ruff: ignore[snake-case-type-alias]
+type _f64_2d = onp.Array2D[np.float64]  # ruff: ignore[snake-case-type-alias]
+type _f64_3d = onp.Array3D[np.float64]  # ruff: ignore[snake-case-type-alias]
 
 type _Indexer = int | slice | EllipsisType | None
 

--- a/scipy-stubs/spatial/transform/_rotation_cy.pyi
+++ b/scipy-stubs/spatial/transform/_rotation_cy.pyi
@@ -7,15 +7,15 @@ import optype.numpy.compat as npc
 
 ###
 
-type _bint = bool | Literal[0, 1]  # noqa: PYI042
+type _bint = bool | Literal[0, 1]  # ruff: ignore[snake-case-type-alias]
 
-type _bool_1d = onp.Array1D[np.bool]  # noqa: PYI042
-type _f64_1d = onp.Array1D[np.float64]  # noqa: PYI042
-type _f64_2d = onp.Array2D[np.float64]  # noqa: PYI042
-type _f64_3d = onp.Array3D[np.float64]  # noqa: PYI042
-type _f64_nd = onp.ArrayND[np.float64]  # noqa: PYI042
-type _f64_xd = onp.Array[tuple[Never, ...], np.float64]  # noqa: PYI042
-type _isize_2d = onp.Array2D[np.intp]  # noqa: PYI042
+type _bool_1d = onp.Array1D[np.bool]  # ruff: ignore[snake-case-type-alias]
+type _f64_1d = onp.Array1D[np.float64]  # ruff: ignore[snake-case-type-alias]
+type _f64_2d = onp.Array2D[np.float64]  # ruff: ignore[snake-case-type-alias]
+type _f64_3d = onp.Array3D[np.float64]  # ruff: ignore[snake-case-type-alias]
+type _f64_nd = onp.ArrayND[np.float64]  # ruff: ignore[snake-case-type-alias]
+type _f64_xd = onp.Array[tuple[Never, ...], np.float64]  # ruff: ignore[snake-case-type-alias]
+type _isize_2d = onp.Array2D[np.intp]  # ruff: ignore[snake-case-type-alias]
 
 type _Indexer = int | slice | EllipsisType | None
 type _Order = Literal["e", "extrinsic", "i", "intrinsic"]

--- a/scipy-stubs/special/_basic.pyi
+++ b/scipy-stubs/special/_basic.pyi
@@ -78,7 +78,7 @@ type _Extend0 = L["zero"]
 type _ExtendC = L["complex"]
 type _Extend = L[_Extend0, _ExtendC]
 
-# ruff: noqa: PYI042
+# ruff: file-ignore[snake-case-type-alias]
 type _tuple2[T] = tuple[T, T]
 type _tuple4[T0, T1] = tuple[T0, T1, T1, T1]
 type _tuple8[T0, T1] = tuple[T0, T1, T1, T1, T1, T1, T1, T1]

--- a/scipy-stubs/special/cython_special.pyi
+++ b/scipy-stubs/special/cython_special.pyi
@@ -108,7 +108,7 @@ class _CythonFunctionOrMethod_4_poly(_BaseCythonFunctionOrMethod, Protocol):
 @type_check_only
 class _CApiDict(TypedDict):
     # for k in scipy.special.cython_special.__pyx_capi__:
-    #    print(f"    {k}: ReadOnly[CapsuleType]")  # noqa: ERA001
+    #    print(f"    {k}: ReadOnly[CapsuleType]")  # ruff: ignore[commented-out-code]
 
     __pyx_fuse_2_0eval_chebyc: ReadOnly[CapsuleType]
     __pyx_fuse_2_0eval_chebys: ReadOnly[CapsuleType]

--- a/scipy-stubs/stats/_distribution_infrastructure.pyi
+++ b/scipy-stubs/stats/_distribution_infrastructure.pyi
@@ -90,10 +90,10 @@ type _DuckDistributionType = type[_DuckDistributionSingle | _DuckDistributionMul
 
 type _Real = npc.floating | npc.integer
 
-type _0D = tuple[()]  # noqa: PYI042
-type _1D = tuple[int]  # noqa: PYI042
-type _2D = tuple[int, int]  # noqa: PYI042
-type _3D = tuple[int, int, int]  # noqa: PYI042
+type _0D = tuple[()]  # ruff: ignore[snake-case-type-alias]
+type _1D = tuple[int]  # ruff: ignore[snake-case-type-alias]
+type _2D = tuple[int, int]  # ruff: ignore[snake-case-type-alias]
+type _3D = tuple[int, int, int]  # ruff: ignore[snake-case-type-alias]
 type _ND = tuple[int, ...]
 
 type _ToFloatMax1D = onp.ToFloatStrict1D | onp.ToFloat
@@ -157,7 +157,7 @@ _null: Final[_Null] = ...
 
 def _isnull(x: object) -> TypeIs[_Null | None]: ...
 
-class _Domain(abc.ABC, Generic[_XT_co]):  # noqa: UP046
+class _Domain(abc.ABC, Generic[_XT_co]):  # ruff: ignore[non-pep695-generic-class]
     @classmethod
     def __class_getitem__(cls, arg: object, /) -> types.GenericAlias: ...
 
@@ -175,7 +175,7 @@ class _Domain(abc.ABC, Generic[_XT_co]):  # noqa: UP046
     @abc.abstractmethod
     def get_numerical_endpoints(self, /, x: _ParamValues) -> tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64]]: ...
 
-class _Interval(_Domain[_XT_co], Generic[_XT_co]):  # pyrefly: ignore[implicit-abstract-class]  # noqa: UP046
+class _Interval(_Domain[_XT_co], Generic[_XT_co]):  # pyrefly: ignore[implicit-abstract-class]  # ruff: ignore[non-pep695-generic-class]
     @override
     @abc.abstractmethod
     def __str__(self, /) -> str: ...
@@ -205,11 +205,11 @@ class _Interval(_Domain[_XT_co], Generic[_XT_co]):  # pyrefly: ignore[implicit-a
 
 class _RealInterval(_Interval[_FloatT_co], Generic[_FloatT_co]):
     @override  # https://github.com/astral-sh/ruff/issues/18372
-    def __str__(self, /) -> str: ...  # noqa: PYI029
+    def __str__(self, /) -> str: ...  # ruff: ignore[str-or-repr-defined-in-stub]
 
 class _IntegerInterval(_Interval[_IntT_co], Generic[_IntT_co]):
     @override  # https://github.com/astral-sh/ruff/issues/18372
-    def __str__(self, /) -> str: ...  # noqa: PYI029
+    def __str__(self, /) -> str: ...  # ruff: ignore[str-or-repr-defined-in-stub]
 
 type _ValidateOut0D[RealT: _Real] = tuple[RealT, np.dtype[RealT], onp.Array0D[np.bool]]
 type _ValidateOutND[RealT: _Real, _ShapeT1: tuple[int, *tuple[int, ...]]] = tuple[

--- a/scipy-stubs/stats/_kde.pyi
+++ b/scipy-stubs/stats/_kde.pyi
@@ -11,7 +11,7 @@ __all__ = ["gaussian_kde"]
 
 ###
 
-type _co_integer = npc.integer | np.bool  # noqa: PYI042
+type _co_integer = npc.integer | np.bool  # ruff: ignore[snake-case-type-alias]
 
 type _ToFloatMax1D = onp.ToFloat | onp.ToFloat1D
 type _ToFloatMax2D = _ToFloatMax1D | onp.ToFloat2D

--- a/scipy-stubs/stats/_new_distributions.pyi
+++ b/scipy-stubs/stats/_new_distributions.pyi
@@ -18,10 +18,10 @@ __all__ = ["Binomial", "Logistic", "Normal", "Uniform"]
 
 ###
 
-type _0D = tuple[()]  # noqa: PYI042
-type _1D = tuple[int]  # noqa: PYI042
-type _2D = tuple[int, int]  # noqa: PYI042
-type _3D = tuple[int, int, int]  # noqa: PYI042
+type _0D = tuple[()]  # ruff: ignore[snake-case-type-alias]
+type _1D = tuple[int]  # ruff: ignore[snake-case-type-alias]
+type _2D = tuple[int, int]  # ruff: ignore[snake-case-type-alias]
+type _3D = tuple[int, int, int]  # ruff: ignore[snake-case-type-alias]
 
 type _ToFloat_1D = onp.ToFloatStrict1D | onp.ToFloat
 type _ToFloat_2D = onp.ToFloatStrict2D | _ToFloat_1D

--- a/scipy-stubs/stats/_variation.pyi
+++ b/scipy-stubs/stats/_variation.pyi
@@ -12,7 +12,7 @@ from ._typing import NanPolicy
 # workaround for https://github.com/microsoft/pyright/issues/10232
 type _JustAnyShape = tuple[Never, ...]
 
-type _co_integer = npc.integer | np.bool  # noqa: PYI042
+type _co_integer = npc.integer | np.bool  # ruff: ignore[snake-case-type-alias]
 
 ###
 

--- a/scipy-stubs/stats/contingency.pyi
+++ b/scipy-stubs/stats/contingency.pyi
@@ -15,7 +15,7 @@ __all__ = ["association", "chi2_contingency", "crosstab", "expected_freq", "marg
 
 ###
 
-type _to_floating = npc.floating | npc.integer | np.bool  # noqa: PYI042
+type _to_floating = npc.floating | npc.integer | np.bool  # ruff: ignore[snake-case-type-alias]
 
 _ShapeT_co = TypeVar("_ShapeT_co", bound=tuple[int, ...], default=tuple[Any, ...], covariant=True)
 

--- a/scripts/scipy_usage.py
+++ b/scripts/scipy_usage.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# ruff: noqa: PLR6301
+# ruff: file-ignore[no-self-use]
 
 import argparse
 import ast
@@ -115,7 +115,7 @@ def download_repo(repo_name: str, target_dir: Path) -> Path:
         try:
             _, _ = urllib.request.urlretrieve(zip_url, zip_path)
         except urllib.error.HTTPError as e:
-            if e.code == 404:  # noqa: PLR2004
+            if e.code == 404:  # ruff: ignore[magic-value-comparison]
                 logger.warning(
                     "Branch %s not found for %s, trying next branch", branch, repo_name
                 )
@@ -138,7 +138,7 @@ def download_repo(repo_name: str, target_dir: Path) -> Path:
         # Fallback: return the first directory
         return next(extract_dir.iterdir())
 
-    raise RuntimeError(f"Could not download {repo_name} - no valid branches found")  # noqa: TRY003
+    raise RuntimeError(f"Could not download {repo_name} - no valid branches found")  # ruff: ignore[raise-vanilla-args]
 
 
 def find_python_files(repo_path: Path) -> Generator[Path]:

--- a/scripts/test_coverage.py
+++ b/scripts/test_coverage.py
@@ -1,6 +1,6 @@
 """Walk through tests/ and collect the qualnames of accessed scipy.* names."""
 
-# ruff: noqa: S101, T201
+# ruff: file-ignore[assert, print]
 
 import ast
 import importlib
@@ -240,7 +240,7 @@ def _should_ignore(qualname: str) -> bool:
     parts = qualname.split(".")
     if any(part.startswith("_") for part in parts[1:]):
         return True  # private
-    if len(parts) < 3 or qualname.endswith(_PACKAGES_PUBLIC):  # noqa: PLR2004
+    if len(parts) < 3 or qualname.endswith(_PACKAGES_PUBLIC):  # ruff: ignore[magic-value-comparison]
         return True  # bare package
     for deprecated_pkg in _PACKAGES_DEPRECATED:
         if (

--- a/scripts/unstubbed_modules.py
+++ b/scripts/unstubbed_modules.py
@@ -2,7 +2,7 @@
 Prints the names of all SciPy modules that are not stubbed.
 """
 
-# ruff: noqa: T201, S101
+# ruff: file-ignore[print, assert]
 import sys
 import warnings
 from collections.abc import Iterator, Sequence

--- a/tests/.ruff.toml
+++ b/tests/.ruff.toml
@@ -1,4 +1,9 @@
 extend = "../pyproject.toml"
 
 [lint]
-extend-ignore = ["B018", "PYI002", "PYI015", "PYI017"]
+extend-ignore = [
+  "useless-expression",
+  "complex-if-statement-in-stub",
+  "assignment-default-in-stub",
+  "complex-assignment-in-stub",
+]

--- a/tests/differentiate/test_differentiate.pyi
+++ b/tests/differentiate/test_differentiate.pyi
@@ -1,4 +1,4 @@
-# ruff: noqa: ERA001
+# ruff: file-ignore[commented-out-code]
 
 from typing import assert_type
 

--- a/tests/signal/test_peak_finding.pyi
+++ b/tests/signal/test_peak_finding.pyi
@@ -1,6 +1,6 @@
 # type-tests for `signal/_peak_finding.pyi`
 
-# ruff: noqa: ERA001
+# ruff: file-ignore[commented-out-code]
 
 from typing import assert_type
 

--- a/tests/sparse/test_bsr.pyi
+++ b/tests/sparse/test_bsr.pyi
@@ -55,7 +55,7 @@ assert_type(bsr_array(_shape2, None, np.complex128), bsr_array[np.complex128])
 assert_type(bsr_matrix(_shape2), bsr_matrix[np.float64])
 
 ###
-# matrix-like (sequences) # noqa: ERA001
+# matrix-like (sequences) # ruff: ignore[commented-out-code]
 
 assert_type(bsr_array(_seq_seq_bool), bsr_array[np.bool])  # type: ignore[assert-type]
 assert_type(bsr_array(_seq_seq_int), bsr_array[np.int_])  # type: ignore[assert-type]

--- a/tests/sparse/test_csc.pyi
+++ b/tests/sparse/test_csc.pyi
@@ -1,4 +1,4 @@
-# ruff: noqa: ERA001
+# ruff: file-ignore[commented-out-code]
 from typing import Any, assert_type
 
 import numpy as np

--- a/tests/sparse/test_lil.pyi
+++ b/tests/sparse/test_lil.pyi
@@ -15,7 +15,7 @@ data2: np.ndarray[tuple[int, int], np.dtype[ScalarType]]
 
 ###
 # LIL matrix constructor
-# ruff: noqa: ERA001
+# ruff: file-ignore[commented-out-code]
 
 # lil_matrix(D)
 assert_type(lil_matrix(data2), lil_matrix[ScalarType])

--- a/tests/sparse/test_spbase.pyi
+++ b/tests/sparse/test_spbase.pyi
@@ -1,4 +1,4 @@
-# ruff: noqa: ERA001
+# ruff: file-ignore[commented-out-code]
 
 from typing import assert_type
 

--- a/tests/spatial/test__rotation.pyi
+++ b/tests/spatial/test__rotation.pyi
@@ -92,7 +92,7 @@ assert_type(_rot_nd.shape, tuple[Any, ...])
 
 # dunders
 
-assert_type(_rot_nd.__bool__(), Literal[True])  # noqa: PLC2801
+assert_type(_rot_nd.__bool__(), Literal[True])  # ruff: ignore[unnecessary-dunder-call]
 assert_type(len(_rot_nd), int)
 assert_type(_rot_nd * _rot_nd, Rotation)
 assert_type(_rot_nd**2.0, Rotation)

--- a/tests/stats/test_distribution_infrastructure.pyi
+++ b/tests/stats/test_distribution_infrastructure.pyi
@@ -17,10 +17,10 @@ from scipy.stats._distribution_infrastructure import (
 
 ###
 
-type _0d = tuple[()]  # noqa: PYI042
-type _1d = tuple[int]  # noqa: PYI042
-type _2d = tuple[int, int]  # noqa: PYI042
-type _3d = tuple[int, int, int]  # noqa: PYI042
+type _0d = tuple[()]  # ruff: ignore[snake-case-type-alias]
+type _1d = tuple[int]  # ruff: ignore[snake-case-type-alias]
+type _2d = tuple[int, int]  # ruff: ignore[snake-case-type-alias]
+type _3d = tuple[int, int, int]  # ruff: ignore[snake-case-type-alias]
 
 ###
 

--- a/tests/stats/test_qmc.pyi
+++ b/tests/stats/test_qmc.pyi
@@ -34,4 +34,4 @@ assert_type(Halton(_d, seed=0), Halton)
 
 assert_type(_h1.base, list[int])
 assert_type(_h1.scramble, bool)
-assert_type(_h1._permutations, list[onp.Array2D[np.int_]])  # noqa: SLF001
+assert_type(_h1._permutations, list[onp.Array2D[np.int_]])  # ruff: ignore[private-member-access]

--- a/uv.lock
+++ b/uv.lock
@@ -977,27 +977,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.21"
+version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/36/6f65aa9989acdec45d417192d8f4e7921931d8a6cf87ac74bce3eed98a8e/ruff-0.15.21.tar.gz", hash = "sha256:d0cfc841c572283c36548f82664a54ce6565567f1b0d5b4cf2caac693d8b7500", size = 4769401, upload-time = "2026-07-09T20:01:34.005Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/c6/ede15cac6839f3dbce52565c8f5164a8210e669c7bc4decb03e5bdf47d0d/ruff-0.15.21-py3-none-linux_armv6l.whl", hash = "sha256:63ea0e965e5d73c90e95b2434beeafc70820536717f561b32ab6e777cb9bdf5d", size = 10854342, upload-time = "2026-07-09T20:00:53.998Z" },
-    { url = "https://files.pythonhosted.org/packages/28/9d/d825b07ee7ea9e2d61df92a860033c94e06e7300d50a1c2653aac27d24fe/ruff-0.15.21-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:0f212c5d7d54c01bbfe6dcab02b724a39300f3e34ed7acbe995ccb320a2c58bd", size = 11139539, upload-time = "2026-07-09T20:00:57.809Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/de/3b107712e642f063c7a9e0887c427b22cb44097de5aab36c05f2e280670c/ruff-0.15.21-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e6312e41bc96791299614995ea3a977c5857c3b5662b1ecef6755b02b87cb646", size = 10595437, upload-time = "2026-07-09T20:01:00.006Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/6f/b4523cc90ba239ede441447a19d0c968846a3012e5a0b0c5b62831a3d5e3/ruff-0.15.21-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:01d65b4831c6b2a4ba8ee6faa84049d44d982b7a706e622c4094c509e51673be", size = 10990053, upload-time = "2026-07-09T20:01:02.187Z" },
-    { url = "https://files.pythonhosted.org/packages/92/cc/c6a9872a5375f0628875481cf2f66b13d7d865bf3ca2e57f91c7e762d976/ruff-0.15.21-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2c5a913a589120ce67933d5d05fd6ddbcc2481c6a054980ee767f7414c72b4fd", size = 10666096, upload-time = "2026-07-09T20:01:04.299Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/97/c621f7a17e097f1790fa3af6374138823b330b2d03fc38337945daca212c/ruff-0.15.21-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5ef04b681d02ad4dc9620f00f83ac5c22f652d0e9a9cfe431d219b16ad5ccc41", size = 11537011, upload-time = "2026-07-09T20:01:06.771Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/51/d928727e476e25ccc57c6f449ffd80241a651a973ad949d39cfb2a771d28/ruff-0.15.21-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:16d090c0740916594157e75b80d666eab8e78083b39b3b0e1d698f4670a17b86", size = 12347101, upload-time = "2026-07-09T20:01:08.859Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/88/8cd62026802b16018ad06931d87997cf795ba2a6239ab659606c87d96bf0/ruff-0.15.21-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3a10e74757dd65004d779b73e2f3c5210156d9980b41224d50d2ebcf1db51e67", size = 11572001, upload-time = "2026-07-09T20:01:11.092Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/97/f63084cf55444fc110e8cb985ebfcc592af47f597d44453d778cb81bc156/ruff-0.15.21-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bab0905d2f29e0d9fbc3c373ed23db0095edaa3f71f1f4f519ec15134d9e85c8", size = 11549239, upload-time = "2026-07-09T20:01:13.27Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/77/f107da4a2874b7715914b03f09ba9c54424de3ff8a1cc5d015d3ee2ce0ac/ruff-0.15.21-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:00eca240af5789fec6fe7df74c088cc1f9644ed83027113468efba7c92b94075", size = 11535340, upload-time = "2026-07-09T20:01:15.206Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/e9/601deb322d3303a7bf212b0100ead6f2ee3f6a044d89c30f2f92bf83c731/ruff-0.15.21-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:262ab31557a75141325e32d3357f3597645a7f084e732b6b054dde428ecd9341", size = 10964048, upload-time = "2026-07-09T20:01:17.723Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/2e/0f2176d1e99c15192caea19c8c3a0a955246b4cb4de795042eeb616345cd/ruff-0.15.21-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:659c4e7a4212f83306045ec7c5e5a356d16d9a6ef4ae0c7a4d872914fc655d9d", size = 10667055, upload-time = "2026-07-09T20:01:19.73Z" },
-    { url = "https://files.pythonhosted.org/packages/48/60/abd74a02e0c4214f12a68becfd30af7165cfdcb0e661ecdc60bbb949c09a/ruff-0.15.21-py3-none-musllinux_1_2_i686.whl", hash = "sha256:9e866eab611a5f959d36df2d10e446973a3610bc42b0c15b31dc27977d59c233", size = 11242043, upload-time = "2026-07-09T20:01:21.947Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/c6/583075d8ccabb4b229345edcaf1545eb3d8d6be90f686a479d7e94088bbf/ruff-0.15.21-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e89bc93c0d3803ba870b55c29671bad9dc6d94bb1eb181b056b52eb05b52854f", size = 11648064, upload-time = "2026-07-09T20:01:24.023Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/3c/37d0ecb729a7cc2d393ea7dce316fc585680f35d93b8d62139d7d0a3700c/ruff-0.15.21-py3-none-win32.whl", hash = "sha256:01f8d5be84823c172b389e123174f781f9daf86d6c58719d603f941932195cdd", size = 10896555, upload-time = "2026-07-09T20:01:26.941Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/b8/e43466b2a6067ce91e669068f6e28d6c719a920f014b070d5c8731725de3/ruff-0.15.21-py3-none-win_amd64.whl", hash = "sha256:d4b8d9a2f0f12b816b50447f6eccb9f4bb01a6b82c86b50fb3b5354b458dc6d3", size = 12038772, upload-time = "2026-07-09T20:01:29.497Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/75/e90ab9aeece218a9fc5a5bc3ec97d0ee6bb3c4ff95869463c1de58e29a1c/ruff-0.15.21-py3-none-win_arm64.whl", hash = "sha256:6e83115d4b9377c1cbc13abf0e051f069fab0ef815ea0504a8a008cee24dd0a8", size = 11375265, upload-time = "2026-07-09T20:01:31.772Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
+    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
+    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
 ]
 
 [[package]]
@@ -1125,7 +1125,7 @@ dev = [
     { name = "packaging", specifier = ">=26.2" },
     { name = "pyrefly", specifier = "==1.1.1" },
     { name = "pytest", specifier = "==9.1.1" },
-    { name = "ruff", specifier = "==0.15.21" },
+    { name = "ruff", specifier = "==0.16.0" },
     { name = "scipy-stubs", extras = ["scipy"] },
     { name = "sp-repo-review", extras = ["cli"], specifier = "==2026.6.18" },
     { name = "stubdefaulter", git = "https://github.com/JelleZijlstra/stubdefaulter.git?rev=866ecca" },
@@ -1135,7 +1135,7 @@ dev = [
 extras = [{ name = "scipy-stubs", extras = ["scipy"] }]
 lint = [
     { name = "dprint-py", specifier = "==0.55.2.0" },
-    { name = "ruff", specifier = "==0.15.21" },
+    { name = "ruff", specifier = "==0.16.0" },
     { name = "scipy-stubs", extras = ["scipy"] },
     { name = "sp-repo-review", extras = ["cli"], specifier = "==2026.6.18" },
 ]


### PR DESCRIPTION
This required fixing 100+ new `noqa-comments` and `rule-codes-in-selectors` ruff errors, both related to ruff-ignore/noqa  comments.