### PR TITLE
🐛 `sparse.linalg.eigs[h]`: propagate `float32`/`complex64`

### DIFF
--- a/scipy-stubs/sparse/linalg/_eigen/arpack/arpack.pyi
+++ b/scipy-stubs/sparse/linalg/_eigen/arpack/arpack.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Mapping
-from typing import Final, Literal, overload
+from typing import Any, Final, Literal, overload
 
 import numpy as np
 import optype.numpy as onp
@@ -14,12 +14,20 @@ __all__ = ["ArpackError", "ArpackNoConvergence", "eigs", "eigsh"]
 
 type _Numeric = npc.number | np.bool
 type _ToFloat = npc.floating | npc.integer | np.bool
+type _ToF64 = npc.floating64 | npc.floating16 | npc.integer | np.bool
+type _ToC64 = _ToF64 | npc.complexfloating128
 
-type _MatrixOperator[_SCT: _Numeric] = spmatrix[_SCT] | sparray[_SCT, tuple[int, int]] | LinearOperator[_SCT]
+type _MatOp[SCT: _Numeric] = spmatrix[SCT] | sparray[SCT, tuple[int, int]] | LinearOperator[SCT]
 
-type _ToRealMatrix = onp.ToFloat2D | _MatrixOperator[_ToFloat]
-type _ToJustComplexMatrix = onp.ToJustComplex2D | _MatrixOperator[npc.complexfloating]
-type _ToComplexMatrix = onp.ToComplex2D | _MatrixOperator[_Numeric]
+type _ToMatFloat = onp.ToFloat2D | _MatOp[_ToFloat]
+type _ToMatF64 = onp.ToArray2D[float, _ToF64] | _MatOp[_ToF64]
+type _ToMatComplex = onp.ToComplex2D | _MatOp[_Numeric]
+type _ToMatC128 = onp.ToArray2D[complex, _ToC64] | _MatOp[_ToC64]
+
+type _AsMatF32 = onp.ToJustFloat32_2D | _MatOp[npc.floating32]
+type _AsMatC64 = onp.ToJustComplex64_2D | _MatOp[npc.complexfloating64]
+type _AsMatC128 = onp.ToJustComplex128_2D | _MatOp[npc.complexfloating128]
+type _AsMatF32C64 = onp.ToJustFloat32_2D | onp.ToJustComplex64_2D | _MatOp[npc.inexact32]
 
 type _Which_eigs = Literal["LM", "SM", "LR", "SR", "LI", "SI"]
 type _Which_eigsh = Literal["LM", "SM", "LA", "SA", "BE"]
@@ -28,26 +36,30 @@ type _Mode = Literal["normal", "buckling", "cayley"]
 
 ###
 
+# NOTE: mypy incorrectly sees disjoint dtypes like `npc.floating32` and `npc.floating64` as overlapping
+# mypy: disable-error-code=overload-overlap
+
 class ArpackError(RuntimeError):
     def __init__[T](self, /, info: T, infodict: Mapping[T, str] | None = None) -> None: ...
 
 class ArpackNoConvergence(ArpackError):
-    eigenvalues: Final[onp.Array1D[np.float64 | np.complex128]]
-    eigenvectors: Final[onp.Array2D[np.float64 | np.complex128]]
+    eigenvalues: Final[onp.Array1D[np.float64 | np.complex128 | Any]]
+    eigenvectors: Final[onp.Array2D[np.float64 | np.complex128 | Any]]
+
     def __init__(
         self,
         /,
         msg: str,
-        eigenvalues: onp.Array1D[np.float64 | np.complex128],
-        eigenvectors: onp.Array2D[np.float64 | np.complex128],
+        eigenvalues: onp.Array1D[np.float64 | np.complex128 | Any],
+        eigenvectors: onp.Array2D[np.float64 | np.complex128 | Any],
     ) -> None: ...
 
 #
-@overload  # returns_eigenvectors: truthy (default)
+@overload  # ~f32 | ~c64, returns_eigenvectors: truthy (default)
 def eigs(
-    A: _ToComplexMatrix,
+    A: _AsMatF32C64,
     k: int = 6,
-    M: _ToComplexMatrix | None = None,
+    M: _ToMatComplex | None = None,
     sigma: onp.ToComplex | None = None,
     which: _Which_eigs = "LM",
     v0: onp.ToComplex1D | None = None,
@@ -55,33 +67,50 @@ def eigs(
     maxiter: int | None = None,
     tol: float = 0,
     return_eigenvectors: onp.ToTrue = True,
-    Minv: _ToComplexMatrix | None = None,
-    OPinv: _ToComplexMatrix | None = None,
+    Minv: _ToMatComplex | None = None,
+    OPinv: _ToMatComplex | None = None,
+    OPpart: _OPpart | None = None,
+    rng: onp.random.ToRNG | None = None,
+) -> tuple[onp.Array1D[np.complex64], onp.Array2D[np.complex64]]: ...
+@overload  # +f64 | ~c128, returns_eigenvectors: truthy (default)
+def eigs(
+    A: _ToMatC128,
+    k: int = 6,
+    M: _ToMatComplex | None = None,
+    sigma: onp.ToComplex | None = None,
+    which: _Which_eigs = "LM",
+    v0: onp.ToComplex1D | None = None,
+    ncv: int | None = None,
+    maxiter: int | None = None,
+    tol: float = 0,
+    return_eigenvectors: onp.ToTrue = True,
+    Minv: _ToMatComplex | None = None,
+    OPinv: _ToMatComplex | None = None,
     OPpart: _OPpart | None = None,
     rng: onp.random.ToRNG | None = None,
 ) -> tuple[onp.Array1D[np.complex128], onp.Array2D[np.complex128]]: ...
-@overload  # returns_eigenvectors: falsy (positional)
+@overload  # +complex (fallback), returns_eigenvectors: truthy (default)
 def eigs(
-    A: _ToComplexMatrix,
-    k: int,
-    M: _ToComplexMatrix | None,
-    sigma: onp.ToComplex | None,
-    which: _Which_eigs,
-    v0: onp.ToComplex1D | None,
-    ncv: int | None,
-    maxiter: int | None,
-    tol: float,
-    return_eigenvectors: onp.ToFalse,
-    Minv: _ToComplexMatrix | None = None,
-    OPinv: _ToComplexMatrix | None = None,
+    A: _ToMatComplex,
+    k: int = 6,
+    M: _ToMatComplex | None = None,
+    sigma: onp.ToComplex | None = None,
+    which: _Which_eigs = "LM",
+    v0: onp.ToComplex1D | None = None,
+    ncv: int | None = None,
+    maxiter: int | None = None,
+    tol: float = 0,
+    return_eigenvectors: onp.ToTrue = True,
+    Minv: _ToMatComplex | None = None,
+    OPinv: _ToMatComplex | None = None,
     OPpart: _OPpart | None = None,
     rng: onp.random.ToRNG | None = None,
-) -> onp.Array1D[np.complex128]: ...
-@overload  # returns_eigenvectors: falsy (keyword)
+) -> tuple[onp.Array1D[np.complex128 | Any], onp.Array2D[np.complex128 | Any]]: ...
+@overload  # ~f32 | ~c64, returns_eigenvectors: falsy (keyword)
 def eigs(
-    A: _ToComplexMatrix,
+    A: _AsMatF32C64,
     k: int = 6,
-    M: _ToComplexMatrix | None = None,
+    M: _ToMatComplex | None = None,
     sigma: onp.ToComplex | None = None,
     which: _Which_eigs = "LM",
     v0: onp.ToComplex1D | None = None,
@@ -90,18 +119,54 @@ def eigs(
     tol: float = 0,
     *,
     return_eigenvectors: onp.ToFalse,
-    Minv: _ToComplexMatrix | None = None,
-    OPinv: _ToComplexMatrix | None = None,
+    Minv: _ToMatComplex | None = None,
+    OPinv: _ToMatComplex | None = None,
+    OPpart: _OPpart | None = None,
+    rng: onp.random.ToRNG | None = None,
+) -> onp.Array1D[np.complex64]: ...
+@overload  # +f64 | ~c128, returns_eigenvectors: falsy (keyword)
+def eigs(
+    A: _ToMatC128,
+    k: int = 6,
+    M: _ToMatComplex | None = None,
+    sigma: onp.ToComplex | None = None,
+    which: _Which_eigs = "LM",
+    v0: onp.ToComplex1D | None = None,
+    ncv: int | None = None,
+    maxiter: int | None = None,
+    tol: float = 0,
+    *,
+    return_eigenvectors: onp.ToFalse,
+    Minv: _ToMatComplex | None = None,
+    OPinv: _ToMatComplex | None = None,
     OPpart: _OPpart | None = None,
     rng: onp.random.ToRNG | None = None,
 ) -> onp.Array1D[np.complex128]: ...
+@overload  # +complex (fallback), returns_eigenvectors: falsy (keyword)
+def eigs(
+    A: _ToMatComplex,
+    k: int = 6,
+    M: _ToMatComplex | None = None,
+    sigma: onp.ToComplex | None = None,
+    which: _Which_eigs = "LM",
+    v0: onp.ToComplex1D | None = None,
+    ncv: int | None = None,
+    maxiter: int | None = None,
+    tol: float = 0,
+    *,
+    return_eigenvectors: onp.ToFalse,
+    Minv: _ToMatComplex | None = None,
+    OPinv: _ToMatComplex | None = None,
+    OPpart: _OPpart | None = None,
+    rng: onp.random.ToRNG | None = None,
+) -> onp.Array1D[np.complex128 | Any]: ...
 
 #
-@overload  # real, returns_eigenvectors: truthy (default)
+@overload  # ~f32, returns_eigenvectors: truthy (default)
 def eigsh(
-    A: _ToRealMatrix,
+    A: _AsMatF32,
     k: int = 6,
-    M: _ToRealMatrix | None = None,
+    M: _ToMatFloat | None = None,
     sigma: onp.ToFloat | None = None,
     which: _Which_eigsh = "LM",
     v0: onp.ToFloat1D | None = None,
@@ -109,16 +174,67 @@ def eigsh(
     maxiter: int | None = None,
     tol: float = 0,
     return_eigenvectors: onp.ToTrue = True,
-    Minv: _ToRealMatrix | None = None,
-    OPinv: _ToRealMatrix | None = None,
+    Minv: _ToMatFloat | None = None,
+    OPinv: _ToMatFloat | None = None,
+    mode: _Mode = "normal",
+    rng: onp.random.ToRNG | None = None,
+) -> tuple[onp.Array1D[np.float32], onp.Array2D[np.float32]]: ...
+@overload  # ~c64, returns_eigenvectors: truthy (default)
+def eigsh(
+    A: _AsMatC64,
+    k: int = 6,
+    M: _ToMatComplex | None = None,
+    sigma: onp.ToFloat | None = None,
+    which: _Which_eigsh = "LM",
+    v0: onp.ToComplex1D | None = None,
+    ncv: int | None = None,
+    maxiter: int | None = None,
+    tol: float = 0,
+    return_eigenvectors: onp.ToTrue = True,
+    Minv: _ToMatComplex | None = None,
+    OPinv: _ToMatComplex | None = None,
+    mode: _Mode = "normal",
+    rng: onp.random.ToRNG | None = None,
+) -> tuple[onp.Array1D[np.float32], onp.Array2D[np.complex64]]: ...
+@overload  # ~f32 | ~c64, returns_eigenvectors: truthy (default)
+def eigsh(
+    A: _AsMatF32C64,
+    k: int = 6,
+    M: _ToMatComplex | None = None,
+    sigma: onp.ToFloat | None = None,
+    which: _Which_eigsh = "LM",
+    v0: onp.ToComplex1D | None = None,
+    ncv: int | None = None,
+    maxiter: int | None = None,
+    tol: float = 0,
+    return_eigenvectors: onp.ToTrue = True,
+    Minv: _ToMatComplex | None = None,
+    OPinv: _ToMatComplex | None = None,
+    mode: _Mode = "normal",
+    rng: onp.random.ToRNG | None = None,
+) -> tuple[onp.Array1D[np.float32], onp.Array2D[np.float32 | np.complex64]]: ...
+@overload  # +f64, returns_eigenvectors: truthy (default)
+def eigsh(
+    A: _ToMatF64,
+    k: int = 6,
+    M: _ToMatFloat | None = None,
+    sigma: onp.ToFloat | None = None,
+    which: _Which_eigsh = "LM",
+    v0: onp.ToFloat1D | None = None,
+    ncv: int | None = None,
+    maxiter: int | None = None,
+    tol: float = 0,
+    return_eigenvectors: onp.ToTrue = True,
+    Minv: _ToMatFloat | None = None,
+    OPinv: _ToMatFloat | None = None,
     mode: _Mode = "normal",
     rng: onp.random.ToRNG | None = None,
 ) -> tuple[onp.Array1D[np.float64], onp.Array2D[np.float64]]: ...
-@overload  # complex, returns_eigenvectors: truthy (default)
+@overload  # ~c128, returns_eigenvectors: truthy (default)
 def eigsh(
-    A: _ToJustComplexMatrix,
+    A: _AsMatC128,
     k: int = 6,
-    M: _ToComplexMatrix | None = None,
+    M: _ToMatComplex | None = None,
     sigma: onp.ToFloat | None = None,
     which: _Which_eigsh = "LM",
     v0: onp.ToComplex1D | None = None,
@@ -126,16 +242,16 @@ def eigsh(
     maxiter: int | None = None,
     tol: float = 0,
     return_eigenvectors: onp.ToTrue = True,
-    Minv: _ToComplexMatrix | None = None,
-    OPinv: _ToComplexMatrix | None = None,
+    Minv: _ToMatComplex | None = None,
+    OPinv: _ToMatComplex | None = None,
     mode: _Mode = "normal",
     rng: onp.random.ToRNG | None = None,
 ) -> tuple[onp.Array1D[np.float64], onp.Array2D[np.complex128]]: ...
-@overload  # real or complex (catch-all), returns_eigenvectors: truthy (default)
+@overload  # +f64 | ~c128, returns_eigenvectors: truthy (default)
 def eigsh(
-    A: _ToComplexMatrix,
+    A: _ToMatC128,
     k: int = 6,
-    M: _ToComplexMatrix | None = None,
+    M: _ToMatComplex | None = None,
     sigma: onp.ToFloat | None = None,
     which: _Which_eigsh = "LM",
     v0: onp.ToComplex1D | None = None,
@@ -143,33 +259,33 @@ def eigsh(
     maxiter: int | None = None,
     tol: float = 0,
     return_eigenvectors: onp.ToTrue = True,
-    Minv: _ToComplexMatrix | None = None,
-    OPinv: _ToComplexMatrix | None = None,
+    Minv: _ToMatComplex | None = None,
+    OPinv: _ToMatComplex | None = None,
     mode: _Mode = "normal",
     rng: onp.random.ToRNG | None = None,
 ) -> tuple[onp.Array1D[np.float64], onp.Array2D[np.float64 | np.complex128]]: ...
-@overload  # real or complex, returns_eigenvectors: falsy (positional)
+@overload  # +complex (fallback), returns_eigenvectors: truthy (default)
 def eigsh(
-    A: _ToComplexMatrix,
-    k: int,
-    M: _ToComplexMatrix | None,
-    sigma: onp.ToFloat | None,
-    which: _Which_eigsh,
-    v0: onp.ToComplex1D | None,
-    ncv: int | None,
-    maxiter: int | None,
-    tol: float,
-    return_eigenvectors: onp.ToFalse,
-    Minv: _ToComplexMatrix | None = None,
-    OPinv: _ToComplexMatrix | None = None,
+    A: _ToMatComplex,
+    k: int = 6,
+    M: _ToMatComplex | None = None,
+    sigma: onp.ToFloat | None = None,
+    which: _Which_eigsh = "LM",
+    v0: onp.ToComplex1D | None = None,
+    ncv: int | None = None,
+    maxiter: int | None = None,
+    tol: float = 0,
+    return_eigenvectors: onp.ToTrue = True,
+    Minv: _ToMatComplex | None = None,
+    OPinv: _ToMatComplex | None = None,
     mode: _Mode = "normal",
     rng: onp.random.ToRNG | None = None,
-) -> onp.Array1D[np.float64]: ...
-@overload  # real or complex, returns_eigenvectors: falsy (keyword)
+) -> tuple[onp.Array1D[np.float64 | Any], onp.Array2D[np.float64 | np.complex128 | Any]]: ...
+@overload  # ~f32 | ~c64, returns_eigenvectors: falsy (keyword)
 def eigsh(
-    A: _ToComplexMatrix,
+    A: _AsMatF32C64,
     k: int = 6,
-    M: _ToComplexMatrix | None = None,
+    M: _ToMatComplex | None = None,
     sigma: onp.ToFloat | None = None,
     which: _Which_eigsh = "LM",
     v0: onp.ToComplex1D | None = None,
@@ -178,8 +294,44 @@ def eigsh(
     tol: float = 0,
     *,
     return_eigenvectors: onp.ToFalse,
-    Minv: _ToComplexMatrix | None = None,
-    OPinv: _ToComplexMatrix | None = None,
+    Minv: _ToMatComplex | None = None,
+    OPinv: _ToMatComplex | None = None,
+    mode: _Mode = "normal",
+    rng: onp.random.ToRNG | None = None,
+) -> onp.Array1D[np.float32]: ...
+@overload  # +f64 | ~c128, returns_eigenvectors: falsy (keyword)
+def eigsh(
+    A: _ToMatC128,
+    k: int = 6,
+    M: _ToMatComplex | None = None,
+    sigma: onp.ToFloat | None = None,
+    which: _Which_eigsh = "LM",
+    v0: onp.ToComplex1D | None = None,
+    ncv: int | None = None,
+    maxiter: int | None = None,
+    tol: float = 0,
+    *,
+    return_eigenvectors: onp.ToFalse,
+    Minv: _ToMatComplex | None = None,
+    OPinv: _ToMatComplex | None = None,
     mode: _Mode = "normal",
     rng: onp.random.ToRNG | None = None,
 ) -> onp.Array1D[np.float64]: ...
+@overload  # +complex (fallback), returns_eigenvectors: falsy (keyword)
+def eigsh(
+    A: _ToMatComplex,
+    k: int = 6,
+    M: _ToMatComplex | None = None,
+    sigma: onp.ToFloat | None = None,
+    which: _Which_eigsh = "LM",
+    v0: onp.ToComplex1D | None = None,
+    ncv: int | None = None,
+    maxiter: int | None = None,
+    tol: float = 0,
+    *,
+    return_eigenvectors: onp.ToFalse,
+    Minv: _ToMatComplex | None = None,
+    OPinv: _ToMatComplex | None = None,
+    mode: _Mode = "normal",
+    rng: onp.random.ToRNG | None = None,
+) -> onp.Array1D[np.float64 | Any]: ...

--- a/tests/sparse/linalg/test__arpack.pyi
+++ b/tests/sparse/linalg/test__arpack.pyi
@@ -1,4 +1,4 @@
-from typing import assert_type
+from typing import Any, assert_type
 
 import numpy as np
 import optype.numpy as onp
@@ -6,28 +6,46 @@ import optype.numpy as onp
 from scipy.sparse import csr_array
 from scipy.sparse.linalg import ArpackNoConvergence, eigs, eigsh
 
-a_f: csr_array[np.float64]
-a_c: csr_array[np.complex128]
-a_fc: csr_array[np.float64] | csr_array[np.complex128]
+###
+
+_a_i: csr_array[np.int64]
+_a_f: csr_array[np.float64]
+_a_c: csr_array[np.complex128]
+_a_fc: csr_array[np.float64] | csr_array[np.complex128]
+
+_a_f32: csr_array[np.float32]
+_a_c128: csr_array[np.complex64]
+_a_f32c64: csr_array[np.float32] | csr_array[np.complex64]
+
+###
 
 # ArpackNoConvergence
-exc: ArpackNoConvergence
-assert_type(exc.eigenvalues, onp.Array1D[np.float64 | np.complex128])
-assert_type(exc.eigenvectors, onp.Array2D[np.float64 | np.complex128])
+_exc: ArpackNoConvergence
+assert_type(_exc.eigenvalues, onp.Array1D[np.float64 | np.complex128 | Any])
+assert_type(_exc.eigenvectors, onp.Array2D[np.float64 | np.complex128 | Any])
 
 # eigs
-assert_type(eigs(a_f), tuple[onp.Array1D[np.complex128], onp.Array2D[np.complex128]])
-assert_type(eigs(a_c), tuple[onp.Array1D[np.complex128], onp.Array2D[np.complex128]])
-assert_type(eigs(a_f, 6, None, None, "LM", None, None, None, 0, False), onp.Array1D[np.complex128])
-assert_type(eigs(a_c, 6, None, None, "LM", None, None, None, 0, False), onp.Array1D[np.complex128])
-assert_type(eigs(a_f, return_eigenvectors=False), onp.Array1D[np.complex128])
-assert_type(eigs(a_c, return_eigenvectors=False), onp.Array1D[np.complex128])
+assert_type(eigs(_a_i), tuple[onp.Array1D[np.complex128], onp.Array2D[np.complex128]])
+assert_type(eigs(_a_f), tuple[onp.Array1D[np.complex128], onp.Array2D[np.complex128]])
+assert_type(eigs(_a_c), tuple[onp.Array1D[np.complex128], onp.Array2D[np.complex128]])
+assert_type(eigs(_a_fc), tuple[onp.Array1D[np.complex128], onp.Array2D[np.complex128]])
+assert_type(eigs(_a_f32), tuple[onp.Array1D[np.complex64], onp.Array2D[np.complex64]])
+assert_type(eigs(_a_c128), tuple[onp.Array1D[np.complex64], onp.Array2D[np.complex64]])
+assert_type(eigs(_a_f32c64), tuple[onp.Array1D[np.complex64], onp.Array2D[np.complex64]])
+assert_type(eigs(_a_f, return_eigenvectors=False), onp.Array1D[np.complex128])
+assert_type(eigs(_a_c, return_eigenvectors=False), onp.Array1D[np.complex128])
+assert_type(eigs(_a_f32, return_eigenvectors=False), onp.Array1D[np.complex64])
+assert_type(eigs(_a_c128, return_eigenvectors=False), onp.Array1D[np.complex64])
 
 # eigsh
-assert_type(eigsh(a_f), tuple[onp.Array1D[np.float64], onp.Array2D[np.float64]])
-assert_type(eigsh(a_c), tuple[onp.Array1D[np.float64], onp.Array2D[np.complex128]])
-assert_type(eigsh(a_fc), tuple[onp.Array1D[np.float64], onp.Array2D[np.float64 | np.complex128]])
-assert_type(eigsh(a_f, 6, None, None, "LM", None, None, None, 0, False), onp.Array1D[np.float64])
-assert_type(eigsh(a_c, 6, None, None, "LM", None, None, None, 0, False), onp.Array1D[np.float64])
-assert_type(eigsh(a_f, return_eigenvectors=False), onp.Array1D[np.float64])
-assert_type(eigsh(a_c, return_eigenvectors=False), onp.Array1D[np.float64])
+assert_type(eigsh(_a_i), tuple[onp.Array1D[np.float64], onp.Array2D[np.float64]])
+assert_type(eigsh(_a_f), tuple[onp.Array1D[np.float64], onp.Array2D[np.float64]])
+assert_type(eigsh(_a_c), tuple[onp.Array1D[np.float64], onp.Array2D[np.complex128]])
+assert_type(eigsh(_a_fc), tuple[onp.Array1D[np.float64], onp.Array2D[np.float64 | np.complex128]])
+assert_type(eigsh(_a_f32), tuple[onp.Array1D[np.float32], onp.Array2D[np.float32]])
+assert_type(eigsh(_a_c128), tuple[onp.Array1D[np.float32], onp.Array2D[np.complex64]])
+assert_type(eigsh(_a_f32c64), tuple[onp.Array1D[np.float32], onp.Array2D[np.float32 | np.complex64]])
+assert_type(eigsh(_a_f, return_eigenvectors=False), onp.Array1D[np.float64])
+assert_type(eigsh(_a_c, return_eigenvectors=False), onp.Array1D[np.float64])
+assert_type(eigsh(_a_f32, return_eigenvectors=False), onp.Array1D[np.float32])
+assert_type(eigsh(_a_c128, return_eigenvectors=False), onp.Array1D[np.float32])


### PR DESCRIPTION
towards #1813