### PR TITLE
✅`stats.mstats`: add test coverage for `kruskal`

### DIFF
--- a/tests/stats/test__stats_py.pyi
+++ b/tests/stats/test__stats_py.pyi
@@ -1225,25 +1225,46 @@ assert_type(ranksums(_f32_nd, _f32_nd, keepdims=True), RanksumsResult[onp.ArrayN
 
 # kruskal
 
-assert_type(kruskal(_f64_1d, _f64_1d), KruskalResult[np.float64])
-assert_type(kruskal(_f64_1d, _f64_2d), KruskalResult[onp.Array1D[np.float64]])
-assert_type(kruskal(_f64_1d, _f64_3d), KruskalResult[onp.Array2D[np.float64]])
+assert_type(kruskal(_f64_nd, _f64_1d), KruskalResult[np.float64 | Any])
+assert_type(kruskal(_f64_nd, _f64_nd), KruskalResult[np.float64 | Any])
+
 assert_type(kruskal(_f64_1d, _f64_nd), KruskalResult[np.float64 | Any])
+
+assert_type(kruskal(_f64_nd, _f64_2d), KruskalResult[onp.ArrayND[np.float64]])  # pyrefly:ignore[assert-type]
+assert_type(kruskal(_f64_nd, _f64_3d), KruskalResult[onp.ArrayND[np.float64]])  # pyrefly:ignore[assert-type]
+
+assert_type(kruskal(_f64_2d, _f64_nd), KruskalResult[onp.ArrayND[np.float64]])  # pyrefly:ignore[assert-type]
+assert_type(kruskal(_f64_3d, _f64_nd), KruskalResult[onp.ArrayND[np.float64]])  # pyrefly:ignore[assert-type]
+
+assert_type(kruskal(_f64_1d, _f64_1d), KruskalResult[np.float64])
+assert_type(kruskal(_f64_1d, _f64_1d, _f64_1d), KruskalResult[np.float64])
 
 assert_type(kruskal(_f64_2d, _f64_1d), KruskalResult[onp.Array1D[np.float64]])
 assert_type(kruskal(_f64_2d, _f64_2d), KruskalResult[onp.Array1D[np.float64]])
-assert_type(kruskal(_f64_2d, _f64_3d), KruskalResult[onp.Array2D[np.float64]])
-assert_type(kruskal(_f64_2d, _f64_nd), KruskalResult[onp.ArrayND[np.float64]])  # pyrefly:ignore[assert-type]
+assert_type(kruskal(_f64_2d, _f64_2d, _f64_2d), KruskalResult[onp.Array1D[np.float64]])
+
+assert_type(kruskal(_f64_1d, _f64_2d), KruskalResult[onp.Array1D[np.float64]])
 
 assert_type(kruskal(_f64_3d, _f64_1d), KruskalResult[onp.Array2D[np.float64]])
 assert_type(kruskal(_f64_3d, _f64_2d), KruskalResult[onp.Array2D[np.float64]])
 assert_type(kruskal(_f64_3d, _f64_3d), KruskalResult[onp.Array2D[np.float64]])
-assert_type(kruskal(_f64_3d, _f64_nd), KruskalResult[onp.ArrayND[np.float64]])  # pyrefly:ignore[assert-type]
+assert_type(kruskal(_f64_3d, _f64_3d, _f64_3d), KruskalResult[onp.Array2D[np.float64]])
 
-assert_type(kruskal(_f64_nd, _f64_1d), KruskalResult[np.float64 | Any])
-assert_type(kruskal(_f64_nd, _f64_2d), KruskalResult[onp.ArrayND[np.float64]])  # pyrefly:ignore[assert-type]
-assert_type(kruskal(_f64_nd, _f64_3d), KruskalResult[onp.ArrayND[np.float64]])  # pyrefly:ignore[assert-type]
-assert_type(kruskal(_f64_nd, _f64_nd), KruskalResult[np.float64 | Any])
+assert_type(kruskal(_f64_1d, _f64_3d), KruskalResult[onp.Array2D[np.float64]])
+assert_type(kruskal(_f64_2d, _f64_3d), KruskalResult[onp.Array2D[np.float64]])
+
+assert_type(kruskal(_f64_1d, _f64_2d, _f64_3d), KruskalResult[onp.ArrayND[np.float64] | Any])
+
+assert_type(kruskal(_f64_1d, _f64_1d, axis=None), KruskalResult[np.float64])
+assert_type(kruskal(_f64_2d, _f64_2d, axis=None), KruskalResult[np.float64])
+assert_type(kruskal(_f64_3d, _f64_3d, axis=None), KruskalResult[np.float64])
+assert_type(kruskal(_f64_nd, _f64_nd, axis=None), KruskalResult[np.float64])
+
+assert_type(kruskal(_f64_1d, _f64_1d, keepdims=True), KruskalResult[onp.ArrayND[np.float64]])
+assert_type(kruskal(_f64_2d, _f64_2d, keepdims=True), KruskalResult[onp.ArrayND[np.float64]])
+assert_type(kruskal(_f64_3d, _f64_3d, keepdims=True), KruskalResult[onp.ArrayND[np.float64]])
+assert_type(kruskal(_f64_nd, _f64_nd, keepdims=True), KruskalResult[onp.ArrayND[np.float64]])
+assert_type(kruskal(_f64_2d, _f64_2d, axis=None, keepdims=True), KruskalResult[onp.ArrayND[np.float64]])
 
 # friedmanchisquare
 

--- a/tests/stats/test__stats_py.pyi
+++ b/tests/stats/test__stats_py.pyi
@@ -1225,46 +1225,25 @@ assert_type(ranksums(_f32_nd, _f32_nd, keepdims=True), RanksumsResult[onp.ArrayN
 
 # kruskal
 
-assert_type(kruskal(_f64_nd, _f64_1d), KruskalResult[np.float64 | Any])
-assert_type(kruskal(_f64_nd, _f64_nd), KruskalResult[np.float64 | Any])
-
-assert_type(kruskal(_f64_1d, _f64_nd), KruskalResult[np.float64 | Any])
-
-assert_type(kruskal(_f64_nd, _f64_2d), KruskalResult[onp.ArrayND[np.float64]])  # pyrefly:ignore[assert-type]
-assert_type(kruskal(_f64_nd, _f64_3d), KruskalResult[onp.ArrayND[np.float64]])  # pyrefly:ignore[assert-type]
-
-assert_type(kruskal(_f64_2d, _f64_nd), KruskalResult[onp.ArrayND[np.float64]])  # pyrefly:ignore[assert-type]
-assert_type(kruskal(_f64_3d, _f64_nd), KruskalResult[onp.ArrayND[np.float64]])  # pyrefly:ignore[assert-type]
-
 assert_type(kruskal(_f64_1d, _f64_1d), KruskalResult[np.float64])
-assert_type(kruskal(_f64_1d, _f64_1d, _f64_1d), KruskalResult[np.float64])
+assert_type(kruskal(_f64_1d, _f64_2d), KruskalResult[onp.Array1D[np.float64]])
+assert_type(kruskal(_f64_1d, _f64_3d), KruskalResult[onp.Array2D[np.float64]])
+assert_type(kruskal(_f64_1d, _f64_nd), KruskalResult[np.float64 | Any])
 
 assert_type(kruskal(_f64_2d, _f64_1d), KruskalResult[onp.Array1D[np.float64]])
 assert_type(kruskal(_f64_2d, _f64_2d), KruskalResult[onp.Array1D[np.float64]])
-assert_type(kruskal(_f64_2d, _f64_2d, _f64_2d), KruskalResult[onp.Array1D[np.float64]])
-
-assert_type(kruskal(_f64_1d, _f64_2d), KruskalResult[onp.Array1D[np.float64]])
+assert_type(kruskal(_f64_2d, _f64_3d), KruskalResult[onp.Array2D[np.float64]])
+assert_type(kruskal(_f64_2d, _f64_nd), KruskalResult[onp.ArrayND[np.float64]])  # pyrefly:ignore[assert-type]
 
 assert_type(kruskal(_f64_3d, _f64_1d), KruskalResult[onp.Array2D[np.float64]])
 assert_type(kruskal(_f64_3d, _f64_2d), KruskalResult[onp.Array2D[np.float64]])
 assert_type(kruskal(_f64_3d, _f64_3d), KruskalResult[onp.Array2D[np.float64]])
-assert_type(kruskal(_f64_3d, _f64_3d, _f64_3d), KruskalResult[onp.Array2D[np.float64]])
+assert_type(kruskal(_f64_3d, _f64_nd), KruskalResult[onp.ArrayND[np.float64]])  # pyrefly:ignore[assert-type]
 
-assert_type(kruskal(_f64_1d, _f64_3d), KruskalResult[onp.Array2D[np.float64]])
-assert_type(kruskal(_f64_2d, _f64_3d), KruskalResult[onp.Array2D[np.float64]])
-
-assert_type(kruskal(_f64_1d, _f64_2d, _f64_3d), KruskalResult[onp.ArrayND[np.float64] | Any])
-
-assert_type(kruskal(_f64_1d, _f64_1d, axis=None), KruskalResult[np.float64])
-assert_type(kruskal(_f64_2d, _f64_2d, axis=None), KruskalResult[np.float64])
-assert_type(kruskal(_f64_3d, _f64_3d, axis=None), KruskalResult[np.float64])
-assert_type(kruskal(_f64_nd, _f64_nd, axis=None), KruskalResult[np.float64])
-
-assert_type(kruskal(_f64_1d, _f64_1d, keepdims=True), KruskalResult[onp.ArrayND[np.float64]])
-assert_type(kruskal(_f64_2d, _f64_2d, keepdims=True), KruskalResult[onp.ArrayND[np.float64]])
-assert_type(kruskal(_f64_3d, _f64_3d, keepdims=True), KruskalResult[onp.ArrayND[np.float64]])
-assert_type(kruskal(_f64_nd, _f64_nd, keepdims=True), KruskalResult[onp.ArrayND[np.float64]])
-assert_type(kruskal(_f64_2d, _f64_2d, axis=None, keepdims=True), KruskalResult[onp.ArrayND[np.float64]])
+assert_type(kruskal(_f64_nd, _f64_1d), KruskalResult[np.float64 | Any])
+assert_type(kruskal(_f64_nd, _f64_2d), KruskalResult[onp.ArrayND[np.float64]])  # pyrefly:ignore[assert-type]
+assert_type(kruskal(_f64_nd, _f64_3d), KruskalResult[onp.ArrayND[np.float64]])  # pyrefly:ignore[assert-type]
+assert_type(kruskal(_f64_nd, _f64_nd), KruskalResult[np.float64 | Any])
 
 # friedmanchisquare
 

--- a/tests/stats/test_mstats_basic.pyi
+++ b/tests/stats/test_mstats_basic.pyi
@@ -5,18 +5,19 @@ from typing import assert_type
 import numpy as np
 import optype.numpy as onp
 
-from scipy.stats.mstats import argstoarray, count_tied_groups
+from scipy.stats._mstats_basic import KruskalResult
+from scipy.stats.mstats import argstoarray, count_tied_groups, kruskal
 
-###
-_x: onp.ToFloatND
-assert_type(count_tied_groups(_x), dict[np.intp, np.intp | int])
+_nd: onp.ToFloatND
 
-###
-_a: onp.ToFloatND
-assert_type(argstoarray(_a), onp.MArray[np.float64])
+# count_tied_groups
+assert_type(count_tied_groups(_nd), dict[np.intp, np.intp | int])
 
-_b: onp.ToFloatND
-assert_type(argstoarray(_a, _b), onp.MArray[np.float64])
+# argstoarray
+assert_type(argstoarray(_nd), onp.MArray[np.float64])
+assert_type(argstoarray(_nd, _nd), onp.MArray[np.float64])
+assert_type(argstoarray(_nd, _nd, _nd), onp.MArray[np.float64])
 
-_c: onp.ToFloatND
-assert_type(argstoarray(_a, _b, _c), onp.MArray[np.float64])
+# kruskal
+assert_type(kruskal(_nd, _nd), KruskalResult)
+assert_type(kruskal(_nd, _nd, _nd), KruskalResult)


### PR DESCRIPTION
Towards #1099 