### PR TITLE
✨ `stats.mstats.tmean`: improve shape-typing and return dtypes

### DIFF
--- a/scipy-stubs/stats/_mstats_basic.pyi
+++ b/scipy-stubs/stats/_mstats_basic.pyi
@@ -1,10 +1,12 @@
 from collections.abc import Callable
 from typing import (
+    Any,
     Concatenate,
     Final,
     Generic,
     Literal,
     NamedTuple,
+    Never,
     Self,
     SupportsIndex,
     TypedDict,
@@ -88,6 +90,10 @@ __all__ = [
 ###
 
 type _MArrayOrND[ScalarT: np.generic] = ScalarT | onp.MArray[ScalarT]
+
+type _AsF64 = np.float64 | npc.integer | np.bool
+
+type _JustAnyShape = tuple[Never, Never, Never, Never]  # workaround for https://github.com/microsoft/pyright/issues/10232
 
 type _KendallTauMethod = Literal["auto", "asymptotic", "exact"]
 type _TheilSlopesMethod = Literal["joint", "separate"]
@@ -468,20 +474,121 @@ def trimmed_stde(
 ) -> _MArrayOrND[np.float64]: ...
 
 #
-@overload
+# NOTE: f32/c64 promotes to f64/c128
+@overload  # ?d ~f64, axis=None (default)
 def tmean(
-    a: onp.ToFloatND,
+    a: onp.ToArrayND[float, _AsF64 | np.float32],
+    limits: tuple[onp.ToFloat, onp.ToFloat] | None = None,
+    inclusive: tuple[bool, bool] = (True, True),
+    axis: None = None,
+) -> np.float64: ...
+@overload  # ?d ~c128, axis=None (default)
+def tmean(
+    a: onp.ToArrayND[op.JustComplex, np.complex128 | np.complex64],
+    limits: tuple[onp.ToComplex, onp.ToComplex] | None = None,
+    inclusive: tuple[bool, bool] = (True, True),
+    axis: None = None,
+) -> np.complex128: ...
+@overload  # ?d T@inexact, axis=None (default)
+def tmean[InexactT: npc.inexact80 | np.float16](
+    a: onp.ToArrayND[InexactT, InexactT],
+    limits: tuple[onp.ToComplex, onp.ToComplex] | None = None,
+    inclusive: tuple[bool, bool] = (True, True),
+    axis: None = None,
+) -> InexactT: ...
+@overload  # ?d +integer | ~f32, axis=<given>
+def tmean(
+    a: onp.ArrayND[_AsF64 | np.float32, _JustAnyShape],
+    limits: tuple[onp.ToFloat, onp.ToFloat] | None = None,
+    inclusive: tuple[bool, bool] = (True, True),
+    *,
+    axis: SupportsIndex,
+) -> onp.MArray[np.float64] | Any: ...
+@overload  # ?d ~c64, axis=<given>
+def tmean(
+    a: onp.ArrayND[np.complex128 | np.complex64, _JustAnyShape],
+    limits: tuple[onp.ToComplex, onp.ToComplex] | None = None,
+    inclusive: tuple[bool, bool] = (True, True),
+    *,
+    axis: SupportsIndex,
+) -> onp.MArray[np.complex128] | Any: ...
+@overload  # ?d T@inexact, axis=<given>
+def tmean[InexactT: npc.inexact80 | np.float16](
+    a: onp.ArrayND[InexactT, _JustAnyShape],
+    limits: tuple[onp.ToComplex, onp.ToComplex] | None = None,
+    inclusive: tuple[bool, bool] = (True, True),
+    *,
+    axis: SupportsIndex,
+) -> onp.MArray[InexactT] | Any: ...
+@overload  # 1d +f64 | ~f32, axis=<given>
+def tmean(
+    a: onp.ToArrayStrict1D[float, _AsF64 | np.float32],
+    limits: tuple[onp.ToFloat, onp.ToFloat] | None = None,
+    inclusive: tuple[bool, bool] = (True, True),
+    *,
+    axis: SupportsIndex,
+) -> np.float64: ...
+@overload  # 1d ~complex | ~c64, axis=<given>
+def tmean(
+    a: onp.ToArrayStrict1D[op.JustComplex, np.complex128 | np.complex64],
+    limits: tuple[onp.ToComplex, onp.ToComplex] | None = None,
+    inclusive: tuple[bool, bool] = (True, True),
+    *,
+    axis: SupportsIndex,
+) -> np.complex128: ...
+@overload  # 1d T@inexact, axis=<given>
+def tmean[InexactT: npc.inexact80 | np.float16](
+    a: onp.ToArrayStrict1D[InexactT, InexactT],
+    limits: tuple[onp.ToComplex, onp.ToComplex] | None = None,
+    inclusive: tuple[bool, bool] = (True, True),
+    *,
+    axis: SupportsIndex,
+) -> InexactT: ...
+@overload  # 2d ~f64, axis=<given>
+def tmean(
+    a: onp.ToArrayStrict2D[float, _AsF64 | np.float32],
+    limits: tuple[onp.ToFloat, onp.ToFloat] | None = None,
+    inclusive: tuple[bool, bool] = (True, True),
+    *,
+    axis: SupportsIndex,
+) -> onp.MArray1D[np.float64]: ...
+@overload  # 2d ~c128, axis=<given>
+def tmean(
+    a: onp.ToArrayStrict2D[op.JustComplex, np.complex128 | np.complex64],
+    limits: tuple[onp.ToComplex, onp.ToComplex] | None = None,
+    inclusive: tuple[bool, bool] = (True, True),
+    *,
+    axis: SupportsIndex,
+) -> onp.MArray1D[np.complex128]: ...
+@overload  # 2d T@inexact, axis=<given>
+def tmean[InexactT: npc.inexact80 | np.float16](
+    a: onp.ToArrayStrict2D[InexactT, InexactT],
+    limits: tuple[onp.ToComplex, onp.ToComplex] | None = None,
+    inclusive: tuple[bool, bool] = (True, True),
+    *,
+    axis: SupportsIndex,
+) -> onp.MArray1D[InexactT]: ...
+@overload  # Nd ~f64
+def tmean(
+    a: onp.ToArrayND[float, _AsF64 | np.float32],
     limits: tuple[onp.ToFloat, onp.ToFloat] | None = None,
     inclusive: tuple[bool, bool] = (True, True),
     axis: SupportsIndex | None = None,
-) -> _MArrayOrND[npc.floating]: ...
-@overload
+) -> onp.MArray[np.float64] | Any: ...
+@overload  # Nd ~c128
 def tmean(
-    a: onp.ToComplexND,
+    a: onp.ToArrayND[op.JustComplex, np.complex128 | np.complex64],
     limits: tuple[onp.ToComplex, onp.ToComplex] | None = None,
     inclusive: tuple[bool, bool] = (True, True),
     axis: SupportsIndex | None = None,
-) -> _MArrayOrND[npc.inexact]: ...
+) -> onp.MArray[np.complex128] | Any: ...
+@overload  # Nd T@inexact
+def tmean[InexactT: npc.inexact80 | np.float16](
+    a: onp.ToArrayND[InexactT, InexactT],
+    limits: tuple[onp.ToComplex, onp.ToComplex] | None = None,
+    inclusive: tuple[bool, bool] = (True, True),
+    axis: SupportsIndex | None = None,
+) -> onp.MArray[InexactT] | Any: ...
 
 #
 def tvar(

--- a/tests/stats/test_mstats.pyi
+++ b/tests/stats/test_mstats.pyi
@@ -10,14 +10,106 @@ from scipy.stats.mstats import tmax, tmean, tmin
 ###
 
 _py_i_1d: list[int]
+_py_i_2d: list[list[int]]
+_py_f_1d: list[float]
+_py_f_2d: list[list[float]]
+_py_c_1d: list[complex]
+_py_c_2d: list[list[complex]]
+
+_i64_1d: onp.Array1D[np.int64]
+_i64_2d: onp.Array2D[np.int64]
+_i64_nd: onp.ArrayND[np.int64]
+
+_f16_1d: onp.Array1D[np.float16]
+_f16_2d: onp.Array2D[np.float16]
+_f16_nd: onp.ArrayND[np.float16]
+
 _f32_1d: onp.Array1D[np.float32]
+_f32_2d: onp.Array2D[np.float32]
+_f32_3d: onp.Array3D[np.float32]
+_f32_nd: onp.ArrayND[np.float32]
+
+_f64_1d: onp.Array1D[np.float64]
+_f64_2d: onp.Array2D[np.float64]
+_f64_nd: onp.ArrayND[np.float64]
+
+_c64_1d: onp.Array1D[np.complex64]
+_c64_2d: onp.Array2D[np.complex64]
+_c64_nd: onp.ArrayND[np.complex64]
+
+_c128_1d: onp.Array1D[np.complex128]
+_c128_2d: onp.Array2D[np.complex128]
+_c128_nd: onp.ArrayND[np.complex128]
+
+_m_f32_nd: onp.MArray[np.float32]
+_m_f64_nd: onp.MArray[np.float64]
 
 ###
+# tmean
 
-assert_type(tmean(_f32_1d), np.floating[Any] | onp.MArray[np.floating[Any]])
+assert_type(tmean(_py_i_1d), np.float64)
+assert_type(tmean(_py_f_1d), np.float64)
+assert_type(tmean(_py_c_1d), np.complex128)
+assert_type(tmean(_py_i_2d), np.float64)
+assert_type(tmean(_py_f_2d), np.float64)
+assert_type(tmean(_py_c_2d), np.complex128)
+assert_type(tmean(_i64_1d), np.float64)
+assert_type(tmean(_i64_2d), np.float64)
+assert_type(tmean(_i64_nd), np.float64)
+assert_type(tmean(_f16_1d), np.float16)
+assert_type(tmean(_f16_nd), np.float16)
+assert_type(tmean(_f32_1d), np.float64)
+assert_type(tmean(_f32_2d), np.float64)
+assert_type(tmean(_f32_nd), np.float64)
+assert_type(tmean(_f64_1d), np.float64)
+assert_type(tmean(_f64_nd), np.float64)
+assert_type(tmean(_c64_1d), np.complex128)
+assert_type(tmean(_c64_nd), np.complex128)
+assert_type(tmean(_c128_1d), np.complex128)
+assert_type(tmean(_c128_nd), np.complex128)
+assert_type(tmean(_m_f32_nd), np.float64)
+assert_type(tmean(_m_f64_nd), np.float64)
+
+assert_type(tmean(_py_i_1d, axis=0), np.float64)
+assert_type(tmean(_py_f_1d, axis=0), np.float64)
+assert_type(tmean(_py_c_1d, axis=0), np.complex128)
+assert_type(tmean(_i64_1d, axis=0), np.float64)
+assert_type(tmean(_f16_1d, axis=0), np.float16)
+assert_type(tmean(_f32_1d, axis=0), np.float64)
+assert_type(tmean(_f64_1d, axis=0), np.float64)
+assert_type(tmean(_c64_1d, axis=0), np.complex128)
+assert_type(tmean(_c128_1d, axis=0), np.complex128)
+
+assert_type(tmean(_py_i_2d, axis=0), onp.MArray1D[np.float64])
+assert_type(tmean(_py_f_2d, axis=0), onp.MArray1D[np.float64])
+assert_type(tmean(_py_c_2d, axis=0), onp.MArray1D[np.complex128])
+assert_type(tmean(_i64_2d, axis=0), onp.MArray1D[np.float64])
+assert_type(tmean(_f16_2d, axis=0), onp.MArray1D[np.float16])
+assert_type(tmean(_f32_2d, axis=0), onp.MArray1D[np.float64])
+assert_type(tmean(_f64_2d, axis=0), onp.MArray1D[np.float64])
+assert_type(tmean(_c64_2d, axis=0), onp.MArray1D[np.complex128])
+assert_type(tmean(_c128_2d, axis=0), onp.MArray1D[np.complex128])
+
+assert_type(tmean(_i64_nd, axis=0), onp.MArray[np.float64] | Any)
+assert_type(tmean(_f16_nd, axis=0), onp.MArray[np.float16] | Any)
+assert_type(tmean(_f32_nd, axis=0), onp.MArray[np.float64] | Any)
+assert_type(tmean(_f64_nd, axis=0), onp.MArray[np.float64] | Any)
+assert_type(tmean(_c64_nd, axis=0), onp.MArray[np.complex128] | Any)
+assert_type(tmean(_c128_nd, axis=0), onp.MArray[np.complex128] | Any)
+assert_type(tmean(_m_f32_nd, axis=0), onp.MArray[np.float64] | Any)
+assert_type(tmean(_m_f64_nd, axis=0), onp.MArray[np.float64] | Any)
+
+assert_type(tmean(_f32_3d, axis=0), onp.MArray[np.float64] | Any)
+assert_type(tmean(_f64_nd, (0.0, 1.0), (True, True), 0), onp.MArray[np.float64] | Any)
+
+###
+# tmin
 
 assert_type(tmin(_py_i_1d), np.int_ | onp.MArray[np.int_])
 assert_type(tmin(_f32_1d), np.float32 | onp.MArray[np.float32])
+
+###
+# tmax
 
 assert_type(tmax(_py_i_1d), np.int_ | onp.MArray[np.int_])
 assert_type(tmax(_f32_1d), np.float32 | onp.MArray[np.float32])


### PR DESCRIPTION
`scipy.stats.mstats.tmean` is now annotated using 15 overloads instead of 2, including special-cased shape-typing overloads for the 1d and 2d cases when `axis` is given (the default `axis=None` always returns a scalar).

towards #1146