### PR TITLE
✨ `stats.mstats.friedmanchisquare`: improve input signature

### DIFF
--- a/scipy-stubs/stats/_mstats_basic.pyi
+++ b/scipy-stubs/stats/_mstats_basic.pyi
@@ -1899,7 +1899,9 @@ def sem(a: onp.ToFloatND, axis: SupportsIndex | None = 0, ddof: onp.ToInt = 1) -
 def f_oneway(arg0: onp.ToFloat1D, /, *args: onp.ToFloat1D) -> F_onewayResult: ...
 
 #
-def friedmanchisquare(arg0: onp.ToFloatND, *args: onp.ToFloatND) -> FriedmanchisquareResult: ...
+def friedmanchisquare(
+    arg0: onp.ToFloat1D, arg1: onp.ToFloat1D, arg2: onp.ToFloat1D, /, *args: onp.ToFloat1D
+) -> FriedmanchisquareResult: ...
 
 #
 def brunnermunzel(

--- a/tests/stats/test_mstats.pyi
+++ b/tests/stats/test_mstats.pyi
@@ -6,12 +6,13 @@ import numpy as np
 import optype.numpy as onp
 import optype.numpy.compat as npc
 
-from scipy.stats._mstats_basic import F_onewayResult, KruskalResult
+from scipy.stats._mstats_basic import F_onewayResult, FriedmanchisquareResult, KruskalResult
 from scipy.stats.mstats import (
     argstoarray,
     count_tied_groups,
     describe,
     f_oneway,
+    friedmanchisquare,
     hdquantiles,
     kendalltau,
     kendalltau_seasonal,
@@ -585,7 +586,8 @@ assert_type(f_oneway(_f64_1d, _i8_1d), F_onewayResult)
 assert_type(f_oneway(_py_f_1d, _f32_1d, _f16_1d), F_onewayResult)
 
 # friedmanchisquare
-# TODO
+assert_type(friedmanchisquare(_f64_1d, _i8_1d, _f32_1d), FriedmanchisquareResult)
+assert_type(friedmanchisquare(_py_f_1d, _py_i_1d, _f16_1d, _f64_1d), FriedmanchisquareResult)
 
 # brunnermunzel
 # TODO


### PR DESCRIPTION
it now requires at least 3 arguments for increased type-safety.

towards #1146