### PR TITLE
🐛 `stats.mstats.pearsonr`: fix return type

### DIFF
--- a/scipy-stubs/stats/_mstats_basic.pyi
+++ b/scipy-stubs/stats/_mstats_basic.pyi
@@ -25,7 +25,7 @@ import optype.numpy.compat as npc
 from numpy._typing import _ArrayLike
 
 from ._stats_mstats_common import SiegelslopesResult, TheilslopesResult
-from ._stats_py import KstestResult, LinregressResult, SignificanceResult
+from ._stats_py import KstestResult, LinregressResult, PearsonRResult, SignificanceResult
 from ._typing import Alternative, BaseBunch, NanPolicy
 
 __all__ = [
@@ -217,8 +217,17 @@ def msign[ScalarT: npc.number | np.timedelta64 | np.bool | np.object_](x: _Array
 @overload
 def msign(x: onp.ToComplexND) -> onp.ArrayND[npc.number | np.timedelta64 | np.bool | np.object_]: ...
 
-#
-def pearsonr(x: onp.ToFloatND, y: onp.ToFloatND) -> tuple[np.float64, np.float64]: ...
+# NOTE: flattens input
+@overload  # ~f64 | +integer, +floating
+def pearsonr(x: onp.ToJustFloat64_ND | onp.ToIntND, y: onp.ToFloatND) -> PearsonRResult[np.float64, np.float64]: ...
+@overload  # +floating, ~f64 | +integer
+def pearsonr(x: onp.ToFloatND, y: onp.ToJustFloat64_ND | onp.ToIntND) -> PearsonRResult[np.float64, np.float64]: ...
+@overload  # ~f32, +float32
+def pearsonr(x: onp.ToJustFloat32_ND, y: onp.ToFloat32_ND) -> PearsonRResult[np.float32, np.float64]: ...
+@overload  # +float32, ~f32
+def pearsonr(x: onp.ToFloat32_ND, y: onp.ToJustFloat32_ND) -> PearsonRResult[np.float32, np.float64]: ...
+@overload  # +floating, +floating
+def pearsonr(x: onp.ToFloatND, y: onp.ToFloatND) -> PearsonRResult[npc.floating, np.float64]: ...
 
 #
 # NOTE: `y` is required with `axis=None` (default)

--- a/tests/stats/test_mstats.pyi
+++ b/tests/stats/test_mstats.pyi
@@ -4,6 +4,7 @@ from typing import Any, assert_type
 
 import numpy as np
 import optype.numpy as onp
+import optype.numpy.compat as npc
 
 from scipy.stats.mstats import (
     describe,
@@ -13,6 +14,7 @@ from scipy.stats.mstats import (
     linregress,
     moment,
     normaltest,
+    pearsonr,
     pointbiserialr,
     sen_seasonal_slopes,
     siegelslopes,
@@ -89,8 +91,31 @@ _m_f64_nd: onp.MArray[np.float64]
 
 ###
 
-# pearsonr
+# argstoarray
 # TODO
+
+# find_repeats
+# TODO
+
+# count_tied_groups
+# TODO
+
+# rankdata
+# TODO
+
+# mode
+# TODO
+
+# msign
+# TODO
+
+# pearsonr
+assert_type(pearsonr(_py_i_1d, _f16_1d).statistic, np.float64)
+assert_type(pearsonr(_f16_2d, _f64_2d).statistic, np.float64)
+assert_type(pearsonr(_f32_2d, _f16_2d).statistic, np.float32)
+assert_type(pearsonr(_f16_1d, _f32_1d).statistic, np.float32)
+assert_type(pearsonr(_f16_2d, _f16_2d).statistic, npc.floating)
+assert_type(pearsonr(_i64_1d, _f64_1d).pvalue, np.float64)
 
 # spearmanr
 assert_type(spearmanr(_py_i_1d, _py_i_1d).statistic, np.float64)


### PR DESCRIPTION
it returns a full-fledged `PearsonRResult`, not a bare tuple.