### PR TITLE
🐛 `stats.mstats.ttest_*`: fix return type

### DIFF
--- a/scipy-stubs/stats/_mstats_basic.pyi
+++ b/scipy-stubs/stats/_mstats_basic.pyi
@@ -341,9 +341,70 @@ def sen_seasonal_slopes(x: onp.ToJustComplex128_ND | onp.ToJustComplex64_ND) -> 
 def sen_seasonal_slopes[ScalarT: npc.inexact80](x: onp.ToArrayND[ScalarT, ScalarT]) -> SenSeasonalSlopesResult[ScalarT]: ...
 
 #
+@overload  # ?d, axis=None
 def ttest_1samp(
-    a: onp.ToFloatND, popmean: onp.ToFloat | onp.ToFloatND, axis: SupportsIndex | None = 0, alternative: Alternative = "two-sided"
-) -> Ttest_1sampResult: ...
+    a: onp.ToFloatND, popmean: onp.ToFloat | onp.ToFloatND, axis: None, alternative: Alternative = "two-sided"
+) -> Ttest_1sampResult[np.float64, np.float64]: ...
+@overload  # ?d ~c128, axis=None
+def ttest_1samp(
+    a: onp.ToArrayND[op.JustComplex, np.complex128 | np.complex64],
+    popmean: onp.ToComplex | onp.ToComplexND,
+    axis: None,
+    alternative: Alternative = "two-sided",
+) -> Ttest_1sampResult[np.float64, np.complex128]: ...
+@overload  # ?d, axis=<given> (default)
+def ttest_1samp(
+    a: _ToFloatStrictND, popmean: onp.ToFloat | onp.ToFloatND, axis: SupportsIndex = 0, alternative: Alternative = "two-sided"
+) -> Ttest_1sampResult[onp.MArray[np.float64] | Any, onp.MArray[np.float64] | Any]: ...
+@overload  # ?d ~c128, axis=<given> (default)
+def ttest_1samp(
+    a: onp.ArrayND[np.complex128 | np.complex64, _JustAnyShape],
+    popmean: onp.ToComplex | onp.ToComplexND,
+    axis: SupportsIndex = 0,
+    alternative: Alternative = "two-sided",
+) -> Ttest_1sampResult[onp.MArray[np.float64] | Any, onp.MArray[np.complex128] | Any]: ...
+@overload  # 1d, axis=<given> (default)
+def ttest_1samp(
+    a: onp.ToFloatStrict1D, popmean: onp.ToFloat | onp.ToFloatND, axis: SupportsIndex = 0, alternative: Alternative = "two-sided"
+) -> Ttest_1sampResult[np.float64, np.float64]: ...
+@overload  # 1d ~c128, axis=<given> (default)
+def ttest_1samp(
+    a: onp.ToArrayStrict1D[op.JustComplex, np.complex128 | np.complex64],
+    popmean: onp.ToComplex | onp.ToComplexND,
+    axis: SupportsIndex = 0,
+    alternative: Alternative = "two-sided",
+) -> Ttest_1sampResult[np.float64, np.complex128]: ...
+@overload  # 2d, axis=<given> (default)
+def ttest_1samp(
+    a: onp.ToFloatStrict2D, popmean: onp.ToFloat | onp.ToFloatND, axis: SupportsIndex = 0, alternative: Alternative = "two-sided"
+) -> Ttest_1sampResult[onp.MArray1D[np.float64], onp.MArray1D[np.float64]]: ...
+@overload  # 2d ~c128, axis=<given> (default)
+def ttest_1samp(
+    a: onp.ToArrayStrict2D[op.JustComplex, np.complex128 | np.complex64],
+    popmean: onp.ToComplex | onp.ToComplexND,
+    axis: SupportsIndex = 0,
+    alternative: Alternative = "two-sided",
+) -> Ttest_1sampResult[onp.MArray1D[np.float64], onp.MArray1D[np.complex128]]: ...
+@overload  # 3d, axis=<given> (default)
+def ttest_1samp(
+    a: onp.ToFloatStrict3D, popmean: onp.ToFloat | onp.ToFloatND, axis: SupportsIndex = 0, alternative: Alternative = "two-sided"
+) -> Ttest_1sampResult[onp.MArray2D[np.float64], onp.MArray2D[np.float64]]: ...
+@overload  # 3d ~c128, axis=<given> (default)
+def ttest_1samp(
+    a: onp.ToArrayStrict3D[op.JustComplex, np.complex128 | np.complex64],
+    popmean: onp.ToComplex | onp.ToComplexND,
+    axis: SupportsIndex = 0,
+    alternative: Alternative = "two-sided",
+) -> Ttest_1sampResult[onp.MArray2D[np.float64], onp.MArray2D[np.complex128]]: ...
+@overload  # fallback
+def ttest_1samp(
+    a: onp.ToComplexND,
+    popmean: onp.ToComplex | onp.ToComplexND,
+    axis: SupportsIndex | None = 0,
+    alternative: Alternative = "two-sided",
+) -> Ttest_1sampResult[onp.MArray[np.float64] | Any, onp.MArray[np.float64] | Any]: ...
+
+#
 def ttest_ind(
     a: onp.ToFloatND,
     b: onp.ToFloatND,
@@ -351,10 +412,16 @@ def ttest_ind(
     equal_var: bool = True,
     alternative: Alternative = "two-sided",
 ) -> Ttest_indResult: ...
+
+#
 def ttest_rel(
     a: onp.ToFloatND, b: onp.ToFloatND, axis: SupportsIndex | None = 0, alternative: Alternative = "two-sided"
 ) -> Ttest_relResult: ...
+
+#
 def mannwhitneyu(x: onp.ToFloatND, y: onp.ToFloatND, use_continuity: bool = True) -> MannwhitneyuResult: ...
+
+#
 def kruskal(arg0: onp.ToFloatND, arg1: onp.ToFloatND, /, *args: onp.ToFloatND) -> KruskalResult: ...
 
 #

--- a/scipy-stubs/stats/_mstats_basic.pyi
+++ b/scipy-stubs/stats/_mstats_basic.pyi
@@ -98,6 +98,7 @@ type _ToJustF64 = np.float64 | np.float32 | np.float16
 
 type _JustAnyShape = tuple[Never, Never, Never, Never]  # workaround for https://github.com/microsoft/pyright/issues/10232
 type _ToFloatStrictND = onp.ArrayND[npc.floating | npc.integer | np.bool, _JustAnyShape]
+type _ToComplexStrictND = onp.ArrayND[npc.number | np.bool, _JustAnyShape]
 
 # workaround for a strange bug in pyright's overlapping overload detection with `numpy<2.1`
 type _WorkaroundForPyright = tuple[int] | tuple[Any, ...]
@@ -405,13 +406,106 @@ def ttest_1samp(
 ) -> Ttest_1sampResult[onp.MArray[np.float64] | Any, onp.MArray[np.float64] | Any]: ...
 
 #
+@overload  # ?d, ?d, axis=None
 def ttest_ind(
-    a: onp.ToFloatND,
-    b: onp.ToFloatND,
+    a: onp.ToFloatND, b: onp.ToFloatND, axis: None, equal_var: bool = True, alternative: Alternative = "two-sided"
+) -> Ttest_indResult[np.float64, np.float64]: ...
+@overload  # ?d ~c128, ?d, axis=None
+def ttest_ind(
+    a: onp.ToArrayND[op.JustComplex, np.complex128 | np.complex64],
+    b: onp.ToComplexND,
+    axis: None,
+    equal_var: bool = True,
+    alternative: Alternative = "two-sided",
+) -> Ttest_indResult[np.float64, np.complex128]: ...
+@overload  # ?d, ?d ~c128, axis=None
+def ttest_ind(
+    a: onp.ToComplexND,
+    b: onp.ToArrayND[op.JustComplex, np.complex128 | np.complex64],
+    axis: None,
+    equal_var: bool = True,
+    alternative: Alternative = "two-sided",
+) -> Ttest_indResult[np.float64, np.complex128]: ...
+@overload  # ?d, ?d, axis=<given> (default)
+def ttest_ind(
+    a: _ToFloatStrictND,
+    b: _ToFloatStrictND,
+    axis: SupportsIndex = 0,
+    equal_var: bool = True,
+    alternative: Alternative = "two-sided",
+) -> Ttest_indResult[onp.MArray[np.float64] | Any, onp.MArray[np.float64] | Any]: ...
+@overload  # ?d ~c128, ?d, axis=<given> (default)
+def ttest_ind(
+    a: onp.ArrayND[np.complex128 | np.complex64, _JustAnyShape],
+    b: _ToComplexStrictND,
+    axis: SupportsIndex = 0,
+    equal_var: bool = True,
+    alternative: Alternative = "two-sided",
+) -> Ttest_indResult[onp.MArray[np.float64] | Any, onp.MArray[np.complex128] | Any]: ...
+@overload  # ?d, ?d ~c128, axis=<given> (default)
+def ttest_ind(
+    a: _ToComplexStrictND,
+    b: onp.ArrayND[np.complex128 | np.complex64, _JustAnyShape],
+    axis: SupportsIndex = 0,
+    equal_var: bool = True,
+    alternative: Alternative = "two-sided",
+) -> Ttest_indResult[onp.MArray[np.float64] | Any, onp.MArray[np.complex128] | Any]: ...
+@overload  # 1d, 1d, axis=<given> (default)
+def ttest_ind(
+    a: onp.ToFloatStrict1D,
+    b: onp.ToFloatStrict1D,
+    axis: SupportsIndex = 0,
+    equal_var: bool = True,
+    alternative: Alternative = "two-sided",
+) -> Ttest_indResult[np.float64, np.float64]: ...
+@overload  # 1d ~c128, 1d, axis=<given> (default)
+def ttest_ind(
+    a: onp.ToArrayStrict1D[op.JustComplex, np.complex128 | np.complex64],
+    b: onp.ToComplexStrict1D,
+    axis: SupportsIndex = 0,
+    equal_var: bool = True,
+    alternative: Alternative = "two-sided",
+) -> Ttest_indResult[np.float64, np.complex128]: ...
+@overload  # 1d, 1d ~c128, axis=<given> (default)
+def ttest_ind(
+    a: onp.ToComplexStrict1D,
+    b: onp.ToArrayStrict1D[op.JustComplex, np.complex128 | np.complex64],
+    axis: SupportsIndex = 0,
+    equal_var: bool = True,
+    alternative: Alternative = "two-sided",
+) -> Ttest_indResult[np.float64, np.complex128]: ...
+@overload  # 2d, 2d, axis=<given> (default)
+def ttest_ind(
+    a: onp.ToFloatStrict2D,
+    b: onp.ToFloatStrict2D,
+    axis: SupportsIndex = 0,
+    equal_var: bool = True,
+    alternative: Alternative = "two-sided",
+) -> Ttest_indResult[onp.MArray1D[np.float64], onp.MArray1D[np.float64]]: ...
+@overload  # 2d ~c128, 2d, axis=<given> (default)
+def ttest_ind(
+    a: onp.ToArrayStrict2D[op.JustComplex, np.complex128 | np.complex64],
+    b: onp.ToComplexStrict2D,
+    axis: SupportsIndex = 0,
+    equal_var: bool = True,
+    alternative: Alternative = "two-sided",
+) -> Ttest_indResult[onp.MArray1D[np.float64], onp.MArray1D[np.complex128]]: ...
+@overload  # 2d, 2d ~c128, axis=<given> (default)
+def ttest_ind(
+    a: onp.ToComplexStrict2D,
+    b: onp.ToArrayStrict2D[op.JustComplex, np.complex128 | np.complex64],
+    axis: SupportsIndex = 0,
+    equal_var: bool = True,
+    alternative: Alternative = "two-sided",
+) -> Ttest_indResult[onp.MArray1D[np.float64], onp.MArray1D[np.complex128]]: ...
+@overload  # fallback
+def ttest_ind(
+    a: onp.ToComplexND,
+    b: onp.ToComplexND,
     axis: SupportsIndex | None = 0,
     equal_var: bool = True,
     alternative: Alternative = "two-sided",
-) -> Ttest_indResult: ...
+) -> Ttest_indResult[onp.MArray[np.float64] | Any, onp.MArray[np.float64] | Any]: ...
 
 #
 def ttest_rel(

--- a/scipy-stubs/stats/_mstats_basic.pyi
+++ b/scipy-stubs/stats/_mstats_basic.pyi
@@ -508,9 +508,26 @@ def ttest_ind(
 ) -> Ttest_indResult[onp.MArray[np.float64] | Any, onp.MArray[np.float64] | Any]: ...
 
 #
+@overload  # ?d, ?d, axis=None
+def ttest_rel(
+    a: onp.ToFloatND, b: onp.ToFloatND, axis: None, alternative: Alternative = "two-sided"
+) -> Ttest_relResult[np.float64, np.float64]: ...
+@overload  # ?d, ?d, axis=<given> (default)
+def ttest_rel(
+    a: _ToFloatStrictND, b: _ToFloatStrictND, axis: SupportsIndex = 0, alternative: Alternative = "two-sided"
+) -> Ttest_relResult[onp.MArray[np.float64] | Any, onp.MArray[np.float64] | Any]: ...
+@overload  # 1d, 1d, axis=<given> (default)
+def ttest_rel(
+    a: onp.ToFloatStrict1D, b: onp.ToFloatStrict1D, axis: SupportsIndex = 0, alternative: Alternative = "two-sided"
+) -> Ttest_relResult[np.float64, np.float64]: ...
+@overload  # 2d, 2d, axis=<given> (default)
+def ttest_rel(
+    a: onp.ToFloatStrict2D, b: onp.ToFloatStrict2D, axis: SupportsIndex = 0, alternative: Alternative = "two-sided"
+) -> Ttest_relResult[onp.MArray1D[np.float64], onp.MArray1D[np.float64]]: ...
+@overload  # fallback
 def ttest_rel(
     a: onp.ToFloatND, b: onp.ToFloatND, axis: SupportsIndex | None = 0, alternative: Alternative = "two-sided"
-) -> Ttest_relResult: ...
+) -> Ttest_relResult[onp.MArray[np.float64] | Any, onp.MArray[np.float64] | Any]: ...
 
 #
 def mannwhitneyu(x: onp.ToFloatND, y: onp.ToFloatND, use_continuity: bool = True) -> MannwhitneyuResult: ...

--- a/tests/stats/test_mstats.pyi
+++ b/tests/stats/test_mstats.pyi
@@ -30,6 +30,7 @@ from scipy.stats.mstats import (
     tmin,
     trim,
     trimmed_mean,
+    ttest_1samp,
     variation,
 )
 
@@ -178,7 +179,16 @@ assert_type(sen_seasonal_slopes(_f80_2d).intra_slope, onp.MArray1D[np.float128])
 assert_type(sen_seasonal_slopes(_c160_2d).inter_slope, np.complex256)
 
 # ttest_1samp
-# TODO
+assert_type(ttest_1samp(_f32_3d, 0.5, axis=None).statistic, np.float64)
+assert_type(ttest_1samp(_py_i_1d, 0.5).statistic, np.float64)
+assert_type(ttest_1samp(_f16_2d, _f64_1d).statistic, onp.MArray1D[np.float64])
+assert_type(ttest_1samp(_i8_3d, 0).pvalue, onp.MArray2D[np.float64])
+assert_type(ttest_1samp(_m_f64_nd, 0.5).statistic, onp.MArray[np.float64] | Any)
+assert_type(ttest_1samp(_py_c_2d, 0.5j, axis=None).statistic, np.complex128)
+assert_type(ttest_1samp(_c64_1d, 0.5).statistic, np.complex128)
+assert_type(ttest_1samp(_c128_2d, 0.5j).statistic, onp.MArray1D[np.complex128])
+assert_type(ttest_1samp(_c128_2d, 0.5j).pvalue, onp.MArray1D[np.float64])
+assert_type(ttest_1samp(_c64_3d, 0.5).statistic, onp.MArray2D[np.complex128])
 
 # ttest_ind
 # TODO

--- a/tests/stats/test_mstats.pyi
+++ b/tests/stats/test_mstats.pyi
@@ -32,6 +32,7 @@ from scipy.stats.mstats import (
     trimmed_mean,
     ttest_1samp,
     ttest_ind,
+    ttest_rel,
     variation,
 )
 
@@ -204,7 +205,11 @@ assert_type(ttest_ind(_c128_2d, _f16_2d).pvalue, onp.MArray1D[np.float64])
 assert_type(ttest_ind(_f32_2d, _c64_2d).statistic, onp.MArray1D[np.complex128])
 
 # ttest_rel
-# TODO
+assert_type(ttest_rel(_f32_3d, _i8_3d, axis=None).statistic, np.float64)
+assert_type(ttest_rel(_py_i_1d, _f16_1d).statistic, np.float64)
+assert_type(ttest_rel(_f16_2d, _f64_2d).statistic, onp.MArray1D[np.float64])
+assert_type(ttest_rel(_i8_2d, _f32_2d).pvalue, onp.MArray1D[np.float64])
+assert_type(ttest_rel(_m_f64_nd, _f64_nd).statistic, onp.MArray[np.float64] | Any)
 
 # mannwhitneyu
 # TODO

--- a/tests/stats/test_mstats.pyi
+++ b/tests/stats/test_mstats.pyi
@@ -31,6 +31,7 @@ from scipy.stats.mstats import (
     trim,
     trimmed_mean,
     ttest_1samp,
+    ttest_ind,
     variation,
 )
 
@@ -191,7 +192,16 @@ assert_type(ttest_1samp(_c128_2d, 0.5j).pvalue, onp.MArray1D[np.float64])
 assert_type(ttest_1samp(_c64_3d, 0.5).statistic, onp.MArray2D[np.complex128])
 
 # ttest_ind
-# TODO
+assert_type(ttest_ind(_f32_3d, _i8_3d, axis=None).statistic, np.float64)
+assert_type(ttest_ind(_py_i_1d, _f16_1d).statistic, np.float64)
+assert_type(ttest_ind(_f16_2d, _f64_2d, equal_var=False).statistic, onp.MArray1D[np.float64])
+assert_type(ttest_ind(_i8_2d, _f32_2d).pvalue, onp.MArray1D[np.float64])
+assert_type(ttest_ind(_m_f64_nd, _f64_nd).statistic, onp.MArray[np.float64] | Any)
+assert_type(ttest_ind(_py_c_2d, _py_f_2d, axis=None).statistic, np.complex128)
+assert_type(ttest_ind(_f64_1d, _c64_1d).statistic, np.complex128)
+assert_type(ttest_ind(_c128_2d, _f16_2d).statistic, onp.MArray1D[np.complex128])
+assert_type(ttest_ind(_c128_2d, _f16_2d).pvalue, onp.MArray1D[np.float64])
+assert_type(ttest_ind(_f32_2d, _c64_2d).statistic, onp.MArray1D[np.complex128])
 
 # ttest_rel
 # TODO


### PR DESCRIPTION
- `ttest_1samp`
- `ttest_ind`
- `ttest_rel`

towards #1777