### PR TITLE
✨ `stats.mstats.{variation,skew,kurtosis}`: improve shape-typing and return dtypes

### DIFF
--- a/scipy-stubs/stats/_mstats_basic.pyi
+++ b/scipy-stubs/stats/_mstats_basic.pyi
@@ -821,7 +821,7 @@ def moment[InexactT: npc.inexact80](
 # TODO(jorenham): Overloads for complex array-likes
 def variation(a: onp.ToFloatND, axis: SupportsIndex | None = 0, ddof: onp.ToInt = 0) -> _MArrayOrND[npc.floating]: ...
 
-# NOTE: f16/f32 and c64 promote to f64 and c128, and the result is always a `MaskedArray`
+#
 @overload  # ?d ~f64, axis=None
 def skew(a: onp.ToFloat64_ND, axis: None, bias: bool = True) -> onp.MArray0D[np.float64]: ...
 @overload  # ?d ~c128, axis=None
@@ -886,9 +886,91 @@ def skew[InexactT: npc.inexact80](
 ) -> onp.MArray[InexactT] | Any: ...
 
 #
+@overload  # ?d ~f64, axis=None, fisher=True
+def kurtosis(a: onp.ToFloat64_ND, axis: None, fisher: Literal[True] = True, bias: bool = True) -> np.float64: ...
+@overload  # ?d ~c128, axis=None, fisher=True
 def kurtosis(
-    a: onp.ToFloatND, axis: SupportsIndex | None = 0, fisher: bool = True, bias: bool = True
-) -> _MArrayOrND[npc.floating]: ...
+    a: onp.ToArrayND[op.JustComplex, np.complex128 | np.complex64], axis: None, fisher: Literal[True] = True, bias: bool = True
+) -> np.complex128: ...
+@overload  # ?d T@inexact80, axis=None, fisher=True
+def kurtosis[InexactT: npc.inexact80](
+    a: onp.ToArrayND[InexactT, InexactT], axis: None, fisher: Literal[True] = True, bias: bool = True
+) -> InexactT: ...
+@overload  # ?d ~f64, axis=<given> (default)
+def kurtosis(
+    a: onp.ArrayND[_AsF64 | np.float32 | np.float16, _JustAnyShape],
+    axis: SupportsIndex = 0,
+    fisher: bool = True,
+    bias: bool = True,
+) -> onp.MArray[np.float64] | Any: ...
+@overload  # ?d ~c128, axis=<given> (default)
+def kurtosis(
+    a: onp.ArrayND[np.complex128 | np.complex64, _JustAnyShape], axis: SupportsIndex = 0, fisher: bool = True, bias: bool = True
+) -> onp.MArray[np.complex128] | Any: ...
+@overload  # ?d T@inexact80, axis=<given> (default)
+def kurtosis[InexactT: npc.inexact80](
+    a: onp.ArrayND[InexactT, _JustAnyShape], axis: SupportsIndex = 0, fisher: bool = True, bias: bool = True
+) -> onp.MArray[InexactT] | Any: ...
+@overload  # 1d ~f64, fisher=True (default)
+def kurtosis(
+    a: onp.ToFloat64Strict1D, axis: SupportsIndex = 0, fisher: Literal[True] = True, bias: bool = True
+) -> np.float64: ...
+@overload  # 1d ~c128, fisher=True (default)
+def kurtosis(
+    a: onp.ToArrayStrict1D[op.JustComplex, np.complex128 | np.complex64],
+    axis: SupportsIndex = 0,
+    fisher: Literal[True] = True,
+    bias: bool = True,
+) -> np.complex128: ...
+@overload  # 1d T@inexact80, fisher=True (default)
+def kurtosis[InexactT: npc.inexact80](
+    a: onp.ToArrayStrict1D[InexactT, InexactT], axis: SupportsIndex = 0, fisher: Literal[True] = True, bias: bool = True
+) -> InexactT: ...
+@overload  # 2d ~f64, axis=<given> (default)
+def kurtosis(
+    a: onp.ToFloat64Strict2D, axis: SupportsIndex = 0, fisher: bool = True, bias: bool = True
+) -> onp.MArray1D[np.float64]: ...
+@overload  # 2d ~c128, axis=<given> (default)
+def kurtosis(
+    a: onp.ToArrayStrict2D[op.JustComplex, np.complex128 | np.complex64],
+    axis: SupportsIndex = 0,
+    fisher: bool = True,
+    bias: bool = True,
+) -> onp.MArray1D[np.complex128]: ...
+@overload  # 2d T@inexact80, axis=<given> (default)
+def kurtosis[InexactT: npc.inexact80](
+    a: onp.ToArrayStrict2D[InexactT, InexactT], axis: SupportsIndex = 0, fisher: bool = True, bias: bool = True
+) -> onp.MArray1D[InexactT]: ...
+@overload  # 3d ~f64, axis=<given> (default)
+def kurtosis(
+    a: onp.ToFloat64Strict3D, axis: SupportsIndex = 0, fisher: bool = True, bias: bool = True
+) -> onp.MArray2D[np.float64]: ...
+@overload  # 3d ~c128, axis=<given> (default)
+def kurtosis(
+    a: onp.ToArrayStrict3D[op.JustComplex, np.complex128 | np.complex64],
+    axis: SupportsIndex = 0,
+    fisher: bool = True,
+    bias: bool = True,
+) -> onp.MArray2D[np.complex128]: ...
+@overload  # 3d T@inexact80, axis=<given> (default)
+def kurtosis[InexactT: npc.inexact80](
+    a: onp.ToArrayStrict3D[InexactT, InexactT], axis: SupportsIndex = 0, fisher: bool = True, bias: bool = True
+) -> onp.MArray2D[InexactT]: ...
+@overload  # Nd ~f64
+def kurtosis(
+    a: onp.ToFloat64_ND, axis: SupportsIndex | None = 0, fisher: bool = True, bias: bool = True
+) -> onp.MArray[np.float64] | Any: ...
+@overload  # Nd ~c128
+def kurtosis(
+    a: onp.ToArrayND[op.JustComplex, np.complex128 | np.complex64],
+    axis: SupportsIndex | None = 0,
+    fisher: bool = True,
+    bias: bool = True,
+) -> onp.MArray[np.complex128] | Any: ...
+@overload  # Nd T@inexact80
+def kurtosis[InexactT: npc.inexact80](
+    a: onp.ToArrayND[InexactT, InexactT], axis: SupportsIndex | None = 0, fisher: bool = True, bias: bool = True
+) -> onp.MArray[InexactT] | Any: ...
 
 #
 def describe(a: onp.ToFloatND, axis: SupportsIndex | None = 0, ddof: onp.ToInt = 0, bias: bool = True) -> DescribeResult: ...

--- a/scipy-stubs/stats/_mstats_basic.pyi
+++ b/scipy-stubs/stats/_mstats_basic.pyi
@@ -820,7 +820,72 @@ def moment[InexactT: npc.inexact80](
 
 # TODO(jorenham): Overloads for complex array-likes
 def variation(a: onp.ToFloatND, axis: SupportsIndex | None = 0, ddof: onp.ToInt = 0) -> _MArrayOrND[npc.floating]: ...
-def skew(a: onp.ToFloatND, axis: SupportsIndex | None = 0, bias: bool = True) -> _MArrayOrND[npc.floating]: ...
+
+# NOTE: f16/f32 and c64 promote to f64 and c128, and the result is always a `MaskedArray`
+@overload  # ?d ~f64, axis=None
+def skew(a: onp.ToFloat64_ND, axis: None, bias: bool = True) -> onp.MArray0D[np.float64]: ...
+@overload  # ?d ~c128, axis=None
+def skew(
+    a: onp.ToArrayND[op.JustComplex, np.complex128 | np.complex64], axis: None, bias: bool = True
+) -> onp.MArray0D[np.complex128]: ...
+@overload  # ?d T@inexact80, axis=None
+def skew[InexactT: npc.inexact80](
+    a: onp.ToArrayND[InexactT, InexactT], axis: None, bias: bool = True
+) -> onp.MArray0D[InexactT]: ...
+@overload  # ?d ~f64, axis=<given> (default)
+def skew(
+    a: onp.ArrayND[_AsF64 | np.float32 | np.float16, _JustAnyShape], axis: SupportsIndex = 0, bias: bool = True
+) -> onp.MArray[np.float64] | Any: ...
+@overload  # ?d ~c128, axis=<given> (default)
+def skew(
+    a: onp.ArrayND[np.complex128 | np.complex64, _JustAnyShape], axis: SupportsIndex = 0, bias: bool = True
+) -> onp.MArray[np.complex128] | Any: ...
+@overload  # ?d T@inexact80, axis=<given> (default)
+def skew[InexactT: npc.inexact80](
+    a: onp.ArrayND[InexactT, _JustAnyShape], axis: SupportsIndex = 0, bias: bool = True
+) -> onp.MArray[InexactT] | Any: ...
+@overload  # 1d ~f64, axis=<given> (default)
+def skew(a: onp.ToFloat64Strict1D, axis: SupportsIndex = 0, bias: bool = True) -> onp.MArray0D[np.float64]: ...
+@overload  # 1d ~c128, axis=<given> (default)
+def skew(
+    a: onp.ToArrayStrict1D[op.JustComplex, np.complex128 | np.complex64], axis: SupportsIndex = 0, bias: bool = True
+) -> onp.MArray0D[np.complex128]: ...
+@overload  # 1d T@inexact80, axis=<given> (default)
+def skew[InexactT: npc.inexact80](
+    a: onp.ToArrayStrict1D[InexactT, InexactT], axis: SupportsIndex = 0, bias: bool = True
+) -> onp.MArray0D[InexactT]: ...
+@overload  # 2d ~f64, axis=<given> (default)
+def skew(a: onp.ToFloat64Strict2D, axis: SupportsIndex = 0, bias: bool = True) -> onp.MArray1D[np.float64]: ...
+@overload  # 2d ~c128, axis=<given> (default)
+def skew(
+    a: onp.ToArrayStrict2D[op.JustComplex, np.complex128 | np.complex64], axis: SupportsIndex = 0, bias: bool = True
+) -> onp.MArray1D[np.complex128]: ...
+@overload  # 2d T@inexact80, axis=<given> (default)
+def skew[InexactT: npc.inexact80](
+    a: onp.ToArrayStrict2D[InexactT, InexactT], axis: SupportsIndex = 0, bias: bool = True
+) -> onp.MArray1D[InexactT]: ...
+@overload  # 3d ~f64, axis=<given> (default)
+def skew(a: onp.ToFloat64Strict3D, axis: SupportsIndex = 0, bias: bool = True) -> onp.MArray2D[np.float64]: ...
+@overload  # 3d ~c128, axis=<given> (default)
+def skew(
+    a: onp.ToArrayStrict3D[op.JustComplex, np.complex128 | np.complex64], axis: SupportsIndex = 0, bias: bool = True
+) -> onp.MArray2D[np.complex128]: ...
+@overload  # 3d T@inexact80, axis=<given> (default)
+def skew[InexactT: npc.inexact80](
+    a: onp.ToArrayStrict3D[InexactT, InexactT], axis: SupportsIndex = 0, bias: bool = True
+) -> onp.MArray2D[InexactT]: ...
+@overload  # Nd ~f64
+def skew(a: onp.ToFloat64_ND, axis: SupportsIndex | None = 0, bias: bool = True) -> onp.MArray[np.float64] | Any: ...
+@overload  # Nd ~c128
+def skew(
+    a: onp.ToArrayND[op.JustComplex, np.complex128 | np.complex64], axis: SupportsIndex | None = 0, bias: bool = True
+) -> onp.MArray[np.complex128] | Any: ...
+@overload  # Nd T@inexact80
+def skew[InexactT: npc.inexact80](
+    a: onp.ToArrayND[InexactT, InexactT], axis: SupportsIndex | None = 0, bias: bool = True
+) -> onp.MArray[InexactT] | Any: ...
+
+#
 def kurtosis(
     a: onp.ToFloatND, axis: SupportsIndex | None = 0, fisher: bool = True, bias: bool = True
 ) -> _MArrayOrND[npc.floating]: ...

--- a/scipy-stubs/stats/_mstats_basic.pyi
+++ b/scipy-stubs/stats/_mstats_basic.pyi
@@ -818,8 +818,65 @@ def moment[InexactT: npc.inexact80](
     a: onp.ToArrayND[InexactT, InexactT], moment: onp.ToInt | onp.ToIntND = 1, axis: SupportsIndex | None = 0
 ) -> onp.MArray[InexactT] | Any: ...
 
-# TODO(jorenham): Overloads for complex array-likes
-def variation(a: onp.ToFloatND, axis: SupportsIndex | None = 0, ddof: onp.ToInt = 0) -> _MArrayOrND[npc.floating]: ...
+# NOTE: f16/f32 and c64 promote only if `a` is masked
+@overload  # ?d ~f64, axis=None
+def variation(a: onp.ToArrayND[float, _AsF64], axis: None, ddof: onp.ToInt = 0) -> np.float64: ...
+@overload  # ?d ~c128, axis=None
+def variation(a: onp.ToJustComplex128_ND, axis: None, ddof: onp.ToInt = 0) -> np.complex128: ...
+@overload  # ?d T@inexact, axis=None
+def variation[InexactT: npc.inexact](a: onp.ToArrayND[InexactT, InexactT], axis: None, ddof: onp.ToInt = 0) -> InexactT: ...
+@overload  # ?d ~f64, axis=<given> (default)
+def variation(
+    a: onp.ArrayND[_AsF64, _JustAnyShape], axis: SupportsIndex = 0, ddof: onp.ToInt = 0
+) -> onp.MArray[np.float64] | Any: ...
+@overload  # ?d ~c128, axis=<given> (default)
+def variation(
+    a: onp.ArrayND[np.complex128, _JustAnyShape], axis: SupportsIndex = 0, ddof: onp.ToInt = 0
+) -> onp.MArray[np.complex128] | Any: ...
+@overload  # ?d T@inexact, axis=<given> (default)
+def variation[InexactT: npc.inexact](
+    a: onp.ArrayND[InexactT, _JustAnyShape], axis: SupportsIndex = 0, ddof: onp.ToInt = 0
+) -> onp.MArray[InexactT] | Any: ...
+@overload  # 1d ~f64, axis=<given> (default)
+def variation(a: onp.ToArrayStrict1D[float, _AsF64], axis: SupportsIndex = 0, ddof: onp.ToInt = 0) -> np.float64: ...
+@overload  # 1d ~c128, axis=<given> (default)
+def variation(a: onp.ToJustComplex128Strict1D, axis: SupportsIndex = 0, ddof: onp.ToInt = 0) -> np.complex128: ...
+@overload  # 1d T@inexact, axis=<given> (default)
+def variation[InexactT: npc.inexact](
+    a: onp.ToArrayStrict1D[InexactT, InexactT], axis: SupportsIndex = 0, ddof: onp.ToInt = 0
+) -> InexactT: ...
+@overload  # 2d ~f64, axis=<given> (default)
+def variation(
+    a: onp.ToArrayStrict2D[float, _AsF64], axis: SupportsIndex = 0, ddof: onp.ToInt = 0
+) -> onp.MArray1D[np.float64]: ...
+@overload  # 2d ~c128, axis=<given> (default)
+def variation(a: onp.ToJustComplex128Strict2D, axis: SupportsIndex = 0, ddof: onp.ToInt = 0) -> onp.MArray1D[np.complex128]: ...
+@overload  # 2d T@inexact, axis=<given> (default)
+def variation[InexactT: npc.inexact](
+    a: onp.ToArrayStrict2D[InexactT, InexactT], axis: SupportsIndex = 0, ddof: onp.ToInt = 0
+) -> onp.MArray1D[InexactT]: ...
+@overload  # 3d ~f64, axis=<given> (default)
+def variation(
+    a: onp.ToArrayStrict3D[float, _AsF64], axis: SupportsIndex = 0, ddof: onp.ToInt = 0
+) -> onp.MArray2D[np.float64]: ...
+@overload  # 3d ~c128, axis=<given> (default)
+def variation(a: onp.ToJustComplex128Strict3D, axis: SupportsIndex = 0, ddof: onp.ToInt = 0) -> onp.MArray2D[np.complex128]: ...
+@overload  # 3d T@inexact, axis=<given> (default)
+def variation[InexactT: npc.inexact](
+    a: onp.ToArrayStrict3D[InexactT, InexactT], axis: SupportsIndex = 0, ddof: onp.ToInt = 0
+) -> onp.MArray2D[InexactT]: ...
+@overload  # Nd ~f64
+def variation(
+    a: onp.ToArrayND[float, _AsF64], axis: SupportsIndex | None = 0, ddof: onp.ToInt = 0
+) -> onp.MArray[np.float64] | Any: ...
+@overload  # Nd ~c128
+def variation(
+    a: onp.ToJustComplex128_ND, axis: SupportsIndex | None = 0, ddof: onp.ToInt = 0
+) -> onp.MArray[np.complex128] | Any: ...
+@overload  # Nd T@inexact
+def variation[InexactT: npc.inexact](
+    a: onp.ToArrayND[InexactT, InexactT], axis: SupportsIndex | None = 0, ddof: onp.ToInt = 0
+) -> onp.MArray[InexactT] | Any: ...
 
 #
 @overload  # ?d ~f64, axis=None

--- a/tests/stats/test_mstats.pyi
+++ b/tests/stats/test_mstats.pyi
@@ -5,7 +5,7 @@ from typing import Any, assert_type
 import numpy as np
 import optype.numpy as onp
 
-from scipy.stats.mstats import moment, normaltest, spearmanr, tmax, tmean, tmin
+from scipy.stats.mstats import moment, normaltest, skew, spearmanr, tmax, tmean, tmin
 
 ###
 
@@ -169,3 +169,25 @@ assert_type(moment(_i64_nd, 2), onp.MArray[np.float64] | Any)
 
 assert_type(moment(_f64_2d, [2, 3]), onp.MArray[np.float64])
 assert_type(moment(_c64_1d, [2, 3], None), onp.MArray[np.complex128])
+
+###
+# skew
+
+assert_type(skew(_f64_2d, None), onp.MArray0D[np.float64])
+assert_type(skew(_c128_2d, axis=None), onp.MArray0D[np.complex128])
+assert_type(skew(_f80_2d, None), onp.MArray0D[np.float128])
+
+assert_type(skew(_py_i_1d), onp.MArray0D[np.float64])
+assert_type(skew(_f32_1d), onp.MArray0D[np.float64])
+assert_type(skew(_py_c_1d), onp.MArray0D[np.complex128])
+assert_type(skew(_f80_1d), onp.MArray0D[np.float128])
+
+assert_type(skew(_f16_2d), onp.MArray1D[np.float64])
+assert_type(skew(_c64_2d, 1), onp.MArray1D[np.complex128])
+assert_type(skew(_f80_2d), onp.MArray1D[np.float128])
+
+assert_type(skew(_f32_3d), onp.MArray2D[np.float64])
+assert_type(skew(_f80_3d), onp.MArray2D[np.float128])
+
+assert_type(skew(_m_f64_nd, 0, False), onp.MArray[np.float64] | Any)
+assert_type(skew(_c64_nd), onp.MArray[np.complex128] | Any)

--- a/tests/stats/test_mstats.pyi
+++ b/tests/stats/test_mstats.pyi
@@ -5,7 +5,7 @@ from typing import Any, assert_type
 import numpy as np
 import optype.numpy as onp
 
-from scipy.stats.mstats import moment, normaltest, skew, spearmanr, tmax, tmean, tmin
+from scipy.stats.mstats import kurtosis, moment, normaltest, skew, spearmanr, tmax, tmean, tmin
 
 ###
 
@@ -191,3 +191,29 @@ assert_type(skew(_f80_3d), onp.MArray2D[np.float128])
 
 assert_type(skew(_m_f64_nd, 0, False), onp.MArray[np.float64] | Any)
 assert_type(skew(_c64_nd), onp.MArray[np.complex128] | Any)
+
+###
+# kurtosis
+
+assert_type(kurtosis(_f64_2d, None), np.float64)
+assert_type(kurtosis(_c128_2d, axis=None), np.complex128)
+assert_type(kurtosis(_f80_2d, None), np.float128)
+
+assert_type(kurtosis(_py_i_1d), np.float64)
+assert_type(kurtosis(_f32_1d), np.float64)
+assert_type(kurtosis(_py_c_1d), np.complex128)
+assert_type(kurtosis(_f80_1d), np.float128)
+
+assert_type(kurtosis(_f16_2d), onp.MArray1D[np.float64])
+assert_type(kurtosis(_c64_2d, 1), onp.MArray1D[np.complex128])
+assert_type(kurtosis(_f80_2d), onp.MArray1D[np.float128])
+
+assert_type(kurtosis(_f32_3d), onp.MArray2D[np.float64])
+assert_type(kurtosis(_f80_3d), onp.MArray2D[np.float128])
+
+assert_type(kurtosis(_m_f64_nd, 0, True, False), onp.MArray[np.float64] | Any)
+assert_type(kurtosis(_c64_nd), onp.MArray[np.complex128] | Any)
+
+# fisher=False returns a 0d `MaskedArray` instead of a scalar
+assert_type(kurtosis(_f64_1d, 0, False), onp.MArray[np.float64] | Any)
+assert_type(kurtosis(_f64_2d, None, False), onp.MArray[np.float64] | Any)

--- a/tests/stats/test_mstats.pyi
+++ b/tests/stats/test_mstats.pyi
@@ -5,7 +5,7 @@ from typing import Any, assert_type
 import numpy as np
 import optype.numpy as onp
 
-from scipy.stats.mstats import kurtosis, moment, normaltest, skew, spearmanr, tmax, tmean, tmin
+from scipy.stats.mstats import kurtosis, moment, normaltest, skew, spearmanr, tmax, tmean, tmin, variation
 
 ###
 
@@ -49,8 +49,20 @@ _m_f32_nd: onp.MArray[np.float32]
 _m_f64_nd: onp.MArray[np.float64]
 
 ###
-# tmean
+# spearmanr
+assert_type(spearmanr(_py_i_1d, _py_i_1d).statistic, np.float64)
+assert_type(spearmanr(_f64_nd, _f64_nd).statistic, np.float64)
+assert_type(spearmanr(_f32_3d, _f32_3d, axis=None).statistic, np.float64)
+assert_type(spearmanr(_py_f_1d, _py_f_1d, axis=0).statistic, np.float64)
+assert_type(spearmanr(_i64_1d, _i64_1d, axis=1).statistic, np.float64)
+assert_type(spearmanr(_py_i_2d, _py_i_2d, axis=0).statistic, onp.Array2D[np.float64])
+assert_type(spearmanr(_f64_2d, _f64_2d, axis=1).statistic, onp.Array2D[np.float64])
+assert_type(spearmanr(_m_f64_nd, _m_f64_nd, axis=0).statistic, onp.Array2D[np.float64] | Any)
+assert_type(spearmanr(_f32_3d, _f32_3d, axis=0).statistic, onp.Array2D[np.float64] | Any)
+assert_type(spearmanr(_f64_2d, axis=1).statistic, onp.Array2D[np.float64] | Any)
 
+###
+# tmean
 assert_type(tmean(_py_i_1d), np.float64)
 assert_type(tmean(_py_f_1d), np.float64)
 assert_type(tmean(_py_c_1d), np.complex128)
@@ -108,46 +120,16 @@ assert_type(tmean(_f64_nd, (0.0, 1.0), (True, True), 0), onp.MArray[np.float64] 
 
 ###
 # tmin
-
 assert_type(tmin(_py_i_1d), np.int_ | onp.MArray[np.int_])
 assert_type(tmin(_f32_1d), np.float32 | onp.MArray[np.float32])
 
 ###
 # tmax
-
 assert_type(tmax(_py_i_1d), np.int_ | onp.MArray[np.int_])
 assert_type(tmax(_f32_1d), np.float32 | onp.MArray[np.float32])
 
 ###
-# spearmanr
-
-assert_type(spearmanr(_py_i_1d, _py_i_1d).statistic, np.float64)
-assert_type(spearmanr(_f64_nd, _f64_nd).statistic, np.float64)
-assert_type(spearmanr(_f32_3d, _f32_3d, axis=None).statistic, np.float64)
-assert_type(spearmanr(_py_f_1d, _py_f_1d, axis=0).statistic, np.float64)
-assert_type(spearmanr(_i64_1d, _i64_1d, axis=1).statistic, np.float64)
-assert_type(spearmanr(_py_i_2d, _py_i_2d, axis=0).statistic, onp.Array2D[np.float64])
-assert_type(spearmanr(_f64_2d, _f64_2d, axis=1).statistic, onp.Array2D[np.float64])
-assert_type(spearmanr(_m_f64_nd, _m_f64_nd, axis=0).statistic, onp.Array2D[np.float64] | Any)
-assert_type(spearmanr(_f32_3d, _f32_3d, axis=0).statistic, onp.Array2D[np.float64] | Any)
-assert_type(spearmanr(_f64_2d, axis=1).statistic, onp.Array2D[np.float64] | Any)
-
-###
-# normaltest
-
-assert_type(normaltest(_f64_nd, axis=None).statistic, np.float64)
-assert_type(normaltest(_py_i_1d).statistic, np.float64)
-assert_type(normaltest(_f64_1d).pvalue, np.float64)
-assert_type(normaltest(_i64_2d).statistic, onp.MArray1D[np.float64])
-assert_type(normaltest(_f32_2d, axis=1).pvalue, onp.Array1D[np.float64])
-assert_type(normaltest(_f32_3d).statistic, onp.MArray2D[np.float64])
-assert_type(normaltest(_f32_nd).statistic, onp.MArray[np.float64] | Any)
-assert_type(normaltest(_m_f64_nd, axis=0).statistic, onp.MArray[np.float64] | Any)
-assert_type(normaltest(_f64_nd, axis=0).pvalue, onp.ArrayND[np.float64] | Any)
-
-###
 # moment
-
 assert_type(moment(_f64_2d, 2, None), np.float64)
 assert_type(moment(_c128_2d, axis=None), np.complex128)
 assert_type(moment(_f80_2d, 2, axis=None), np.float128)
@@ -171,8 +153,32 @@ assert_type(moment(_f64_2d, [2, 3]), onp.MArray[np.float64])
 assert_type(moment(_c64_1d, [2, 3], None), onp.MArray[np.complex128])
 
 ###
-# skew
+# variation
+assert_type(variation(_f64_2d, None), np.float64)
+assert_type(variation(_c64_2d, axis=None), np.complex64)
+assert_type(variation(_f80_2d, None), np.float128)
 
+assert_type(variation(_py_i_1d), np.float64)
+assert_type(variation(_py_c_1d), np.complex128)
+assert_type(variation(_i64_1d), np.float64)
+assert_type(variation(_f16_1d), np.float16)
+assert_type(variation(_f32_1d), np.float32)
+assert_type(variation(_c128_1d), np.complex128)
+assert_type(variation(_f80_1d), np.float128)
+
+assert_type(variation(_py_f_2d), onp.MArray1D[np.float64])
+assert_type(variation(_f16_2d), onp.MArray1D[np.float16])
+assert_type(variation(_c64_2d, 1), onp.MArray1D[np.complex64])
+assert_type(variation(_f80_2d), onp.MArray1D[np.float128])
+
+assert_type(variation(_f32_3d), onp.MArray2D[np.float32])
+assert_type(variation(_f80_3d), onp.MArray2D[np.float128])
+
+assert_type(variation(_i64_nd, 0, 1), onp.MArray[np.float64] | Any)
+assert_type(variation(_m_f32_nd), onp.MArray[np.float32] | Any)
+
+###
+# skew
 assert_type(skew(_f64_2d, None), onp.MArray0D[np.float64])
 assert_type(skew(_c128_2d, axis=None), onp.MArray0D[np.complex128])
 assert_type(skew(_f80_2d, None), onp.MArray0D[np.float128])
@@ -194,7 +200,6 @@ assert_type(skew(_c64_nd), onp.MArray[np.complex128] | Any)
 
 ###
 # kurtosis
-
 assert_type(kurtosis(_f64_2d, None), np.float64)
 assert_type(kurtosis(_c128_2d, axis=None), np.complex128)
 assert_type(kurtosis(_f80_2d, None), np.float128)
@@ -217,3 +222,15 @@ assert_type(kurtosis(_c64_nd), onp.MArray[np.complex128] | Any)
 # fisher=False returns a 0d `MaskedArray` instead of a scalar
 assert_type(kurtosis(_f64_1d, 0, False), onp.MArray[np.float64] | Any)
 assert_type(kurtosis(_f64_2d, None, False), onp.MArray[np.float64] | Any)
+
+###
+# normaltest
+assert_type(normaltest(_f64_nd, axis=None).statistic, np.float64)
+assert_type(normaltest(_py_i_1d).statistic, np.float64)
+assert_type(normaltest(_f64_1d).pvalue, np.float64)
+assert_type(normaltest(_i64_2d).statistic, onp.MArray1D[np.float64])
+assert_type(normaltest(_f32_2d, axis=1).pvalue, onp.Array1D[np.float64])
+assert_type(normaltest(_f32_3d).statistic, onp.MArray2D[np.float64])
+assert_type(normaltest(_f32_nd).statistic, onp.MArray[np.float64] | Any)
+assert_type(normaltest(_m_f64_nd, axis=0).statistic, onp.MArray[np.float64] | Any)
+assert_type(normaltest(_f64_nd, axis=0).pvalue, onp.ArrayND[np.float64] | Any)


### PR DESCRIPTION
towards #1146