### PR TITLE
✨ `stats.mstats.trimboth`: improve shape-typing and return dtypes

### DIFF
--- a/scipy-stubs/stats/_mstats_basic.pyi
+++ b/scipy-stubs/stats/_mstats_basic.pyi
@@ -751,34 +751,76 @@ def trim[ScalarT: npc.number | np.bool](
 ) -> onp.MArray[ScalarT, _WorkaroundForPyright]: ...
 
 #
-@overload
+@overload  # 1d bool
 def trimboth(
-    data: onp.SequenceND[op.JustInt | np.int_],
+    data: list[bool],
+    proportiontocut: float | npc.floating = 0.2,
+    inclusive: tuple[bool, bool] = (True, True),
+    axis: SupportsIndex | None = None,
+) -> onp.MArray1D[np.bool]: ...
+@overload  # ?d bool
+def trimboth(
+    data: onp.SequenceND[list[bool]],
+    proportiontocut: float | npc.floating = 0.2,
+    inclusive: tuple[bool, bool] = (True, True),
+    axis: SupportsIndex | None = None,
+) -> onp.MArray[np.bool]: ...
+@overload  # 1d ~int
+def trimboth(
+    data: list[int],
+    proportiontocut: float | npc.floating = 0.2,
+    inclusive: tuple[bool, bool] = (True, True),
+    axis: SupportsIndex | None = None,
+) -> onp.MArray1D[np.int_]: ...
+@overload  # ?d ~int
+def trimboth(
+    data: onp.SequenceND[list[int]],
     proportiontocut: float | npc.floating = 0.2,
     inclusive: tuple[bool, bool] = (True, True),
     axis: SupportsIndex | None = None,
 ) -> onp.MArray[np.int_]: ...
-@overload
+@overload  # 1d ~float
 def trimboth(
-    data: onp.SequenceND[float],
+    data: list[float],
     proportiontocut: float | npc.floating = 0.2,
     inclusive: tuple[bool, bool] = (True, True),
     axis: SupportsIndex | None = None,
-) -> onp.MArray[np.float64 | np.int_]: ...
-@overload
+) -> onp.MArray1D[np.float64]: ...
+@overload  # ?d ~float
 def trimboth(
-    data: onp.SequenceND[complex],
+    data: onp.SequenceND[list[float]],
     proportiontocut: float | npc.floating = 0.2,
     inclusive: tuple[bool, bool] = (True, True),
     axis: SupportsIndex | None = None,
-) -> onp.MArray[np.complex128 | np.float64 | np.int_]: ...
-@overload
+) -> onp.MArray[np.float64]: ...
+@overload  # 1d ~complex
+def trimboth(
+    data: list[complex],
+    proportiontocut: float | npc.floating = 0.2,
+    inclusive: tuple[bool, bool] = (True, True),
+    axis: SupportsIndex | None = None,
+) -> onp.MArray1D[np.complex128]: ...
+@overload  # ?d ~complex
+def trimboth(
+    data: onp.SequenceND[list[complex]],
+    proportiontocut: float | npc.floating = 0.2,
+    inclusive: tuple[bool, bool] = (True, True),
+    axis: SupportsIndex | None = None,
+) -> onp.MArray[np.complex128]: ...
+@overload  # ?d T@+number
+def trimboth[ShapeT: tuple[int, ...], ScalarT: npc.number | np.bool](
+    data: onp.ArrayND[ScalarT, ShapeT],
+    proportiontocut: float | npc.floating = 0.2,
+    inclusive: tuple[bool, bool] = (True, True),
+    axis: SupportsIndex | None = None,
+) -> onp.MArray[ScalarT, ShapeT]: ...
+@overload  # Nd T@+number
 def trimboth[ScalarT: npc.number | np.bool](
-    data: _ArrayLike[ScalarT],
+    data: onp.ToArrayND[ScalarT, ScalarT],
     proportiontocut: float | npc.floating = 0.2,
     inclusive: tuple[bool, bool] = (True, True),
     axis: SupportsIndex | None = None,
-) -> onp.MArray[ScalarT]: ...
+) -> onp.MArray[ScalarT, _WorkaroundForPyright]: ...
 
 #
 @overload

--- a/tests/stats/test_mstats.pyi
+++ b/tests/stats/test_mstats.pyi
@@ -39,6 +39,7 @@ from scipy.stats.mstats import (
     tmean,
     tmin,
     trim,
+    trimboth,
     trimmed_mean,
     ttest_1samp,
     ttest_ind,
@@ -260,18 +261,28 @@ assert_type(trim(_py_f_1d), onp.MArray1D[np.float64])
 assert_type(trim(_py_f_2d), onp.MArray[np.float64])
 assert_type(trim(_py_c_1d), onp.MArray1D[np.complex128])
 assert_type(trim(_py_c_2d), onp.MArray[np.complex128])
-
 assert_type(trim(_i64_1d), onp.MArray1D[np.int64])
 assert_type(trim(_f16_2d), onp.MArray2D[np.float16])
 assert_type(trim(_f32_3d), onp.MArray3D[np.float32])
 assert_type(trim(_f80_2d), onp.MArray2D[np.float128])
 assert_type(trim(_c64_nd), onp.MArray[np.complex64])
 assert_type(trim(_m_f32_nd), onp.MArray[np.float32])
-
 assert_type(trim(_f64_2d, (0.1, 0.1), (True, True), True, 0), onp.MArray2D[np.float64])
 
 # trimboth
-# TODO
+assert_type(trimboth(_py_b_1d), onp.MArray1D[np.bool])
+assert_type(trimboth(_py_b_2d), onp.MArray[np.bool])
+assert_type(trimboth(_py_i_1d), onp.MArray1D[np.int_])
+assert_type(trimboth(_py_i_2d), onp.MArray[np.int_])
+assert_type(trimboth(_py_f_1d), onp.MArray1D[np.float64])
+assert_type(trimboth(_py_c_2d), onp.MArray[np.complex128])
+assert_type(trimboth(_i64_1d), onp.MArray1D[np.int64])
+assert_type(trimboth(_f16_2d), onp.MArray2D[np.float16])
+assert_type(trimboth(_f32_3d), onp.MArray3D[np.float32])
+assert_type(trimboth(_f80_2d), onp.MArray2D[np.float128])
+assert_type(trimboth(_c64_nd), onp.MArray[np.complex64])
+assert_type(trimboth(_m_f32_nd), onp.MArray[np.float32])
+assert_type(trimboth(_f64_2d, 0.1, (True, True), 0), onp.MArray2D[np.float64])
 
 # trimtail
 # TODO


### PR DESCRIPTION
towards #1146