### PR TITLE
✨ `stats.mstats.hdquantiles`: improve shape-typing and return dtypes

### DIFF
--- a/scipy-stubs/stats/_mstats_extras.pyi
+++ b/scipy-stubs/stats/_mstats_extras.pyi
@@ -1,4 +1,4 @@
-from typing import SupportsIndex, overload
+from typing import Never, SupportsIndex, overload
 
 import numpy as np
 import optype.numpy as onp
@@ -22,23 +22,51 @@ __all__ = [
 type _Tuple2[T] = tuple[T, T]
 type _FloatND = onp.ArrayND[np.float64]
 
+type _JustAnyShape = tuple[Never, Never, Never, Never]  # workaround for https://github.com/microsoft/pyright/issues/10232
+type _ToFloatStrictND = onp.ArrayND[npc.floating | npc.integer | np.bool, _JustAnyShape]
+
 type _ToProb = onp.ToFloat | onp.ToFloatND
 type _ToPoints = onp.ToFloat | onp.ToFloat1D | None
 type _ToAxis = SupportsIndex | None
 
 ###
 
-@overload
+# NOTE: with `axis=None` the result is 1-d for any input rank
+@overload  # ?d, axis=None (default), var=False (default)
 def hdquantiles(
-    data: onp.ToFloat1D, prob: _ToProb = (0.25, 0.5, 0.75), axis: _ToAxis = None, var: onp.ToFalse = False
+    data: onp.ToFloatND, prob: _ToProb = (0.25, 0.5, 0.75), axis: None = None, var: onp.ToFalse = False
 ) -> onp.MArray1D[np.float64]: ...
-@overload
-def hdquantiles(data: onp.ToFloat1D, prob: _ToProb, axis: _ToAxis, var: onp.ToTrue) -> onp.MArray2D[np.float64]: ...
-@overload
+@overload  # ?d, axis=None (default), var=True
+def hdquantiles(data: onp.ToFloatND, prob: _ToProb, axis: None, var: onp.ToTrue) -> onp.MArray2D[np.float64]: ...
+@overload  # ?d, axis=None (default), var=True
 def hdquantiles(
-    data: onp.ToFloat1D, prob: _ToProb = (0.25, 0.5, 0.75), axis: _ToAxis = None, *, var: onp.ToTrue
+    data: onp.ToFloatND, prob: _ToProb = (0.25, 0.5, 0.75), axis: None = None, *, var: onp.ToTrue
 ) -> onp.MArray2D[np.float64]: ...
-@overload
+@overload  # ?d, axis=<given>, var=False (default)
+def hdquantiles(
+    data: _ToFloatStrictND, prob: _ToProb = (0.25, 0.5, 0.75), *, axis: SupportsIndex, var: onp.ToFalse = False
+) -> onp.MArray[np.float64]: ...
+@overload  # ?d, axis=<given>, var=True
+def hdquantiles(
+    data: _ToFloatStrictND, prob: _ToProb = (0.25, 0.5, 0.75), *, axis: SupportsIndex, var: onp.ToTrue
+) -> onp.MArray[np.float64]: ...
+@overload  # 1d, axis=<given>, var=False (default)
+def hdquantiles(
+    data: onp.ToFloatStrict1D, prob: _ToProb = (0.25, 0.5, 0.75), *, axis: SupportsIndex, var: onp.ToFalse = False
+) -> onp.MArray1D[np.float64]: ...
+@overload  # 1d, axis=<given>, var=True
+def hdquantiles(
+    data: onp.ToFloatStrict1D, prob: _ToProb = (0.25, 0.5, 0.75), *, axis: SupportsIndex, var: onp.ToTrue
+) -> onp.MArray2D[np.float64]: ...
+@overload  # 2d, axis=<given>, var=False (default)
+def hdquantiles(
+    data: onp.ToFloatStrict2D, prob: _ToProb = (0.25, 0.5, 0.75), *, axis: SupportsIndex, var: onp.ToFalse = False
+) -> onp.MArray2D[np.float64]: ...
+@overload  # 2d, axis=<given>, var=True
+def hdquantiles(
+    data: onp.ToFloatStrict2D, prob: _ToProb = (0.25, 0.5, 0.75), *, axis: SupportsIndex, var: onp.ToTrue
+) -> onp.MArray3D[np.float64]: ...
+@overload  # fallback
 def hdquantiles(
     data: onp.ToFloatND, prob: _ToProb = (0.25, 0.5, 0.75), axis: _ToAxis = None, var: bool = False
 ) -> onp.MArray[np.float64]: ...

--- a/tests/stats/test_mstats.pyi
+++ b/tests/stats/test_mstats.pyi
@@ -11,6 +11,7 @@ from scipy.stats.mstats import (
     argstoarray,
     count_tied_groups,
     describe,
+    hdquantiles,
     kendalltau,
     kendalltau_seasonal,
     kruskal,
@@ -582,6 +583,16 @@ assert_type(mquantiles(_f80_nd, axis=0), onp.MArray[np.float128] | Any)
 # TODO
 
 ###
+
+# hdquantiles
+assert_type(hdquantiles(_f64_3d), onp.MArray1D[np.float64])
+assert_type(hdquantiles(_i8_2d, var=True), onp.MArray2D[np.float64])
+assert_type(hdquantiles(_f32_2d, (0.1, 0.9), None, True), onp.MArray2D[np.float64])
+assert_type(hdquantiles(_py_f_1d, axis=0), onp.MArray1D[np.float64])
+assert_type(hdquantiles(_f64_1d, axis=0, var=True), onp.MArray2D[np.float64])
+assert_type(hdquantiles(_f64_2d, axis=0), onp.MArray2D[np.float64])
+assert_type(hdquantiles(_f16_2d, axis=1, var=True), onp.MArray3D[np.float64])
+assert_type(hdquantiles(_f64_nd, axis=0), onp.MArray[np.float64])
 
 # rsh
 assert_type(rsh(_py_i_1d), onp.MArray1D[np.float64])


### PR DESCRIPTION
towards #1146