### PR TITLE
🐛 `interpolate`: fix return types of `{pchip,barycentric}_interpolate` for certain inputs

### DIFF
--- a/scipy-stubs/interpolate/_cubic.pyi
+++ b/scipy-stubs/interpolate/_cubic.pyi
@@ -1,4 +1,5 @@
 from _typeshed import Incomplete
+from collections.abc import Iterable
 from types import ModuleType
 from typing import Any, ClassVar, Generic, Literal, Never, overload, override
 from typing_extensions import TypeVar
@@ -325,9 +326,14 @@ class CubicSpline(CubicHermiteSpline[_CT_co, _ShapeT_co], Generic[_CT_co, _Shape
         extrapolate: _Extrapolate | None = None,
     ) -> None: ...
 
+@overload  # der: int
 def pchip_interpolate(
-    xi: onp.ToFloat1D, yi: onp.ToFloatND, x: onp.ToFloat | onp.ToFloat1D, der: onp.ToInt | onp.ToInt1D = 0, axis: _ToAxis = 0
+    xi: onp.ToFloat1D, yi: onp.ToFloatND, x: onp.ToFloat | onp.ToFloat1D, der: int | npc.integer = 0, axis: _ToAxis = 0
 ) -> onp.ArrayND[np.float64]: ...
+@overload  # der: Iterable[int]
+def pchip_interpolate(
+    xi: onp.ToFloat1D, yi: onp.ToFloatND, x: onp.ToFloat | onp.ToFloat1D, der: Iterable[int | npc.integer], axis: _ToAxis = 0
+) -> list[onp.ArrayND[np.float64]]: ...
 
 # undocumented
 @overload

--- a/scipy-stubs/interpolate/_cubic.pyi
+++ b/scipy-stubs/interpolate/_cubic.pyi
@@ -325,13 +325,8 @@ class CubicSpline(CubicHermiteSpline[_CT_co, _ShapeT_co], Generic[_CT_co, _Shape
         extrapolate: _Extrapolate | None = None,
     ) -> None: ...
 
-@overload
 def pchip_interpolate(
-    xi: onp.ToFloat1D, yi: onp.ToFloat1D, x: onp.ToFloat, der: onp.ToInt = 0, axis: _ToAxis = 0
-) -> np.float64: ...
-@overload
-def pchip_interpolate(
-    xi: onp.ToFloat1D, yi: onp.ToFloat1D, x: onp.ToFloat1D, der: onp.ToInt | onp.ToInt1D = 0, axis: _ToAxis = 0
+    xi: onp.ToFloat1D, yi: onp.ToFloatND, x: onp.ToFloat | onp.ToFloat1D, der: onp.ToInt | onp.ToInt1D = 0, axis: _ToAxis = 0
 ) -> onp.ArrayND[np.float64]: ...
 
 # undocumented

--- a/scipy-stubs/interpolate/_polyint.pyi
+++ b/scipy-stubs/interpolate/_polyint.pyi
@@ -245,91 +245,31 @@ def approximate_taylor_polynomial(
 ) -> np.poly1d: ...
 
 #
-@overload  # 0d f64
+@overload  # f64
 def barycentric_interpolate(
     xi: onp.ToFloat1D,
     yi: onp.ToFloatND,
-    x: onp.ToFloat,
-    axis: int = 0,
-    *,
-    der: int | list[int] | None = 0,
-    rng: onp.random.ToRNG | None = None,
-) -> np.float64: ...
-@overload  # 1d f64
-def barycentric_interpolate(
-    xi: onp.ToFloat1D,
-    yi: onp.ToFloatND,
-    x: onp.ToFloatStrict1D,
-    axis: int = 0,
-    *,
-    der: int | list[int] | None = 0,
-    rng: onp.random.ToRNG | None = None,
-) -> onp.Array1D[np.float64]: ...
-@overload  # nd f64
-def barycentric_interpolate(
-    xi: onp.ToFloat1D,
-    yi: onp.ToFloatND,
-    x: onp.ToFloatND,
+    x: onp.ToFloat | onp.ToFloatND,
     axis: int = 0,
     *,
     der: int | list[int] | None = 0,
     rng: onp.random.ToRNG | None = None,
 ) -> onp.ArrayND[np.float64]: ...
-@overload  # 0d c128
-def barycentric_interpolate(
-    xi: onp.ToFloat1D,
-    yi: onp.ToJustComplexND,
-    x: onp.ToFloat,
-    axis: int = 0,
-    *,
-    der: int | list[int] | None = 0,
-    rng: onp.random.ToRNG | None = None,
-) -> np.complex128: ...
-@overload  # 1d c128
-def barycentric_interpolate(
-    xi: onp.ToFloat1D,
-    yi: onp.ToJustComplexND,
-    x: onp.ToFloatStrict1D,
-    axis: int = 0,
-    *,
-    der: int | list[int] | None = 0,
-    rng: onp.random.ToRNG | None = None,
-) -> onp.Array1D[np.complex128]: ...
 @overload  # nd c128
 def barycentric_interpolate(
     xi: onp.ToFloat1D,
     yi: onp.ToJustComplexND,
-    x: onp.ToFloatND,
+    x: onp.ToFloat | onp.ToFloatND,
     axis: int = 0,
     *,
     der: int | list[int] | None = 0,
     rng: onp.random.ToRNG | None = None,
 ) -> onp.ArrayND[np.complex128]: ...
-@overload  # 0d f64 or c128
-def barycentric_interpolate(
-    xi: onp.ToFloat1D,
-    yi: onp.ToComplexND,
-    x: onp.ToFloat,
-    axis: int = 0,
-    *,
-    der: int | list[int] | None = 0,
-    rng: onp.random.ToRNG | None = None,
-) -> np.float64 | np.complex128: ...
-@overload  # 1d f64 or c128
-def barycentric_interpolate(
-    xi: onp.ToFloat1D,
-    yi: onp.ToComplexND,
-    x: onp.ToFloatStrict1D,
-    axis: int = 0,
-    *,
-    der: int | list[int] | None = 0,
-    rng: onp.random.ToRNG | None = None,
-) -> onp.Array1D[np.float64 | np.complex128]: ...
 @overload  # nd f64 or c128
 def barycentric_interpolate(
     xi: onp.ToFloat1D,
     yi: onp.ToComplexND,
-    x: onp.ToFloatND,
+    x: onp.ToFloat | onp.ToFloatND,
     axis: int = 0,
     *,
     der: int | list[int] | None = 0,

--- a/tests/interpolate/test_cubic.pyi
+++ b/tests/interpolate/test_cubic.pyi
@@ -77,5 +77,5 @@ assert_type(cs_nd.solve(), onp.Array1D[np.float64])
 ###
 # pchip_interpolate
 
-assert_type(pchip_interpolate(x_1d, y_1d, 0.5), np.float64)
+assert_type(pchip_interpolate(x_1d, y_1d, 0.5), onp.ArrayND[np.float64])
 assert_type(pchip_interpolate(x_1d, y_1d, x_1d), onp.ArrayND[np.float64])


### PR DESCRIPTION
Both should return a (0d) `ndarray` for scalar input (instead of a scalar), and `pchip_interpolate` should return a list of arrays when multiple `der` are given.

fixes #1834