### PR TITLE
🐛 `signal`: fix typo in `detrend` param string literal types

### DIFF
--- a/scipy-stubs/signal/_spectral_py.pyi
+++ b/scipy-stubs/signal/_spectral_py.pyi
@@ -7,6 +7,7 @@ import optype as op
 import optype.numpy as onp
 import optype.numpy.compat as npc
 
+from ._signaltools import _TrendType
 from .windows._windows import _ToWindow
 
 __all__ = ["check_COLA", "check_NOLA", "coherence", "csd", "istft", "lombscargle", "periodogram", "spectrogram", "stft", "welch"]
@@ -25,7 +26,7 @@ type _ToInexact32ND = onp.ToArrayND[npc.inexact32, npc.inexact32 | npc.floating1
 type _ToInexact64ND = onp.ToArrayND[complex, npc.inexact64 | npc.integer | np.bool]
 type _ToInexact80ND = onp.ToArrayND[npc.inexact80, npc.inexact80]
 
-type _Detrend = Literal["literal", "constant", False] | Callable[[onp.ArrayND], onp.ArrayND]
+type _Detrend = _TrendType | Literal[False] | Callable[[onp.ArrayND], onp.ArrayND]
 type _Scaling = Literal["density", "spectrum"]
 type _LegacyScaling = Literal["psd", "spectrum"]
 type _Average = Literal["mean", "median"]


### PR DESCRIPTION
The `detrend` parameter of the following public `scipy.signal` functions incorrectly rejected the valid `linear` value because of a typo:

- `periodogram`
- `welch`
- `csd`
- `spectrogram`
- `stft`
- `coherence`

fixes #2071