### PR TITLE
✨ `stats.mstats.trim`: improve shape-typing and return dtypes

### DIFF
--- a/scipy-stubs/stats/_mstats_basic.pyi
+++ b/scipy-stubs/stats/_mstats_basic.pyi
@@ -378,33 +378,81 @@ def trimr[ScalarT: npc.number | np.bool](
 ) -> onp.MArray[ScalarT]: ...
 
 #
-@overload
+@overload  # 1d bool
+def trim(  # type:ignore[overload-overlap]
+    a: list[bool],
+    limits: tuple[onp.ToFloat, onp.ToFloat] | None = None,
+    inclusive: tuple[bool, bool] = (True, True),
+    relative: bool = False,
+    axis: SupportsIndex | None = None,
+) -> onp.MArray1D[np.bool]: ...
+@overload  # ?d bool
+def trim(  # type:ignore[overload-overlap]
+    a: onp.SequenceND[list[bool]],
+    limits: tuple[onp.ToFloat, onp.ToFloat] | None = None,
+    inclusive: tuple[bool, bool] = (True, True),
+    relative: bool = False,
+    axis: SupportsIndex | None = None,
+) -> onp.MArray[np.bool]: ...
+@overload  # 1d ~int
 def trim(
-    a: onp.SequenceND[op.JustInt | np.int_],
+    a: list[int],
+    limits: tuple[onp.ToFloat, onp.ToFloat] | None = None,
+    inclusive: tuple[bool, bool] = (True, True),
+    relative: bool = False,
+    axis: SupportsIndex | None = None,
+) -> onp.MArray1D[np.int_]: ...
+@overload  # ?d ~int
+def trim(
+    a: onp.SequenceND[list[int]],
     limits: tuple[onp.ToFloat, onp.ToFloat] | None = None,
     inclusive: tuple[bool, bool] = (True, True),
     relative: bool = False,
     axis: SupportsIndex | None = None,
 ) -> onp.MArray[np.int_]: ...
-@overload
+@overload  # 1d ~float
 def trim(
-    a: onp.SequenceND[float],
+    a: list[float],
     limits: tuple[onp.ToFloat, onp.ToFloat] | None = None,
     inclusive: tuple[bool, bool] = (True, True),
     relative: bool = False,
     axis: SupportsIndex | None = None,
-) -> onp.MArray[np.float64 | np.int_]: ...
-@overload
+) -> onp.MArray1D[np.float64]: ...
+@overload  # ?d ~float
 def trim(
-    a: onp.SequenceND[complex],
+    a: onp.SequenceND[list[float]],
+    limits: tuple[onp.ToFloat, onp.ToFloat] | None = None,
+    inclusive: tuple[bool, bool] = (True, True),
+    relative: bool = False,
+    axis: SupportsIndex | None = None,
+) -> onp.MArray[np.float64]: ...
+@overload  # 1d ~complex
+def trim(
+    a: list[complex],
     limits: tuple[onp.ToComplex, onp.ToComplex] | None = None,
     inclusive: tuple[bool, bool] = (True, True),
     relative: bool = False,
     axis: SupportsIndex | None = None,
-) -> onp.MArray[np.complex128 | np.float64 | np.int_]: ...
-@overload
+) -> onp.MArray1D[np.complex128]: ...
+@overload  # ?d ~complex
+def trim(
+    a: onp.SequenceND[list[complex]],
+    limits: tuple[onp.ToComplex, onp.ToComplex] | None = None,
+    inclusive: tuple[bool, bool] = (True, True),
+    relative: bool = False,
+    axis: SupportsIndex | None = None,
+) -> onp.MArray[np.complex128]: ...
+@overload  # ?d T@+number
+def trim[ShapeT: tuple[int, ...], ScalarT: npc.number | np.bool](
+    a: onp.ArrayND[ScalarT, ShapeT],
+    limits: tuple[onp.ToComplex, onp.ToComplex] | None = None,
+    inclusive: tuple[bool, bool] = (True, True),
+    relative: bool = False,
+    axis: SupportsIndex | None = None,
+) -> onp.MArray[ScalarT, ShapeT]: ...
+@overload  # Nd T@+number
 def trim[ScalarT: npc.number | np.bool](
-    a: _ArrayLike[ScalarT],
+    a: onp.ToArrayND[ScalarT, ScalarT],
     limits: tuple[onp.ToComplex, onp.ToComplex] | None = None,
     inclusive: tuple[bool, bool] = (True, True),
     relative: bool = False,

--- a/scipy-stubs/stats/_mstats_basic.pyi
+++ b/scipy-stubs/stats/_mstats_basic.pyi
@@ -96,6 +96,9 @@ type _AsF64 = np.float64 | npc.integer | np.bool
 type _JustAnyShape = tuple[Never, Never, Never, Never]  # workaround for https://github.com/microsoft/pyright/issues/10232
 type _ToFloatStrictND = onp.ArrayND[npc.floating | npc.integer | np.bool, _JustAnyShape]
 
+# workaround for a strange bug in pyright's overlapping overload detection with `numpy<2.1`
+type _WorkaroundForPyright = tuple[int] | tuple[Any, ...]
+
 type _KendallTauMethod = Literal["auto", "asymptotic", "exact"]
 type _TheilSlopesMethod = Literal["joint", "separate"]
 type _SiegelSlopesMethod = Literal["hierarchical", "separate"]
@@ -457,7 +460,7 @@ def trim[ScalarT: npc.number | np.bool](
     inclusive: tuple[bool, bool] = (True, True),
     relative: bool = False,
     axis: SupportsIndex | None = None,
-) -> onp.MArray[ScalarT]: ...
+) -> onp.MArray[ScalarT, _WorkaroundForPyright]: ...
 
 #
 @overload

--- a/tests/stats/test_mstats.pyi
+++ b/tests/stats/test_mstats.pyi
@@ -5,10 +5,12 @@ from typing import Any, assert_type
 import numpy as np
 import optype.numpy as onp
 
-from scipy.stats.mstats import kurtosis, moment, normaltest, skew, spearmanr, tmax, tmean, tmin, variation
+from scipy.stats.mstats import kurtosis, moment, normaltest, skew, spearmanr, tmax, tmean, tmin, trim, variation
 
 ###
 
+_py_b_1d: list[bool]
+_py_b_2d: list[list[bool]]
 _py_i_1d: list[int]
 _py_i_2d: list[list[int]]
 _py_f_1d: list[float]
@@ -60,6 +62,26 @@ assert_type(spearmanr(_f64_2d, _f64_2d, axis=1).statistic, onp.Array2D[np.float6
 assert_type(spearmanr(_m_f64_nd, _m_f64_nd, axis=0).statistic, onp.Array2D[np.float64] | Any)
 assert_type(spearmanr(_f32_3d, _f32_3d, axis=0).statistic, onp.Array2D[np.float64] | Any)
 assert_type(spearmanr(_f64_2d, axis=1).statistic, onp.Array2D[np.float64] | Any)
+
+###
+# trim
+assert_type(trim(_py_b_1d), onp.MArray1D[np.bool])
+assert_type(trim(_py_b_2d), onp.MArray[np.bool])
+assert_type(trim(_py_i_1d), onp.MArray1D[np.int_])
+assert_type(trim(_py_i_2d), onp.MArray[np.int_])
+assert_type(trim(_py_f_1d), onp.MArray1D[np.float64])
+assert_type(trim(_py_f_2d), onp.MArray[np.float64])
+assert_type(trim(_py_c_1d), onp.MArray1D[np.complex128])
+assert_type(trim(_py_c_2d), onp.MArray[np.complex128])
+
+assert_type(trim(_i64_1d), onp.MArray1D[np.int64])
+assert_type(trim(_f16_2d), onp.MArray2D[np.float16])
+assert_type(trim(_f32_3d), onp.MArray3D[np.float32])
+assert_type(trim(_f80_2d), onp.MArray2D[np.float128])
+assert_type(trim(_c64_nd), onp.MArray[np.complex64])
+assert_type(trim(_m_f32_nd), onp.MArray[np.float32])
+
+assert_type(trim(_f64_2d, (0.1, 0.1), (True, True), True, 0), onp.MArray2D[np.float64])
 
 ###
 # tmean


### PR DESCRIPTION
towards #1146