### PR TITLE
🐛 `stats.mstats.{skew,kurtosis}test`: fix return type

### DIFF
--- a/scipy-stubs/stats/_mstats_basic.pyi
+++ b/scipy-stubs/stats/_mstats_basic.pyi
@@ -1458,14 +1458,56 @@ def stde_median(data: onp.ToFloatND, axis: SupportsIndex | None = None) -> _MArr
 def stde_median(data: onp.ToComplexND, axis: SupportsIndex | None = None) -> _MArrayOrND[npc.inexact]: ...
 
 #
-@overload
+@overload  # ?d, axis=None
+def skewtest(a: onp.ToFloatND, axis: None, alternative: Alternative = "two-sided") -> SkewtestResult[np.float64, np.float64]: ...
+@overload  # ?d ~c128, axis=None
 def skewtest(
-    a: onp.ToFloatND, axis: SupportsIndex | None = 0, alternative: Alternative = "two-sided"
-) -> SkewtestResult[_MArrayOrND[np.float64], _MArrayOrND[np.float64]]: ...
-@overload
+    a: onp.ToArrayND[op.JustComplex, np.complex128 | np.complex64], axis: None, alternative: Alternative = "two-sided"
+) -> SkewtestResult[np.float64, np.complex128]: ...
+@overload  # ?d, axis=<given> (default)
+def skewtest(
+    a: _ToFloatStrictND, axis: SupportsIndex = 0, alternative: Alternative = "two-sided"
+) -> SkewtestResult[onp.ArrayND[np.float64] | Any, onp.MArray[np.float64] | Any]: ...
+@overload  # ?d ~c128, axis=<given> (default)
+def skewtest(
+    a: onp.ArrayND[np.complex128 | np.complex64, _JustAnyShape],
+    axis: SupportsIndex = 0,
+    alternative: Alternative = "two-sided",
+) -> SkewtestResult[onp.ArrayND[np.float64] | Any, onp.MArray[np.complex128] | Any]: ...
+@overload  # 1d, axis=<given> (default)
+def skewtest(
+    a: onp.ToFloatStrict1D, axis: SupportsIndex = 0, alternative: Alternative = "two-sided"
+) -> SkewtestResult[np.float64, np.float64]: ...
+@overload  # 1d ~c128, axis=<given> (default)
+def skewtest(
+    a: onp.ToArrayStrict1D[op.JustComplex, np.complex128 | np.complex64],
+    axis: SupportsIndex = 0,
+    alternative: Alternative = "two-sided",
+) -> SkewtestResult[np.float64, np.complex128]: ...
+@overload  # 2d, axis=<given> (default)
+def skewtest(
+    a: onp.ToFloatStrict2D, axis: SupportsIndex = 0, alternative: Alternative = "two-sided"
+) -> SkewtestResult[onp.Array1D[np.float64], onp.MArray1D[np.float64]]: ...
+@overload  # 2d ~c128, axis=<given> (default)
+def skewtest(
+    a: onp.ToArrayStrict2D[op.JustComplex, np.complex128 | np.complex64],
+    axis: SupportsIndex = 0,
+    alternative: Alternative = "two-sided",
+) -> SkewtestResult[onp.Array1D[np.float64], onp.MArray1D[np.complex128]]: ...
+@overload  # 3d, axis=<given> (default)
+def skewtest(
+    a: onp.ToFloatStrict3D, axis: SupportsIndex = 0, alternative: Alternative = "two-sided"
+) -> SkewtestResult[onp.Array2D[np.float64], onp.MArray2D[np.float64]]: ...
+@overload  # 3d ~c128, axis=<given> (default)
+def skewtest(
+    a: onp.ToArrayStrict3D[op.JustComplex, np.complex128 | np.complex64],
+    axis: SupportsIndex = 0,
+    alternative: Alternative = "two-sided",
+) -> SkewtestResult[onp.Array2D[np.float64], onp.MArray2D[np.complex128]]: ...
+@overload  # fallback
 def skewtest(
     a: onp.ToComplexND, axis: SupportsIndex | None = 0, alternative: Alternative = "two-sided"
-) -> SkewtestResult[_MArrayOrND[np.float64], _MArrayOrND[np.float64 | np.complex128]]: ...
+) -> SkewtestResult[onp.ArrayND[np.float64] | Any, onp.MArray[np.float64] | Any]: ...
 
 #
 @overload

--- a/scipy-stubs/stats/_mstats_basic.pyi
+++ b/scipy-stubs/stats/_mstats_basic.pyi
@@ -1470,9 +1470,7 @@ def skewtest(
 ) -> SkewtestResult[onp.ArrayND[np.float64] | Any, onp.MArray[np.float64] | Any]: ...
 @overload  # ?d ~c128, axis=<given> (default)
 def skewtest(
-    a: onp.ArrayND[np.complex128 | np.complex64, _JustAnyShape],
-    axis: SupportsIndex = 0,
-    alternative: Alternative = "two-sided",
+    a: onp.ArrayND[np.complex128 | np.complex64, _JustAnyShape], axis: SupportsIndex = 0, alternative: Alternative = "two-sided"
 ) -> SkewtestResult[onp.ArrayND[np.float64] | Any, onp.MArray[np.complex128] | Any]: ...
 @overload  # 1d, axis=<given> (default)
 def skewtest(
@@ -1510,14 +1508,56 @@ def skewtest(
 ) -> SkewtestResult[onp.ArrayND[np.float64] | Any, onp.MArray[np.float64] | Any]: ...
 
 #
-@overload
+@overload  # ?d, axis=None
 def kurtosistest(
-    a: onp.ToFloatND, axis: SupportsIndex | None = 0, alternative: Alternative = "two-sided"
-) -> KurtosistestResult[_MArrayOrND[np.float64], _MArrayOrND[np.float64]]: ...
-@overload
+    a: onp.ToFloatND, axis: None, alternative: Alternative = "two-sided"
+) -> KurtosistestResult[np.float64, np.float64]: ...
+@overload  # ?d ~c128, axis=None
+def kurtosistest(
+    a: onp.ToArrayND[op.JustComplex, np.complex128 | np.complex64], axis: None, alternative: Alternative = "two-sided"
+) -> KurtosistestResult[np.float64, np.complex128]: ...
+@overload  # ?d, axis=<given> (default)
+def kurtosistest(
+    a: _ToFloatStrictND, axis: SupportsIndex = 0, alternative: Alternative = "two-sided"
+) -> KurtosistestResult[onp.ArrayND[np.float64] | Any, onp.MArray[np.float64] | Any]: ...
+@overload  # ?d ~c128, axis=<given> (default)
+def kurtosistest(
+    a: onp.ArrayND[np.complex128 | np.complex64, _JustAnyShape], axis: SupportsIndex = 0, alternative: Alternative = "two-sided"
+) -> KurtosistestResult[onp.ArrayND[np.float64] | Any, onp.MArray[np.complex128] | Any]: ...
+@overload  # 1d, axis=<given> (default)
+def kurtosistest(
+    a: onp.ToFloatStrict1D, axis: SupportsIndex = 0, alternative: Alternative = "two-sided"
+) -> KurtosistestResult[np.float64, np.float64]: ...
+@overload  # 1d ~c128, axis=<given> (default)
+def kurtosistest(
+    a: onp.ToArrayStrict1D[op.JustComplex, np.complex128 | np.complex64],
+    axis: SupportsIndex = 0,
+    alternative: Alternative = "two-sided",
+) -> KurtosistestResult[np.float64, np.complex128]: ...
+@overload  # 2d, axis=<given> (default)
+def kurtosistest(
+    a: onp.ToFloatStrict2D, axis: SupportsIndex = 0, alternative: Alternative = "two-sided"
+) -> KurtosistestResult[onp.Array1D[np.float64], onp.MArray1D[np.float64]]: ...
+@overload  # 2d ~c128, axis=<given> (default)
+def kurtosistest(
+    a: onp.ToArrayStrict2D[op.JustComplex, np.complex128 | np.complex64],
+    axis: SupportsIndex = 0,
+    alternative: Alternative = "two-sided",
+) -> KurtosistestResult[onp.Array1D[np.float64], onp.MArray1D[np.complex128]]: ...
+@overload  # 3d, axis=<given> (default)
+def kurtosistest(
+    a: onp.ToFloatStrict3D, axis: SupportsIndex = 0, alternative: Alternative = "two-sided"
+) -> KurtosistestResult[onp.Array2D[np.float64], onp.MArray2D[np.float64]]: ...
+@overload  # 3d ~c128, axis=<given> (default)
+def kurtosistest(
+    a: onp.ToArrayStrict3D[op.JustComplex, np.complex128 | np.complex64],
+    axis: SupportsIndex = 0,
+    alternative: Alternative = "two-sided",
+) -> KurtosistestResult[onp.Array2D[np.float64], onp.MArray2D[np.complex128]]: ...
+@overload  # fallback
 def kurtosistest(
     a: onp.ToComplexND, axis: SupportsIndex | None = 0, alternative: Alternative = "two-sided"
-) -> KurtosistestResult[_MArrayOrND[np.float64], _MArrayOrND[np.float64 | np.complex128]]: ...
+) -> KurtosistestResult[onp.ArrayND[np.float64] | Any, onp.MArray[np.float64] | Any]: ...
 
 #
 @overload  # ?d, axis=None

--- a/tests/stats/test_mstats.pyi
+++ b/tests/stats/test_mstats.pyi
@@ -21,6 +21,7 @@ from scipy.stats.mstats import (
     sen_seasonal_slopes,
     siegelslopes,
     skew,
+    skewtest,
     spearmanr,
     theilslopes,
     tmax,
@@ -482,7 +483,16 @@ assert_type(describe(_b_nd).kurtosis, onp.MArray[np.float64] | Any)
 # TODO
 
 # skewtest
-# TODO
+assert_type(skewtest(_f32_3d, axis=None).statistic, np.float64)
+assert_type(skewtest(_py_c_2d, axis=None).statistic, np.complex128)
+assert_type(skewtest(_py_i_1d).statistic, np.float64)
+assert_type(skewtest(_f16_2d).statistic, onp.MArray1D[np.float64])
+assert_type(skewtest(_m_f64_nd).statistic, onp.MArray[np.float64] | Any)
+assert_type(skewtest(_c64_1d).statistic, np.complex128)
+assert_type(skewtest(_c128_2d).statistic, onp.MArray1D[np.complex128])
+assert_type(skewtest(_i8_3d).pvalue, onp.Array2D[np.float64])
+assert_type(skewtest(_c128_2d).pvalue, onp.Array1D[np.float64])
+assert_type(skewtest(_c64_3d).statistic, onp.MArray2D[np.complex128])
 
 # kurtosistest
 # TODO

--- a/tests/stats/test_mstats.pyi
+++ b/tests/stats/test_mstats.pyi
@@ -11,6 +11,7 @@ from scipy.stats.mstats import (
     kendalltau,
     kendalltau_seasonal,
     kurtosis,
+    kurtosistest,
     linregress,
     mode,
     moment,
@@ -495,7 +496,16 @@ assert_type(skewtest(_c128_2d).pvalue, onp.Array1D[np.float64])
 assert_type(skewtest(_c64_3d).statistic, onp.MArray2D[np.complex128])
 
 # kurtosistest
-# TODO
+assert_type(kurtosistest(_f32_3d, axis=None).statistic, np.float64)
+assert_type(kurtosistest(_py_i_1d).statistic, np.float64)
+assert_type(kurtosistest(_f16_2d).statistic, onp.MArray1D[np.float64])
+assert_type(kurtosistest(_i8_3d).pvalue, onp.Array2D[np.float64])
+assert_type(kurtosistest(_m_f64_nd).statistic, onp.MArray[np.float64] | Any)
+assert_type(kurtosistest(_py_c_2d, axis=None).statistic, np.complex128)
+assert_type(kurtosistest(_c64_1d).statistic, np.complex128)
+assert_type(kurtosistest(_c128_2d).statistic, onp.MArray1D[np.complex128])
+assert_type(kurtosistest(_c128_2d).pvalue, onp.Array1D[np.float64])
+assert_type(kurtosistest(_c64_3d).statistic, onp.MArray2D[np.complex128])
 
 # normaltest
 assert_type(normaltest(_f64_nd, axis=None).statistic, np.float64)


### PR DESCRIPTION
towards #1777