### PR TITLE
🐛 `stats.mstats.{kendalltau,pointbiserialr}`: fix result value types

### DIFF
--- a/scipy-stubs/stats/_mstats_basic.pyi
+++ b/scipy-stubs/stats/_mstats_basic.pyi
@@ -174,7 +174,7 @@ class DescribeResult(NamedTuple, Generic[_ShapeT_co, _MinMaxT_co, _MeanT_co, _Va
 
 class PointbiserialrResult(NamedTuple):
     correlation: np.float64
-    pvalue: np.float64
+    pvalue: onp.MArray0D[np.float64]
 
 class Ttest_relResult(_TestResult[_NDT_f_co, _NDT_fc_co], Generic[_NDT_f_co, _NDT_fc_co]): ...
 class Ttest_indResult(_TestResult[_NDT_f_co, _NDT_fc_co], Generic[_NDT_f_co, _NDT_fc_co]): ...
@@ -281,6 +281,8 @@ def kendalltau(
     alternative: Alternative = "two-sided",
 ) -> SignificanceResult: ...
 def kendalltau_seasonal(x: onp.ToFloatND) -> _KendallTauSeasonalResult: ...
+
+#
 def pointbiserialr(x: onp.ToFloatND, y: onp.ToFloatND) -> PointbiserialrResult: ...
 
 # NOTE: flattens input

--- a/scipy-stubs/stats/_mstats_basic.pyi
+++ b/scipy-stubs/stats/_mstats_basic.pyi
@@ -271,7 +271,7 @@ def spearmanr(
     alternative: Alternative = "two-sided",
 ) -> SignificanceResult[onp.Array2D[np.float64] | Any]: ...
 
-#
+# NOTE: flattens input
 def kendalltau(
     x: onp.ToFloatND,
     y: onp.ToFloatND,
@@ -279,7 +279,7 @@ def kendalltau(
     use_missing: bool = False,
     method: _KendallTauMethod = "auto",
     alternative: Alternative = "two-sided",
-) -> SignificanceResult: ...
+) -> SignificanceResult[np.float64]: ...
 
 #
 def kendalltau_seasonal(x: onp.ToFloatND) -> _KendallTauSeasonalResult: ...

--- a/scipy-stubs/stats/_mstats_basic.pyi
+++ b/scipy-stubs/stats/_mstats_basic.pyi
@@ -145,14 +145,14 @@ class _TestResult(NamedTuple, Generic[_NDT_f_co, _NDT_fc_co]):
 _KendallTauSeasonalResult = TypedDict(
     "_KendallTauSeasonalResult",
     {
-        "seasonal tau": _MArrayOrND[np.float64],
+        "seasonal tau": onp.MArray1D[np.float64],
         "global tau": np.float64,
         "global tau (alt)": np.float64,
-        "seasonal p-value": onp.ArrayND[np.float64],
+        "seasonal p-value": onp.Array1D[np.float64],
         "global p-value (indep)": np.float64,
         "global p-value (dep)": np.float64,
-        "chi2 total": onp.MArray[np.float64],
-        "chi2 trend": onp.MArray[np.float64],
+        "chi2 total": np.float64,
+        "chi2 trend": np.float64,
     },
 )
 
@@ -280,6 +280,8 @@ def kendalltau(
     method: _KendallTauMethod = "auto",
     alternative: Alternative = "two-sided",
 ) -> SignificanceResult: ...
+
+#
 def kendalltau_seasonal(x: onp.ToFloatND) -> _KendallTauSeasonalResult: ...
 
 #

--- a/tests/stats/test_mstats.pyi
+++ b/tests/stats/test_mstats.pyi
@@ -7,6 +7,7 @@ import optype.numpy as onp
 
 from scipy.stats.mstats import (
     describe,
+    kendalltau_seasonal,
     kurtosis,
     linregress,
     moment,
@@ -106,7 +107,9 @@ assert_type(spearmanr(_f64_2d, axis=1).statistic, onp.Array2D[np.float64] | Any)
 # TODO
 
 # kendalltau_seasonal
-# TODO
+assert_type(kendalltau_seasonal(_f32_2d)["seasonal tau"], onp.MArray1D[np.float64])
+assert_type(kendalltau_seasonal(_py_i_2d)["seasonal p-value"], onp.Array1D[np.float64])
+assert_type(kendalltau_seasonal(_m_f64_nd)["chi2 total"], np.float64)
 
 # pointbiserialr
 assert_type(pointbiserialr(_py_b_1d, _py_i_1d).correlation, np.float64)

--- a/tests/stats/test_mstats.pyi
+++ b/tests/stats/test_mstats.pyi
@@ -7,6 +7,7 @@ import optype.numpy as onp
 
 from scipy.stats.mstats import (
     describe,
+    kendalltau,
     kendalltau_seasonal,
     kurtosis,
     linregress,
@@ -104,7 +105,8 @@ assert_type(spearmanr(_f32_3d, _f32_3d, axis=0).statistic, onp.Array2D[np.float6
 assert_type(spearmanr(_f64_2d, axis=1).statistic, onp.Array2D[np.float64] | Any)
 
 # kentalltau
-# TODO
+assert_type(kendalltau(_py_i_1d, _f16_1d).statistic, np.float64)
+assert_type(kendalltau(_f64_2d, _f32_2d, method="exact").pvalue, np.float64)
 
 # kendalltau_seasonal
 assert_type(kendalltau_seasonal(_f32_2d)["seasonal tau"], onp.MArray1D[np.float64])

--- a/tests/stats/test_mstats.pyi
+++ b/tests/stats/test_mstats.pyi
@@ -11,6 +11,7 @@ from scipy.stats.mstats import (
     linregress,
     moment,
     normaltest,
+    pointbiserialr,
     sen_seasonal_slopes,
     siegelslopes,
     skew,
@@ -108,7 +109,8 @@ assert_type(spearmanr(_f64_2d, axis=1).statistic, onp.Array2D[np.float64] | Any)
 # TODO
 
 # pointbiserialr
-# TODO
+assert_type(pointbiserialr(_py_b_1d, _py_i_1d).correlation, np.float64)
+assert_type(pointbiserialr(_i8_2d, _f16_2d).pvalue, onp.MArray0D[np.float64])
 
 # linregress
 assert_type(linregress(_py_i_1d, _f16_1d).slope, np.float64)


### PR DESCRIPTION
This fixes some of the return types of the dict returned by `kendalltau_seasonal`, and the attribute types of the result classes returned by `kendalltau` and `pointbiserialr`.

towards #1777