### PR TITLE
✨ `stats.mstats.kstest`: improve shape-typing and return dtypes

### DIFF
--- a/scipy-stubs/stats/_mstats_basic.pyi
+++ b/scipy-stubs/stats/_mstats_basic.pyi
@@ -109,6 +109,7 @@ type _SiegelSlopesMethod = Literal["hierarchical", "separate"]
 
 type _KSMethod = Literal["auto", "exact", "asymp"]
 type _KTestMethod = Literal[_KSMethod, "approx"]
+type _ToCDF = str | Callable[[onp.ArrayND[np.float64]], onp.ToFloatND]
 
 # we can't use a generic shape-type here due to a variance bug in pyright
 type _KstestResult0 = KstestResult[np.float64, np.int8]
@@ -597,22 +598,78 @@ def ks_2samp(
 ) -> _KstestResultAny: ...
 
 #
-@overload
+@overload  # ?d, ?d | 1d
 def kstest(
-    data1: onp.ToFloatND,
-    data2: onp.ToFloatND | str | Callable[[float], onp.ToFloat],
+    data1: _ToFloatStrictND,
+    data2: _ToFloatStrictND | onp.ToFloatStrict1D | _ToCDF,
     args: tuple[()] = (),
     alternative: Alternative = "two-sided",
     method: _KTestMethod = "auto",
-) -> KstestResult: ...
-@overload
+) -> _KstestResultAny: ...
+@overload  # ?d | 1d, ?d
+def kstest(
+    data1: _ToFloatStrictND | onp.ToFloatStrict1D,
+    data2: _ToFloatStrictND,
+    args: tuple[()] = (),
+    alternative: Alternative = "two-sided",
+    method: _KTestMethod = "auto",
+) -> _KstestResultAny: ...
+@overload  # 1d, 1d
+def kstest(
+    data1: onp.ToFloatStrict1D,
+    data2: onp.ToFloatStrict1D | _ToCDF,
+    args: tuple[()] = (),
+    alternative: Alternative = "two-sided",
+    method: _KTestMethod = "auto",
+) -> _KstestResult0: ...
+@overload  # 2d, <=2d
+def kstest(
+    data1: onp.ToFloatStrict2D,
+    data2: onp.ToFloatStrict1D | onp.ToFloatStrict2D | _ToCDF,
+    args: tuple[()] = (),
+    alternative: Alternative = "two-sided",
+    method: _KTestMethod = "auto",
+) -> _KstestResult1: ...
+@overload  # <=2d, 2d
+def kstest(
+    data1: onp.ToFloatStrict1D | onp.ToFloatStrict2D,
+    data2: onp.ToFloatStrict2D,
+    args: tuple[()] = (),
+    alternative: Alternative = "two-sided",
+    method: _KTestMethod = "auto",
+) -> _KstestResult1: ...
+@overload  # fallback
 def kstest(
     data1: onp.ToFloatND,
-    data2: Callable[Concatenate[float, ...], onp.ToFloat],
+    data2: onp.ToFloatND | _ToCDF,
+    args: tuple[()] = (),
+    alternative: Alternative = "two-sided",
+    method: _KTestMethod = "auto",
+) -> _KstestResultAny: ...
+@overload  # 1d, args=<given>
+def kstest(
+    data1: onp.ToFloatStrict1D,
+    data2: Callable[Concatenate[onp.ArrayND[np.float64], ...], onp.ToFloatND],
     args: tuple[object, ...],
     alternative: Alternative = "two-sided",
     method: _KTestMethod = "auto",
-) -> KstestResult: ...
+) -> _KstestResult0: ...
+@overload  # 2d, args=<given>
+def kstest(
+    data1: onp.ToFloatStrict2D,
+    data2: Callable[Concatenate[onp.ArrayND[np.float64], ...], onp.ToFloatND],
+    args: tuple[object, ...],
+    alternative: Alternative = "two-sided",
+    method: _KTestMethod = "auto",
+) -> _KstestResult1: ...
+@overload  # fallback, args=<given>
+def kstest(
+    data1: onp.ToFloatND,
+    data2: Callable[Concatenate[onp.ArrayND[np.float64], ...], onp.ToFloatND],
+    args: tuple[object, ...],
+    alternative: Alternative = "two-sided",
+    method: _KTestMethod = "auto",
+) -> _KstestResultAny: ...
 
 #
 @overload

--- a/tests/stats/test_mstats.pyi
+++ b/tests/stats/test_mstats.pyi
@@ -22,6 +22,7 @@ from scipy.stats.mstats import (
     kendalltau_seasonal,
     kruskal,
     ks_2samp,
+    kstest,
     kurtosis,
     kurtosistest,
     linregress,
@@ -112,6 +113,8 @@ _c128_1d: onp.Array1D[np.complex128]
 _c128_2d: onp.Array2D[np.complex128]
 _c128_3d: onp.Array3D[np.complex128]
 _c128_nd: onp.ArrayND[np.complex128]
+
+def _cdf2(x: onp.ArrayND[np.float64], a: float, /) -> onp.ArrayND[np.float64]: ...
 
 _m_f32_nd: onp.MArray[np.float32]
 _m_f64_nd: onp.MArray[np.float64]
@@ -252,8 +255,15 @@ assert_type(ks_2samp(_f64_2d, _i8_2d).statistic, onp.Array1D[np.float64])
 assert_type(ks_2samp(_f16_2d, _f64_1d).statistic_sign, onp.Array1D[np.int8])
 assert_type(ks_2samp(_m_f64_nd, _f64_nd).statistic, np.float64 | Any)
 
-# ktest
-# TODO
+# kstest
+assert_type(kstest(_py_f_1d, _i8_1d).statistic, np.float64)
+assert_type(kstest(_f32_1d, "norm").statistic_sign, np.int8)
+assert_type(kstest(_f64_2d, _i8_2d).statistic, onp.Array1D[np.float64])
+assert_type(kstest(_f16_2d, "norm").statistic_sign, onp.Array1D[np.int8])
+assert_type(kstest(_f64_2d, _f64_1d).statistic, onp.Array1D[np.float64])
+assert_type(kstest(_f64_nd, _f64_nd).statistic, np.float64 | Any)
+assert_type(kstest(_f64_1d, _cdf2, (1.0,)).statistic, np.float64)
+assert_type(kstest(_f64_2d, _cdf2, (1.0,)).statistic, onp.Array1D[np.float64])
 
 # trima
 # TODO


### PR DESCRIPTION
towards #1146