### PR TITLE
✨ `stats.mstats.compare_medians_ms`: improve shape-typing and return dtypes

### DIFF
--- a/scipy-stubs/stats/_mstats_extras.pyi
+++ b/scipy-stubs/stats/_mstats_extras.pyi
@@ -256,10 +256,20 @@ def median_cihs(
 ) -> _Tuple2[np.float64] | onp.MArray[np.float64] | Any: ...
 
 #
-@overload
+@overload  # ?d, ?d, axis=None (default)
 def compare_medians_ms(group_1: onp.ToFloatND, group_2: onp.ToFloatND, axis: None = None) -> np.float64: ...
-@overload
-def compare_medians_ms(group_1: onp.ToFloatND, group_2: onp.ToFloatND, axis: SupportsIndex) -> onp.ArrayND[np.float64]: ...
+@overload  # ?d, ?d, axis=<given>
+def compare_medians_ms(
+    group_1: _ToFloatStrictND, group_2: _ToFloatStrictND, axis: SupportsIndex
+) -> onp.ArrayND[np.float64] | Any: ...
+@overload  # 1d, 1d, axis=<given>
+def compare_medians_ms(group_1: onp.ToFloatStrict1D, group_2: onp.ToFloatStrict1D, axis: SupportsIndex) -> np.float64: ...
+@overload  # 2d, 2d, axis=<given>
+def compare_medians_ms(
+    group_1: onp.ToFloatStrict2D, group_2: onp.ToFloatStrict2D, axis: SupportsIndex
+) -> onp.Array1D[np.float64]: ...
+@overload  # fallback
+def compare_medians_ms(group_1: onp.ToFloatND, group_2: onp.ToFloatND, axis: _ToAxis = None) -> onp.ArrayND[np.float64] | Any: ...
 
 #
 @overload  # ?d T@floating, axis=None (default)

--- a/tests/stats/test_mstats.pyi
+++ b/tests/stats/test_mstats.pyi
@@ -9,6 +9,7 @@ import optype.numpy.compat as npc
 from scipy.stats._mstats_basic import F_onewayResult, FriedmanchisquareResult, KruskalResult
 from scipy.stats.mstats import (
     argstoarray,
+    compare_medians_ms,
     count_tied_groups,
     describe,
     f_oneway,
@@ -677,7 +678,11 @@ assert_type(median_cihs(_i8_2d, axis=0), onp.MArray2D[np.float64])
 assert_type(median_cihs(_f80_2d, axis=1), onp.MArray2D[np.longdouble])
 
 # compare_medians_ms
-# TODO
+assert_type(compare_medians_ms(_py_f_1d, _i8_1d), np.float64)
+assert_type(compare_medians_ms(_f32_3d, _f64_3d), np.float64)
+assert_type(compare_medians_ms(_f16_1d, _f64_1d, 0), np.float64)
+assert_type(compare_medians_ms(_i8_2d, _f32_2d, 0), onp.Array1D[np.float64])
+assert_type(compare_medians_ms(_f64_nd, _f64_nd, 0), onp.ArrayND[np.float64] | Any)
 
 # idealfourths
 assert_type(idealfourths(_f16_1d), list[np.float16])


### PR DESCRIPTION
towards #1146