### PR TITLE
🐛 `io`: remove fictitious `ABCMeta` and `@abstractmethod`s

### DIFF
--- a/scipy-stubs/io/_harwell_boeing/_fortran_format_parser.pyi
+++ b/scipy-stubs/io/_harwell_boeing/_fortran_format_parser.pyi
@@ -1,4 +1,3 @@
-import abc
 import re
 from typing import Final, Literal, Self, type_check_only
 
@@ -17,7 +16,7 @@ TOKENS: Final[dict[_TokenType, str]]
 class BadFortranFormat(SyntaxError): ...
 
 @type_check_only
-class _NumberFormat[NumberT: (int, float)](metaclass=abc.ABCMeta):
+class _NumberFormat[NumberT: (int, float)]:
     width: Final[int]
     repeat: Final[int | None]
     min: Final[int | None]

--- a/scipy-stubs/io/arff/_arffread.pyi
+++ b/scipy-stubs/io/arff/_arffread.pyi
@@ -1,4 +1,3 @@
-import abc
 import re
 from collections.abc import Iterable, Iterator, Sequence
 from csv import Dialect
@@ -31,7 +30,7 @@ r_wcomattrval: Final[re.Pattern[str]] = ...  # undocumented
 class ArffError(OSError): ...
 class ParseArffError(ArffError): ...
 
-class Attribute(Generic[_T_co], metaclass=abc.ABCMeta):  # undocumented
+class Attribute(Generic[_T_co]):  # undocumented
     type_name: ClassVar[str | None]
     dtype: Any
     range: Any

--- a/scipy-stubs/io/matlab/_miobase.pyi
+++ b/scipy-stubs/io/matlab/_miobase.pyi
@@ -1,4 +1,3 @@
-import abc
 from collections.abc import Callable, Mapping
 from typing import IO, Any, Final, Literal, Protocol, TypeVar, type_check_only
 
@@ -28,9 +27,7 @@ class MatWriteWarning(UserWarning): ...
 
 class MatVarReader:
     def __init__(self, /, file_reader: MatFileReader) -> None: ...
-    @abc.abstractmethod
     def read_header(self, /) -> dict[str, Any]: ...
-    @abc.abstractmethod
     def array_from_header(self, /, header: Mapping[str, object]) -> onp.ArrayND: ...
 
 class MatFileReader:


### PR DESCRIPTION
Well, apparently #2075 was just the tip of the iceberg. ... and there's more coming after this one