### PR TITLE
✨ `stats.mstats.trimtail`: improve shape-typing and return dtypes

### DIFF
--- a/scipy-stubs/stats/_mstats_basic.pyi
+++ b/scipy-stubs/stats/_mstats_basic.pyi
@@ -823,38 +823,86 @@ def trimboth[ScalarT: npc.number | np.bool](
 ) -> onp.MArray[ScalarT, _WorkaroundForPyright]: ...
 
 #
-@overload
+@overload  # 1d bool
 def trimtail(
-    data: onp.SequenceND[op.JustInt | np.int_],
+    data: list[bool],
+    proportiontocut: float | npc.floating = 0.2,
+    tail: Literal["left", "right"] = "left",
+    inclusive: tuple[bool, bool] = (True, True),
+    axis: SupportsIndex | None = None,
+) -> onp.MArray1D[np.bool]: ...
+@overload  # ?d bool
+def trimtail(
+    data: onp.SequenceND[list[bool]],
+    proportiontocut: float | npc.floating = 0.2,
+    tail: Literal["left", "right"] = "left",
+    inclusive: tuple[bool, bool] = (True, True),
+    axis: SupportsIndex | None = None,
+) -> onp.MArray[np.bool]: ...
+@overload  # 1d ~int
+def trimtail(
+    data: list[int],
+    proportiontocut: float | npc.floating = 0.2,
+    tail: Literal["left", "right"] = "left",
+    inclusive: tuple[bool, bool] = (True, True),
+    axis: SupportsIndex | None = None,
+) -> onp.MArray1D[np.int_]: ...
+@overload  # ?d ~int
+def trimtail(
+    data: onp.SequenceND[list[int]],
     proportiontocut: float | npc.floating = 0.2,
     tail: Literal["left", "right"] = "left",
     inclusive: tuple[bool, bool] = (True, True),
     axis: SupportsIndex | None = None,
 ) -> onp.MArray[np.int_]: ...
-@overload
+@overload  # 1d ~float
 def trimtail(
-    data: onp.SequenceND[float],
+    data: list[float],
     proportiontocut: float | npc.floating = 0.2,
     tail: Literal["left", "right"] = "left",
     inclusive: tuple[bool, bool] = (True, True),
     axis: SupportsIndex | None = None,
-) -> onp.MArray[np.float64 | np.int_]: ...
-@overload
+) -> onp.MArray1D[np.float64]: ...
+@overload  # ?d ~float
 def trimtail(
-    data: onp.SequenceND[complex],
+    data: onp.SequenceND[list[float]],
     proportiontocut: float | npc.floating = 0.2,
     tail: Literal["left", "right"] = "left",
     inclusive: tuple[bool, bool] = (True, True),
     axis: SupportsIndex | None = None,
-) -> onp.MArray[np.complex128 | np.float64 | np.int_]: ...
-@overload
+) -> onp.MArray[np.float64]: ...
+@overload  # 1d ~complex
+def trimtail(
+    data: list[complex],
+    proportiontocut: float | npc.floating = 0.2,
+    tail: Literal["left", "right"] = "left",
+    inclusive: tuple[bool, bool] = (True, True),
+    axis: SupportsIndex | None = None,
+) -> onp.MArray1D[np.complex128]: ...
+@overload  # ?d ~complex
+def trimtail(
+    data: onp.SequenceND[list[complex]],
+    proportiontocut: float | npc.floating = 0.2,
+    tail: Literal["left", "right"] = "left",
+    inclusive: tuple[bool, bool] = (True, True),
+    axis: SupportsIndex | None = None,
+) -> onp.MArray[np.complex128]: ...
+@overload  # Nd T@+number
+def trimtail[ShapeT: tuple[int, ...], ScalarT: npc.number | np.bool](
+    data: onp.ArrayND[ScalarT, ShapeT],
+    proportiontocut: float | npc.floating = 0.2,
+    tail: Literal["left", "right"] = "left",
+    inclusive: tuple[bool, bool] = (True, True),
+    axis: SupportsIndex | None = None,
+) -> onp.MArray[ScalarT, ShapeT]: ...
+@overload  # ?d T@+number
 def trimtail[ScalarT: npc.number | np.bool](
-    data: _ArrayLike[ScalarT],
+    data: onp.ToArrayND[ScalarT, ScalarT],
     proportiontocut: float | npc.floating = 0.2,
     tail: Literal["left", "right"] = "left",
     inclusive: tuple[bool, bool] = (True, True),
     axis: SupportsIndex | None = None,
-) -> onp.MArray[ScalarT]: ...
+) -> onp.MArray[ScalarT, _WorkaroundForPyright]: ...
 
 #
 # NOTE: f32/c64 promotes to f64/c128

--- a/tests/stats/test_mstats.pyi
+++ b/tests/stats/test_mstats.pyi
@@ -49,6 +49,7 @@ from scipy.stats.mstats import (
     trimboth,
     trimmed_mean,
     trimmed_mean_ci,
+    trimtail,
     ttest_1samp,
     ttest_ind,
     ttest_rel,
@@ -293,7 +294,21 @@ assert_type(trimboth(_m_f32_nd), onp.MArray[np.float32])
 assert_type(trimboth(_f64_2d, 0.1, (True, True), 0), onp.MArray2D[np.float64])
 
 # trimtail
-# TODO
+assert_type(trimtail(_py_b_1d), onp.MArray1D[np.bool])
+assert_type(trimtail(_py_b_2d), onp.MArray[np.bool])
+assert_type(trimtail(_py_i_1d), onp.MArray1D[np.int_])
+assert_type(trimtail(_py_i_2d), onp.MArray[np.int_])
+assert_type(trimtail(_py_f_1d), onp.MArray1D[np.float64])
+assert_type(trimtail(_py_f_2d), onp.MArray[np.float64])
+assert_type(trimtail(_py_c_1d), onp.MArray1D[np.complex128])
+assert_type(trimtail(_py_c_2d), onp.MArray[np.complex128])
+assert_type(trimtail(_i64_1d), onp.MArray1D[np.int64])
+assert_type(trimtail(_f16_2d, tail="right"), onp.MArray2D[np.float16])
+assert_type(trimtail(_f32_3d), onp.MArray3D[np.float32])
+assert_type(trimtail(_f80_2d), onp.MArray2D[np.float128])
+assert_type(trimtail(_c64_nd), onp.MArray[np.complex64])
+assert_type(trimtail(_m_f32_nd), onp.MArray[np.float32])
+assert_type(trimtail(_f64_2d, 0.1, "right", (True, True), 0), onp.MArray2D[np.float64])
 
 # trimmed_mean
 assert_type(trimmed_mean(_py_i_1d), np.float64)


### PR DESCRIPTION
#1146