### PR TITLE
💬 Update future SciPy versions in deprecation messages

### DIFF
--- a/scipy-stubs/cluster/vq/_vq_impl.pyi
+++ b/scipy-stubs/cluster/vq/_vq_impl.pyi
@@ -46,14 +46,14 @@ def vq(
 #
 @overload  # float64
 @deprecated(
-    "`scipy.cluster.vq.py_vq` was unintentionally public, and will be removed in SciPy 1.20.0, use `scipy.cluster.vq.vq` instead."
+    "`scipy.cluster.vq.py_vq` was unintentionally public, and will be removed in SciPy 2.1.0, use `scipy.cluster.vq.vq` instead."
 )
 def py_vq(
     obs: onp.ToFloat64_2D, code_book: onp.ToFloat64_2D, check_finite: bool = True
 ) -> tuple[onp.Array1D[np.intp], onp.Array1D[np.float64]]: ...
 @overload  # floating
 @deprecated(
-    "`scipy.cluster.vq.py_vq` was unintentionally public, and will be removed in SciPy 1.20.0, use `scipy.cluster.vq.vq` instead."
+    "`scipy.cluster.vq.py_vq` was unintentionally public, and will be removed in SciPy 2.1.0, use `scipy.cluster.vq.vq` instead."
 )
 def py_vq(
     obs: onp.ToFloat2D, code_book: onp.ToFloat2D, check_finite: bool = True

--- a/scipy-stubs/interpolate/_interpolate.pyi
+++ b/scipy-stubs/interpolate/_interpolate.pyi
@@ -432,6 +432,6 @@ class NdPPoly(Generic[_CT_co]):
 
 #
 @deprecated(
-    "This function is deprecated and will be removed in SciPy 1.20.0. Use `scipy.interpolate.BarycentricInterpolator` instead."
+    "This function is deprecated and will be removed in SciPy 2.1.0. Use `scipy.interpolate.BarycentricInterpolator` instead."
 )
 def lagrange(x: onp.ToComplex1D, w: onp.ToComplex1D) -> np.poly1d: ...

--- a/scipy-stubs/interpolate/_pade.pyi
+++ b/scipy-stubs/interpolate/_pade.pyi
@@ -5,5 +5,5 @@ import optype.numpy as onp
 
 __all__ = ["pade"]
 
-@deprecated("This function is deprecated and will be removed in SciPy 1.20.0. Use `mpmath.pade` instead.")
+@deprecated("This function is deprecated and will be removed in SciPy 2.1.0. Use `mpmath.pade` instead.")
 def pade(an: onp.ToComplex1D, m: onp.ToJustInt, n: onp.ToJustInt | None = None) -> tuple[np.poly1d, np.poly1d]: ...

--- a/scipy-stubs/interpolate/_polyint.pyi
+++ b/scipy-stubs/interpolate/_polyint.pyi
@@ -235,7 +235,7 @@ def krogh_interpolate(
 ) -> onp.ArrayND[np.float64 | np.complex128]: ...
 
 #
-@deprecated("This function is deprecated and will be removed in SciPy 1.20.0.")
+@deprecated("This function is deprecated and will be removed in SciPy 2.1.0.")
 def approximate_taylor_polynomial(
     f: Callable[[onp.Array1D[np.float64]], onp.ToComplexND] | np.ufunc,
     x: onp.ToFloat,

--- a/scipy-stubs/io/_fast_matrix_market/__init__.pyi
+++ b/scipy-stubs/io/_fast_matrix_market/__init__.pyi
@@ -51,7 +51,7 @@ class _TextToBytesWrapper(io.BufferedReader):
 #
 @overload
 @deprecated(
-    "The default value for `spmatrix` is changing to `False` in v1.20. That means the default return type will be a sparse "
+    "The default value for `spmatrix` is changing to `False` in v2.1. That means the default return type will be a sparse "
     "array. Unless you use * instead of @, ** for matrix power, or you depend on 2D shapes from e.g. `A.sum(axis=0)` it may not "
     "matter to you. See the spmatrix to sparray migration guide for details. "
     "https://docs.scipy.org/doc/scipy/reference/sparse.migration_to_sparray.html"

--- a/scipy-stubs/io/_harwell_boeing/hb.pyi
+++ b/scipy-stubs/io/_harwell_boeing/hb.pyi
@@ -126,7 +126,7 @@ def _write_data(m: sparray | spmatrix, fid: IO[str], header: HBInfo) -> None: ..
 
 #
 @overload
-@deprecated("The default value for `spmatrix` is changing to False in v1.20.")
+@deprecated("The default value for `spmatrix` is changing to False in v2.1.")
 def hb_read(path_or_open_file: FileLike[str], *, spmatrix: _NoValueType = ...) -> csc_matrix[Any]: ...
 @overload
 def hb_read(path_or_open_file: FileLike[str], *, spmatrix: Literal[True]) -> csc_matrix[Any]: ...

--- a/scipy-stubs/io/_mmio.pyi
+++ b/scipy-stubs/io/_mmio.pyi
@@ -72,7 +72,7 @@ class MMFile:
 
     # dtype is either intp, uint64, float64, or complex128, depending on the field
     @overload
-    @deprecated("The default value for `spmatrix` is changing to False in v1.20.")
+    @deprecated("The default value for `spmatrix` is changing to False in v2.1.")
     def read(self, /, source: FileLike[bytes], *, spmatrix: _NoValueType = ...) -> onp.Array2D[Any] | coo_matrix[Any]: ...
     @overload
     def read(self, /, source: FileLike[bytes], *, spmatrix: Literal[True]) -> onp.Array2D[Any] | coo_matrix[Any]: ...

--- a/scipy-stubs/io/matlab/_mio.pyi
+++ b/scipy-stubs/io/matlab/_mio.pyi
@@ -52,7 +52,7 @@ def mat_reader_factory(
 
 #
 @overload
-@deprecated("The default value for `spmatrix` is changing to False in v1.20.")
+@deprecated("The default value for `spmatrix` is changing to False in v2.1.")
 def loadmat(
     file_name: FileLike[bytes],
     mdict: Mapping[str, object] | None = None,

--- a/scipy-stubs/linalg/_matfuncs.pyi
+++ b/scipy-stubs/linalg/_matfuncs.pyi
@@ -85,32 +85,32 @@ def fractional_matrix_power[ShapeT: _AtLeast2D_ish](
     A: onp.ArrayND[npc.complexfloating128 | npc.complexfloating64, ShapeT], t: onp.ToJustFloat
 ) -> onp.ArrayND[np.complex128, ShapeT]: ...
 @overload  # Nd T, +int t
-@deprecated("bool, float16, longdouble, and clongdouble input will no longer be supported in SciPy 1.20")
+@deprecated("bool, float16, longdouble, and clongdouble input will no longer be supported in SciPy 2.1")
 def fractional_matrix_power[NumberT: npc.inexact80 | np.float16 | np.bool, ShapeT: _AtLeast2D_ish](
     A: onp.ArrayND[NumberT, ShapeT], t: _ToPosInt
 ) -> onp.ArrayND[NumberT, ShapeT]: ...
 @overload  # Nd bool, int t
-@deprecated("bool input will no longer be supported in SciPy 1.20")
+@deprecated("bool input will no longer be supported in SciPy 2.1")
 def fractional_matrix_power[ShapeT: _AtLeast2D_ish](
     A: onp.ArrayND[np.bool, ShapeT], t: onp.ToInt
 ) -> onp.ArrayND[np.bool | np.float64, ShapeT]: ...
 @overload  # Nd bool, ~float t
-@deprecated("bool input will no longer be supported in SciPy 1.20")
+@deprecated("bool input will no longer be supported in SciPy 2.1")
 def fractional_matrix_power[ShapeT: _AtLeast2D_ish](
     A: onp.ArrayND[np.bool, ShapeT], t: onp.ToJustFloat
 ) -> onp.ArrayND[np.float64 | np.complex128, ShapeT]: ...
 @overload  # Nd f16, ~float t
-@deprecated("float16 input will no longer be supported in SciPy 1.20")
+@deprecated("float16 input will no longer be supported in SciPy 2.1")
 def fractional_matrix_power[ShapeT: _AtLeast2D_ish](
     A: onp.ArrayND[npc.floating16, ShapeT], t: onp.ToJustFloat
 ) -> onp.ArrayND[np.float64 | np.complex128, ShapeT]: ...
 @overload  # Nd f80, ~float t
-@deprecated("longdouble input will no longer be supported in SciPy 1.20")
+@deprecated("longdouble input will no longer be supported in SciPy 2.1")
 def fractional_matrix_power[ShapeT: _AtLeast2D_ish](
     A: onp.ArrayND[npc.floating80, ShapeT], t: onp.ToJustFloat
 ) -> onp.ArrayND[np.longdouble | np.clongdouble, ShapeT]: ...
 @overload  # Nd c160, ~float t
-@deprecated("clongdouble input will no longer be supported in SciPy 1.20")
+@deprecated("clongdouble input will no longer be supported in SciPy 2.1")
 def fractional_matrix_power[ShapeT: _AtLeast2D_ish](
     A: onp.ArrayND[npc.complexfloating160, ShapeT], t: onp.ToJustFloat
 ) -> onp.ArrayND[np.clongdouble, ShapeT]: ...
@@ -146,16 +146,16 @@ def sqrtm[ComplexT: np.complex128 | np.complex64, ShapeT: _AtLeast2D_ish](
     A: onp.ArrayND[ComplexT, ShapeT],
 ) -> onp.ArrayND[ComplexT, ShapeT]: ...
 @overload  # Nd bool
-@deprecated("bool input will no longer be supported in SciPy 1.20")
+@deprecated("bool input will no longer be supported in SciPy 2.1")
 def sqrtm[ShapeT: _AtLeast2D_ish](A: onp.ArrayND[np.bool, ShapeT]) -> onp.ArrayND[np.float64 | np.complex128, ShapeT]: ...
 @overload  # Nd f80
-@deprecated("longdouble input will no longer be supported in SciPy 1.20")
+@deprecated("longdouble input will no longer be supported in SciPy 2.1")
 def sqrtm[ShapeT: _AtLeast2D_ish](A: onp.ArrayND[npc.floating80, ShapeT]) -> onp.ArrayND[np.float64 | np.complex128, ShapeT]: ...
 @overload  # Nd f16
-@deprecated("float16 input will no longer be supported in SciPy 1.20")
+@deprecated("float16 input will no longer be supported in SciPy 2.1")
 def sqrtm[ShapeT: _AtLeast2D_ish](A: onp.ArrayND[npc.floating16, ShapeT]) -> onp.ArrayND[np.float32 | np.complex64, ShapeT]: ...
 @overload  # Nd c160
-@deprecated("clongdouble input will no longer be supported in SciPy 1.20")
+@deprecated("clongdouble input will no longer be supported in SciPy 2.1")
 def sqrtm[ShapeT: _AtLeast2D_ish](A: onp.ArrayND[npc.complexfloating160, ShapeT]) -> onp.ArrayND[np.complex128, ShapeT]: ...
 @overload  # 2d +float
 def sqrtm(A: Sequence[Sequence[float]]) -> onp.Array2D[np.float64 | np.complex128]: ...
@@ -178,16 +178,16 @@ def logm[ShapeT: _AtLeast2D_ish](
     A: onp.ArrayND[npc.complexfloating128 | npc.complexfloating64, ShapeT],
 ) -> onp.ArrayND[np.complex128, ShapeT]: ...
 @overload  # Nd bool
-@deprecated("bool input will no longer be supported in SciPy 1.20")
+@deprecated("bool input will no longer be supported in SciPy 2.1")
 def logm[ShapeT: _AtLeast2D_ish](A: onp.ArrayND[np.bool, ShapeT]) -> onp.ArrayND[np.float64 | np.complex128, ShapeT]: ...
 @overload  # Nd f80
-@deprecated("longdouble input will no longer be supported in SciPy 1.20")
+@deprecated("longdouble input will no longer be supported in SciPy 2.1")
 def logm[ShapeT: _AtLeast2D_ish](A: onp.ArrayND[npc.floating80, ShapeT]) -> onp.ArrayND[np.float64 | np.complex128, ShapeT]: ...
 @overload  # Nd f16
-@deprecated("float16 input will no longer be supported in SciPy 1.20")
+@deprecated("float16 input will no longer be supported in SciPy 2.1")
 def logm[ShapeT: _AtLeast2D_ish](A: onp.ArrayND[npc.floating16, ShapeT]) -> onp.ArrayND[np.float64 | np.complex128, ShapeT]: ...
 @overload  # Nd c160
-@deprecated("clongdouble input will no longer be supported in SciPy 1.20")
+@deprecated("clongdouble input will no longer be supported in SciPy 2.1")
 def logm[ShapeT: _AtLeast2D_ish](A: onp.ArrayND[npc.complexfloating160, ShapeT]) -> onp.ArrayND[np.complex128, ShapeT]: ...
 @overload  # 2d +float
 def logm(A: Sequence[Sequence[float]]) -> onp.Array2D[np.float64 | np.complex128]: ...
@@ -210,10 +210,10 @@ def expm[ComplexT: np.complex128 | np.complex64, ShapeT: _AtLeast2D_ish](
     A: onp.ArrayND[ComplexT, ShapeT],
 ) -> onp.ArrayND[ComplexT, ShapeT]: ...
 @overload  # Nd bool
-@deprecated("bool input will no longer be supported in SciPy 1.20")
+@deprecated("bool input will no longer be supported in SciPy 2.1")
 def expm[ShapeT: _AtLeast2D_ish](A: onp.ArrayND[np.bool, ShapeT]) -> onp.ArrayND[np.float64, ShapeT]: ...
 @overload  # Nd f16
-@deprecated("float16 input will no longer be supported in SciPy 1.20")
+@deprecated("float16 input will no longer be supported in SciPy 2.1")
 def expm[ShapeT: _AtLeast2D_ish](A: onp.ArrayND[npc.floating16, ShapeT]) -> onp.ArrayND[np.float32, ShapeT]: ...
 @overload  # 2d +float
 def expm(A: Sequence[Sequence[float]]) -> onp.Array2D[np.float64]: ...
@@ -241,10 +241,10 @@ def cosm[ComplexT: np.complex128 | np.complex64, ShapeT: _AtLeast2D_ish](
     A: onp.ArrayND[ComplexT, ShapeT],
 ) -> onp.ArrayND[ComplexT, ShapeT]: ...
 @overload  # Nd bool
-@deprecated("bool input will no longer be supported in SciPy 1.20")
+@deprecated("bool input will no longer be supported in SciPy 2.1")
 def cosm[ShapeT: _AtLeast2D_ish](A: onp.ArrayND[np.bool, ShapeT]) -> onp.ArrayND[np.float64, ShapeT]: ...
 @overload  # Nd f16
-@deprecated("float16 input will no longer be supported in SciPy 1.20")
+@deprecated("float16 input will no longer be supported in SciPy 2.1")
 def cosm[ShapeT: _AtLeast2D_ish](A: onp.ArrayND[npc.floating16, ShapeT]) -> onp.ArrayND[np.float32, ShapeT]: ...
 @overload  # 2d +float
 def cosm(A: Sequence[Sequence[float]]) -> onp.Array2D[np.float64]: ...
@@ -267,10 +267,10 @@ def sinm[ComplexT: np.complex128 | np.complex64, ShapeT: _AtLeast2D_ish](
     A: onp.ArrayND[ComplexT, ShapeT],
 ) -> onp.ArrayND[ComplexT, ShapeT]: ...
 @overload  # Nd bool
-@deprecated("bool input will no longer be supported in SciPy 1.20")
+@deprecated("bool input will no longer be supported in SciPy 2.1")
 def sinm[ShapeT: _AtLeast2D_ish](A: onp.ArrayND[np.bool, ShapeT]) -> onp.ArrayND[np.float64, ShapeT]: ...
 @overload  # Nd f16
-@deprecated("float16 input will no longer be supported in SciPy 1.20")
+@deprecated("float16 input will no longer be supported in SciPy 2.1")
 def sinm[ShapeT: _AtLeast2D_ish](A: onp.ArrayND[npc.floating16, ShapeT]) -> onp.ArrayND[np.float32, ShapeT]: ...
 @overload  # 2d +float
 def sinm(A: Sequence[Sequence[float]]) -> onp.Array2D[np.float64]: ...
@@ -293,10 +293,10 @@ def tanm[ComplexT: np.complex128 | np.complex64, ShapeT: _AtLeast2D_ish](
     A: onp.ArrayND[ComplexT, ShapeT],
 ) -> onp.ArrayND[ComplexT, ShapeT]: ...
 @overload  # Nd bool
-@deprecated("bool input will no longer be supported in SciPy 1.20")
+@deprecated("bool input will no longer be supported in SciPy 2.1")
 def tanm[ShapeT: _AtLeast2D_ish](A: onp.ArrayND[np.bool, ShapeT]) -> onp.ArrayND[np.float64, ShapeT]: ...
 @overload  # Nd f16
-@deprecated("float16 input will no longer be supported in SciPy 1.20")
+@deprecated("float16 input will no longer be supported in SciPy 2.1")
 def tanm[ShapeT: _AtLeast2D_ish](A: onp.ArrayND[npc.floating16, ShapeT]) -> onp.ArrayND[np.float32, ShapeT]: ...
 @overload  # 2d +float
 def tanm(A: Sequence[Sequence[float]]) -> onp.Array2D[np.float64]: ...
@@ -319,7 +319,7 @@ def coshm[ComplexT: np.complex128 | np.complex64, ShapeT: _AtLeast2D_ish](
     A: onp.ArrayND[ComplexT, ShapeT],
 ) -> onp.ArrayND[ComplexT, ShapeT]: ...
 @overload  # Nd f16
-@deprecated("float16 input will no longer be supported in SciPy 1.20")
+@deprecated("float16 input will no longer be supported in SciPy 2.1")
 def coshm[ShapeT: _AtLeast2D_ish](A: onp.ArrayND[npc.floating16, ShapeT]) -> onp.ArrayND[np.float32, ShapeT]: ...
 @overload  # 2d +float
 def coshm(A: Sequence[Sequence[float]]) -> onp.Array2D[np.float64]: ...
@@ -342,7 +342,7 @@ def sinhm[ComplexT: np.complex128 | np.complex64, ShapeT: _AtLeast2D_ish](
     A: onp.ArrayND[ComplexT, ShapeT],
 ) -> onp.ArrayND[ComplexT, ShapeT]: ...
 @overload  # Nd f16
-@deprecated("float16 input will no longer be supported in SciPy 1.20")
+@deprecated("float16 input will no longer be supported in SciPy 2.1")
 def sinhm[ShapeT: _AtLeast2D_ish](A: onp.ArrayND[npc.floating16, ShapeT]) -> onp.ArrayND[np.float32, ShapeT]: ...
 @overload  # 2d +float
 def sinhm(A: Sequence[Sequence[float]]) -> onp.Array2D[np.float64]: ...
@@ -365,7 +365,7 @@ def tanhm[ComplexT: np.complex128 | np.complex64, ShapeT: _AtLeast2D_ish](
     A: onp.ArrayND[ComplexT, ShapeT],
 ) -> onp.ArrayND[ComplexT, ShapeT]: ...
 @overload  # Nd f16
-@deprecated("float16 input will no longer be supported in SciPy 1.20")
+@deprecated("float16 input will no longer be supported in SciPy 2.1")
 def tanhm[ShapeT: _AtLeast2D_ish](A: onp.ArrayND[npc.floating16, ShapeT]) -> onp.ArrayND[np.float32, ShapeT]: ...
 @overload  # 2d +float
 def tanhm(A: Sequence[Sequence[float]]) -> onp.Array2D[np.float64]: ...
@@ -404,7 +404,7 @@ def funm[ComplexT: np.complex128 | np.complex64, ShapeT: _AtLeast2D_ish](
     A: onp.ArrayND[ComplexT, ShapeT], func: _Func1D[ComplexT], disp: onp.ToFalse
 ) -> tuple[onp.ArrayND[ComplexT, ShapeT], float]: ...
 @overload  # Nd bool | f16 | f80 | c160
-@deprecated("bool, float16, longdouble, and clongdouble input will no longer be supported in SciPy 1.20")
+@deprecated("bool, float16, longdouble, and clongdouble input will no longer be supported in SciPy 2.1")
 def funm[ShapeT: _AtLeast2D_ish](
     A: onp.ArrayND[np.bool | npc.floating16 | npc.inexact80, ShapeT], func: _Func1D[Any], disp: onp.ToTrue = True
 ) -> onp.ArrayND[npc.inexact64 | npc.inexact32, ShapeT]: ...
@@ -442,16 +442,16 @@ def signm[ComplexT: np.complex128 | np.complex64, ShapeT: _AtLeast2D_ish](
     A: onp.ArrayND[ComplexT, ShapeT],
 ) -> onp.ArrayND[ComplexT, ShapeT]: ...
 @overload  # Nd bool
-@deprecated("bool input will no longer be supported in SciPy 1.20")
+@deprecated("bool input will no longer be supported in SciPy 2.1")
 def signm[ShapeT: _AtLeast2D_ish](A: onp.ArrayND[np.bool, ShapeT]) -> onp.ArrayND[np.float32, ShapeT]: ...
 @overload  # Nd f80
-@deprecated("longdouble input will no longer be supported in SciPy 1.20")
+@deprecated("longdouble input will no longer be supported in SciPy 2.1")
 def signm[ShapeT: _AtLeast2D_ish](A: onp.ArrayND[npc.floating80, ShapeT]) -> onp.ArrayND[np.float64, ShapeT]: ...
 @overload  # Nd f16
-@deprecated("float16 input will no longer be supported in SciPy 1.20")
+@deprecated("float16 input will no longer be supported in SciPy 2.1")
 def signm[ShapeT: _AtLeast2D_ish](A: onp.ArrayND[npc.floating16, ShapeT]) -> onp.ArrayND[np.float32, ShapeT]: ...
 @overload  # Nd c160
-@deprecated("clongdouble input will no longer be supported in SciPy 1.20")
+@deprecated("clongdouble input will no longer be supported in SciPy 2.1")
 def signm[ShapeT: _AtLeast2D_ish](A: onp.ArrayND[npc.complexfloating160, ShapeT]) -> onp.ArrayND[np.complex128, ShapeT]: ...
 @overload  # 2d +float
 def signm(A: Sequence[Sequence[float]]) -> onp.Array2D[np.float64]: ...
@@ -486,10 +486,10 @@ def khatri_rao[ScalarT: (npc.signedinteger, npc.unsignedinteger, np.float32, np.
     a: onp.Array3D[ScalarT], b: onp.Array2D[ScalarT]
 ) -> onp.Array3D[ScalarT]: ...
 @overload  # Nd bool | f16 | f80 | c160, Nd +complex
-@deprecated("bool, float16, longdouble, and clongdouble input will no longer be supported in SciPy 1.20")
+@deprecated("bool, float16, longdouble, and clongdouble input will no longer be supported in SciPy 2.1")
 def khatri_rao(a: onp.ArrayND[np.bool | npc.floating16 | npc.inexact80], b: onp.ToComplexND) -> onp.ArrayND[Any]: ...
 @overload  # Nd +complex, Nd bool | f16 | f80 | c160
-@deprecated("bool, float16, longdouble, and clongdouble input will no longer be supported in SciPy 1.20")
+@deprecated("bool, float16, longdouble, and clongdouble input will no longer be supported in SciPy 2.1")
 def khatri_rao(a: onp.ToComplexND, b: onp.ArrayND[np.bool | npc.floating16 | npc.inexact80]) -> onp.ArrayND[Any]: ...
 @overload  # 2d +float, 2d +float
 def khatri_rao(a: Sequence[Sequence[float]], b: Sequence[Sequence[float]]) -> onp.Array2D[np.float64]: ...

--- a/scipy-stubs/linalg/_special_matrices.pyi
+++ b/scipy-stubs/linalg/_special_matrices.pyi
@@ -318,16 +318,16 @@ def hankel(c: onp.ToJustComplexStrict1D, r: onp.ToJustComplexStrict1D | None = N
 @overload
 def hankel[ScalarT: np.generic](c: _ToStrict1D[ScalarT], r: _ToStrict1D[ScalarT] | None = None) -> onp.Array2D[ScalarT]: ...
 @overload
-@deprecated("Beginning in SciPy 1.19, multidimensional input will be treated as a batch, not `ravel`ed.")
+@deprecated("Beginning in SciPy 2.0, multidimensional input will be treated as a batch, not `ravel`ed.")
 def hankel(c: onp.ToJustIntND, r: onp.ToJustIntND | None = None) -> _Int2D: ...
 @overload
-@deprecated("Beginning in SciPy 1.19, multidimensional input will be treated as a batch, not `ravel`ed.")
+@deprecated("Beginning in SciPy 2.0, multidimensional input will be treated as a batch, not `ravel`ed.")
 def hankel(c: onp.ToJustFloatND, r: onp.ToJustFloatND | None = None) -> _Float2D: ...
 @overload
-@deprecated("Beginning in SciPy 1.19, multidimensional input will be treated as a batch, not `ravel`ed.")
+@deprecated("Beginning in SciPy 2.0, multidimensional input will be treated as a batch, not `ravel`ed.")
 def hankel(c: onp.ToJustComplexND, r: onp.ToJustComplexND | None = None) -> _Complex2D: ...
 @overload
-@deprecated("Beginning in SciPy 1.19, multidimensional input will be treated as a batch, not `ravel`ed.")
+@deprecated("Beginning in SciPy 2.0, multidimensional input will be treated as a batch, not `ravel`ed.")
 def hankel[ScalarT: np.generic](c: _ToStrict2ND[ScalarT], r: _ToStrict2ND[ScalarT] | None = None) -> onp.Array2D[ScalarT]: ...
 @overload
 def hankel[ScalarT: np.generic](c: _To1D[ScalarT], r: _To1D[ScalarT] | None = None) -> onp.Array2D[ScalarT]: ...

--- a/scipy-stubs/odr/_models.pyi
+++ b/scipy-stubs/odr/_models.pyi
@@ -21,19 +21,19 @@ class _SimpleModel(_NamedModel):
 
 ###
 
-@deprecated("`scipy.odr` is deprecated and will be removed in SciPy 1.19.0.")
+@deprecated("`scipy.odr` is deprecated and will be removed in SciPy 2.0.0.")
 class _MultilinearModel(_SimpleModel): ...
 
-@deprecated("`scipy.odr` is deprecated and will be removed in SciPy 1.19.0.")
+@deprecated("`scipy.odr` is deprecated and will be removed in SciPy 2.0.0.")
 class _ExponentialModel(_SimpleModel): ...
 
-@deprecated("`scipy.odr` is deprecated and will be removed in SciPy 1.19.0.")
+@deprecated("`scipy.odr` is deprecated and will be removed in SciPy 2.0.0.")
 class _UnilinearModel(_SimpleModel): ...
 
-@deprecated("`scipy.odr` is deprecated and will be removed in SciPy 1.19.0.")
+@deprecated("`scipy.odr` is deprecated and will be removed in SciPy 2.0.0.")
 class _QuadraticModel(_SimpleModel): ...
 
-@deprecated("`scipy.odr` is deprecated and will be removed in SciPy 1.19.0.")
+@deprecated("`scipy.odr` is deprecated and will be removed in SciPy 2.0.0.")
 def polynomial(order: onp.ToInt | onp.ToInt1D) -> _NamedModel: ...
 
 multilinear: Final[_MultilinearModel] = ...

--- a/scipy-stubs/odr/_odrpack.pyi
+++ b/scipy-stubs/odr/_odrpack.pyi
@@ -57,19 +57,19 @@ class _FullOutput(TypedDict):
 
 ###
 
-@deprecated("`scipy.odr` is deprecated and will be removed in SciPy 1.19.0.")
+@deprecated("`scipy.odr` is deprecated and will be removed in SciPy 2.0.0.")
 class OdrWarning(UserWarning): ...
 
-@deprecated("`scipy.odr` is deprecated and will be removed in SciPy 1.19.0.")
+@deprecated("`scipy.odr` is deprecated and will be removed in SciPy 2.0.0.")
 class OdrError(Exception): ...
 
-@deprecated("`scipy.odr` is deprecated and will be removed in SciPy 1.19.0.")
+@deprecated("`scipy.odr` is deprecated and will be removed in SciPy 2.0.0.")
 class OdrStop(Exception): ...
 
 odr_error = OdrError
 odr_stop = OdrStop
 
-@deprecated("`scipy.odr` is deprecated and will be removed in SciPy 1.19.0.")
+@deprecated("`scipy.odr` is deprecated and will be removed in SciPy 2.0.0.")
 class Data:
     x: Final[onp.ArrayND[_ToFloatScalar]]
     y: Final[onp.ArrayND[_ToFloatScalar] | _ToFloatScalar | None]
@@ -91,7 +91,7 @@ class Data:
     def __getattr__(self, attr: str, /) -> Any: ...
     def set_meta(self, /, **kwds: object) -> None: ...
 
-@deprecated("`scipy.odr` is deprecated and will be removed in SciPy 1.19.0.")
+@deprecated("`scipy.odr` is deprecated and will be removed in SciPy 2.0.0.")
 class RealData(Data):
     sx: Final[onp.ArrayND[_ToFloatScalar] | None]
     sy: Final[onp.ArrayND[_ToFloatScalar] | None]
@@ -197,7 +197,7 @@ class RealData(Data):
         meta: dict[str, Any] | None = None,
     ) -> None: ...
 
-@deprecated("`scipy.odr` is deprecated and will be removed in SciPy 1.19.0.")
+@deprecated("`scipy.odr` is deprecated and will be removed in SciPy 2.0.0.")
 class Model:
     fcn: Final[_FCN]
     fjacb: Final[_FCN]
@@ -221,7 +221,7 @@ class Model:
     def __getattr__(self, attr: str, /) -> Any: ...
     def set_meta(self, /, **kwds: object) -> None: ...
 
-@deprecated("`scipy.odr` is deprecated and will be removed in SciPy 1.19.0.")
+@deprecated("`scipy.odr` is deprecated and will be removed in SciPy 2.0.0.")
 class Output:
     beta: Final[onp.Array1D[np.float64]]
     sd_beta: Final[onp.Array1D[np.float64]]
@@ -247,7 +247,7 @@ class Output:
     def __init__(self, /, output: _RawOutput | _RawOutputFull) -> None: ...
     def pprint(self, /) -> None: ...
 
-@deprecated("`scipy.odr` is deprecated and will be removed in SciPy 1.19.0.")
+@deprecated("`scipy.odr` is deprecated and will be removed in SciPy 2.0.0.")
 class ODR:
     data: Final[Data]
     model: Final[Model]
@@ -324,7 +324,7 @@ class ODR:
     def restart(self, /, iter: int | None = None) -> Output: ...
 
 @overload
-@deprecated("`scipy.odr` is deprecated and will be removed in SciPy 1.19.0.")
+@deprecated("`scipy.odr` is deprecated and will be removed in SciPy 2.0.0.")
 def odr(
     fcn: _FCN,
     beta0: onp.ToFloat1D,
@@ -355,7 +355,7 @@ def odr(
     full_output: onp.ToFalse = 0,
 ) -> _RawOutput: ...
 @overload
-@deprecated("`scipy.odr` is deprecated and will be removed in SciPy 1.19.0.")
+@deprecated("`scipy.odr` is deprecated and will be removed in SciPy 2.0.0.")
 def odr(
     fcn: _FCN,
     beta0: onp.ToFloat1D,

--- a/scipy-stubs/optimize/_linprog.pyi
+++ b/scipy-stubs/optimize/_linprog.pyi
@@ -157,7 +157,7 @@ def linprog(
     integrality: _Max3 | Sequence[_Max3] | onp.CanArrayND[npc.integer] | None = None,
 ) -> _OptimizeResultHighs: ...
 @overload  # interior-point (legacy, see https://github.com/scipy/scipy/issues/15707)
-@deprecated("`method='interior-point'` is deprecated and will be removed in SciPy 1.17. Please use one of the HIGHS solvers.")
+@deprecated("`method='interior-point'` is deprecated. Please use one of the HIGHS solvers.")
 def linprog(
     c: onp.ToFloat1D,
     A_ub: onp.ToFloat2D | None = None,
@@ -173,7 +173,7 @@ def linprog(
     integrality: _Max3 | Sequence[_Max3] | onp.CanArrayND[npc.integer] | None = None,
 ) -> OptimizeResult: ...
 @overload  # revised simplex (legacy, see https://github.com/scipy/scipy/issues/15707)
-@deprecated("`method='revised simplex'` is deprecated and will be removed in SciPy 1.17. Please use one of the HIGHS solvers.")
+@deprecated("`method='revised simplex'` is deprecated. Please use one of the HIGHS solvers.")
 def linprog(
     c: onp.ToFloat1D,
     A_ub: onp.ToFloat2D | None = None,
@@ -189,7 +189,7 @@ def linprog(
     integrality: _Max3 | Sequence[_Max3] | onp.CanArrayND[npc.integer] | None = None,
 ) -> OptimizeResult: ...
 @overload  # simplex (legacy, see https://github.com/scipy/scipy/issues/15707)
-@deprecated("`method='simplex'` is deprecated and will be removed in SciPy 1.17. Please use one of the HIGHS solvers.")
+@deprecated("`method='simplex'` is deprecated. Please use one of the HIGHS solvers.")
 def linprog(
     c: onp.ToFloat1D,
     A_ub: onp.ToFloat2D | None = None,

--- a/scipy-stubs/signal/_spectral_py.pyi
+++ b/scipy-stubs/signal/_spectral_py.pyi
@@ -48,7 +48,7 @@ def lombscargle(
 ) -> _float64_1d: ...
 @overload
 @deprecated(
-    "The `precenter` argument is deprecated and will be removed in SciPy 1.19.0. "
+    "The `precenter` argument is deprecated and will be removed in SciPy 2.0. "
     "The functionality can be substituted by passing `y - y.mean()` to `y`."
 )
 def lombscargle(

--- a/scipy-stubs/spatial/_kdtree.pyi
+++ b/scipy-stubs/spatial/_kdtree.pyi
@@ -110,28 +110,28 @@ class KDTree(cKDTree[_BoxSizeT_co, _BoxSizeDataT_co], Generic[_BoxSizeT_co, _Box
     ) -> tuple[float, np.intp] | tuple[onp.ArrayND[np.float64], onp.ArrayND[np.intp]]: ...
 
 @overload
-@deprecated("This function is deprecated in favor of `scipy.spatial.distance.minkowski` and will be removed in SciPy 1.20.0.")
+@deprecated("This function is deprecated in favor of `scipy.spatial.distance.minkowski` and will be removed in SciPy 2.1.0.")
 def minkowski_distance_p(x: onp.ToFloatND, y: onp.ToFloatND, p: float = 2.0) -> onp.ArrayND[np.float64]: ...
 @overload
-@deprecated("This function is deprecated in favor of `scipy.spatial.distance.minkowski` and will be removed in SciPy 1.20.0.")
+@deprecated("This function is deprecated in favor of `scipy.spatial.distance.minkowski` and will be removed in SciPy 2.1.0.")
 def minkowski_distance_p(x: onp.ToComplexND, y: onp.ToComplexND, p: float = 2.0) -> onp.ArrayND[np.float64 | np.complex128]: ...
 
 #
 @overload
-@deprecated("This function is deprecated in favor of `scipy.spatial.distance.minkowski` and will be removed in SciPy 1.20.0.")
+@deprecated("This function is deprecated in favor of `scipy.spatial.distance.minkowski` and will be removed in SciPy 2.1.0.")
 def minkowski_distance(x: onp.ToFloatND, y: onp.ToFloatND, p: float = 2.0) -> onp.ArrayND[np.float64]: ...
 @overload
-@deprecated("This function is deprecated in favor of `scipy.spatial.distance.minkowski` and will be removed in SciPy 1.20.0.")
+@deprecated("This function is deprecated in favor of `scipy.spatial.distance.minkowski` and will be removed in SciPy 2.1.0.")
 def minkowski_distance(x: onp.ToComplexND, y: onp.ToComplexND, p: float = 2.0) -> onp.ArrayND[np.float64 | np.complex128]: ...
 
 #
 @overload
-@deprecated("This function is deprecated in favor of `scipy.spatial.distance.cdist` and will be removed in SciPy 1.20.0.")
+@deprecated("This function is deprecated in favor of `scipy.spatial.distance.cdist` and will be removed in SciPy 2.1.0.")
 def distance_matrix(
     x: onp.ToFloatND, y: onp.ToFloatND, p: float = 2.0, threshold: int = 1_000_000
 ) -> onp.Array2D[np.float64]: ...
 @overload
-@deprecated("This function is deprecated in favor of `scipy.spatial.distance.cdist` and will be removed in SciPy 1.20.0.")
+@deprecated("This function is deprecated in favor of `scipy.spatial.distance.cdist` and will be removed in SciPy 2.1.0.")
 def distance_matrix(
     x: onp.ToComplexND, y: onp.ToComplexND, p: float = 2.0, threshold: int = 1_000_000
 ) -> onp.Array2D[np.float64 | np.complex128]: ...

--- a/scipy-stubs/spatial/_qhull.pyi
+++ b/scipy-stubs/spatial/_qhull.pyi
@@ -248,17 +248,17 @@ class HalfspaceIntersection(_QhullUser):
     def add_halfspaces(self, /, halfspaces: onp.ToFloat2D, restart: bool = False) -> None: ...
 
 @overload
-@deprecated("`tsearch` is deprecated in favor of `Delaunay.find_simplex` and will be removed in SciPy 1.22.0.")
+@deprecated("`tsearch` is deprecated in favor of `Delaunay.find_simplex` and will be removed in SciPy 2.3.0.")
 def tsearch(tri: Delaunay, xi: _ToArrayStrictND) -> onp.ArrayND[np.int32]: ...
 @overload
-@deprecated("`tsearch` is deprecated in favor of `Delaunay.find_simplex` and will be removed in SciPy 1.22.0.")
+@deprecated("`tsearch` is deprecated in favor of `Delaunay.find_simplex` and will be removed in SciPy 2.3.0.")
 def tsearch(tri: Delaunay, xi: onp.ToFloatStrict1D) -> onp.Array0D[np.int32]: ...
 @overload
-@deprecated("`tsearch` is deprecated in favor of `Delaunay.find_simplex` and will be removed in SciPy 1.22.0.")
+@deprecated("`tsearch` is deprecated in favor of `Delaunay.find_simplex` and will be removed in SciPy 2.3.0.")
 def tsearch(tri: Delaunay, xi: onp.ToFloatStrict2D) -> onp.Array1D[np.int32]: ...
 @overload
-@deprecated("`tsearch` is deprecated in favor of `Delaunay.find_simplex` and will be removed in SciPy 1.22.0.")
+@deprecated("`tsearch` is deprecated in favor of `Delaunay.find_simplex` and will be removed in SciPy 2.3.0.")
 def tsearch(tri: Delaunay, xi: onp.ToFloatStrict3D) -> onp.Array2D[np.int32]: ...
 @overload
-@deprecated("`tsearch` is deprecated in favor of `Delaunay.find_simplex` and will be removed in SciPy 1.22.0.")
+@deprecated("`tsearch` is deprecated in favor of `Delaunay.find_simplex` and will be removed in SciPy 2.3.0.")
 def tsearch(tri: Delaunay, xi: onp.ToFloatND) -> onp.ArrayND[np.int32]: ...

--- a/scipy-stubs/stats/_morestats.pyi
+++ b/scipy-stubs/stats/_morestats.pyi
@@ -770,7 +770,7 @@ def yeojohnson_normplot(
     "`MonteCarloMethod` to approximate the p-value via Monte Carlo simulation. "
     "When `method` is specified, the result object will include a `pvalue` attribute and not attributes `critical_value`, "
     "`significance_level`, or `fit_result`. "
-    "Beginning in 1.19.0, these other attributes will no longer be available, "
+    "Beginning in 2.0.0, these other attributes will no longer be available, "
     "and a p-value will always be computed according to one of the available `method` options.",
     category=FutureWarning,
 )
@@ -784,7 +784,7 @@ def anderson(
 @overload
 @deprecated(
     "Parameter `variant` has been introduced to replace `midrank`; "
-    "`midrank` will be removed in SciPy 1.19.0. Specify `variant` to silence this warning. "
+    "`midrank` will be removed in SciPy 2.0.0. Specify `variant` to silence this warning. "
     "Note that the returned object will no longer be unpackable as a tuple, and `critical_values` will be omitted."
 )
 def anderson_ksamp(


### PR DESCRIPTION
The next SciPy release will be 2.0, not 1.19.