### PR TITLE
🐛 `stats.mstats.rsh`: fix return type

### DIFF
--- a/scipy-stubs/stats/_mstats_extras.pyi
+++ b/scipy-stubs/stats/_mstats_extras.pyi
@@ -23,6 +23,7 @@ type _Tuple2[T] = tuple[T, T]
 type _FloatND = onp.ArrayND[np.float64]
 
 type _ToProb = onp.ToFloat | onp.ToFloatND
+type _ToPoints = onp.ToFloat | onp.ToFloat1D | None
 type _ToAxis = SupportsIndex | None
 
 ###
@@ -93,4 +94,7 @@ def idealfourths(data: onp.ToFloatND, axis: None = None) -> list[np.float64]: ..
 def idealfourths(data: onp.ToFloatND, axis: SupportsIndex) -> onp.MArray[np.float64]: ...
 
 #
-def rsh(data: onp.ToFloatND, points: onp.ToFloatND | None = None) -> np.float64: ...
+@overload  # ~f64
+def rsh(data: onp.ToFloat64_1D, points: _ToPoints = None) -> onp.MArray1D[np.float64]: ...
+@overload  # T@floating80
+def rsh(data: onp.ToArray1D[npc.floating80, npc.floating80], points: _ToPoints = None) -> onp.MArray1D[np.longdouble]: ...

--- a/tests/stats/test_mstats.pyi
+++ b/tests/stats/test_mstats.pyi
@@ -19,6 +19,7 @@ from scipy.stats.mstats import (
     normaltest,
     pearsonr,
     pointbiserialr,
+    rsh,
     sen_seasonal_slopes,
     siegelslopes,
     skew,
@@ -571,3 +572,11 @@ assert_type(mquantiles(_f80_nd, axis=0), onp.MArray[np.float128] | Any)
 
 # brunnermunzel
 # TODO
+
+###
+
+# rsh
+assert_type(rsh(_py_i_1d), onp.MArray1D[np.float64])
+assert_type(rsh(_f32_1d, 0.5), onp.MArray1D[np.float64])
+assert_type(rsh(_m_f64_nd, _f64_1d), onp.MArray1D[np.float64])
+assert_type(rsh(_f80_1d), onp.MArray1D[np.longdouble])


### PR DESCRIPTION
closes #1777