### PR TITLE
✨ `linalg.qr_{delete, insert, update}` : improve return dtypes

### DIFF
--- a/scipy-stubs/linalg/_decomp_update.pyi
+++ b/scipy-stubs/linalg/_decomp_update.pyi
@@ -45,6 +45,16 @@ def qr_delete(
     overwrite_qr: bool = False,
     check_finite: bool = True,
 ) -> _QR[np.complex128]: ...
+@overload  # ~f32 | ~f64 | ~c64 | ~c128
+def qr_delete(
+    Q: onp.ToArrayND[complex, npc.inexact],
+    R: onp.ToArrayND[complex, npc.inexact],
+    k: onp.ToJustInt,
+    p: onp.ToJustInt = 1,
+    which: _Which = "row",
+    overwrite_qr: bool = False,
+    check_finite: bool = True,
+) -> _QR[npc.inexact]: ...
 
 #
 @overload  # ~f32 | ~c64
@@ -80,6 +90,17 @@ def qr_insert(
     overwrite_qru: bool = False,
     check_finite: bool = True,
 ) -> _QR[np.complex128]: ...
+@overload  # ~f32 | ~f64 | ~c64 | ~c128
+def qr_insert(
+    Q: onp.ToArrayND[complex, npc.inexact],
+    R: onp.ToArrayND[complex, npc.inexact],
+    u: onp.ToArrayND[complex, npc.inexact],
+    k: onp.ToJustInt,
+    which: _Which = "row",
+    rcond: onp.ToFloat | None = None,
+    overwrite_qru: bool = False,
+    check_finite: bool = True,
+) -> _QR[npc.inexact]: ...
 
 #
 @overload  # ~f32 | ~c64
@@ -109,3 +130,12 @@ def qr_update(
     overwrite_qruv: bool = False,
     check_finite: bool = True,
 ) -> _QR[np.complex128]: ...
+@overload  # ~f32 | ~f64 | ~c64 | ~c128
+def qr_update(
+    Q: onp.ToArrayND[complex, npc.inexact],
+    R: onp.ToArrayND[complex, npc.inexact],
+    u: onp.ToArrayND[complex, npc.inexact],
+    v: onp.ToArrayND[complex, npc.inexact],
+    overwrite_qruv: bool = False,
+    check_finite: bool = True,
+) -> _QR[npc.inexact]: ...

--- a/scipy-stubs/linalg/_decomp_update.pyi
+++ b/scipy-stubs/linalg/_decomp_update.pyi
@@ -1,4 +1,6 @@
-from typing import Literal
+# NOTE: mypy incorrectly sees disjoint dtypes as overlapping
+# mypy: disable-error-code=overload-overlap
+from typing import Literal, overload
 
 import numpy as np
 import optype.numpy as onp
@@ -13,30 +15,127 @@ type _Which = Literal["row", "col"]
 
 ###
 
-def qr_delete[SCT: _Inexact](
-    Q: onp.ArrayND[SCT],
-    R: onp.ArrayND[SCT],
+@overload  # float32 -> float32
+def qr_delete(
+    Q: onp.ToArrayND[np.float32, np.float32],
+    R: onp.ToArrayND[np.float32, np.float32],
     k: onp.ToJustInt,
     p: onp.ToJustInt = 1,
     which: _Which = "row",
     overwrite_qr: bool = False,
     check_finite: bool = True,
-) -> _QR[SCT]: ...
-def qr_insert[SCT: _Inexact](
-    Q: onp.ArrayND[SCT],
-    R: onp.ArrayND[SCT],
-    u: onp.ArrayND[SCT],
+) -> _QR[np.float32]: ...
+@overload  # float64 -> float64
+def qr_delete(
+    Q: onp.ToJustFloat64_ND,
+    R: onp.ToJustFloat64_ND,
+    k: onp.ToJustInt,
+    p: onp.ToJustInt = 1,
+    which: _Which = "row",
+    overwrite_qr: bool = False,
+    check_finite: bool = True,
+) -> _QR[np.float64]: ...
+@overload  # complex64 -> complex64
+def qr_delete(
+    Q: onp.ToArrayND[np.complex64, np.complex64],
+    R: onp.ToArrayND[np.complex64, np.complex64],
+    k: onp.ToJustInt,
+    p: onp.ToJustInt = 1,
+    which: _Which = "row",
+    overwrite_qr: bool = False,
+    check_finite: bool = True,
+) -> _QR[np.complex64]: ...
+@overload  # complex128 -> complex128
+def qr_delete(
+    Q: onp.ToJustComplex128_ND,
+    R: onp.ToJustComplex128_ND,
+    k: onp.ToJustInt,
+    p: onp.ToJustInt = 1,
+    which: _Which = "row",
+    overwrite_qr: bool = False,
+    check_finite: bool = True,
+) -> _QR[np.complex128]: ...
+
+#
+@overload  # float32 -> float32
+def qr_insert(
+    Q: onp.ToArrayND[np.float32, np.float32],
+    R: onp.ToArrayND[np.float32, np.float32],
+    u: onp.ToArrayND[np.float32, np.float32],
     k: onp.ToJustInt,
     which: _Which = "row",
     rcond: onp.ToFloat | None = None,
     overwrite_qru: bool = False,
     check_finite: bool = True,
-) -> _QR[SCT]: ...
-def qr_update[SCT: _Inexact](
-    Q: onp.ArrayND[SCT],
-    R: onp.ArrayND[SCT],
-    u: onp.ArrayND[SCT],
-    v: onp.ArrayND[SCT],
+) -> _QR[np.float32]: ...
+@overload  # float64 -> float64
+def qr_insert(
+    Q: onp.ToJustFloat64_ND,
+    R: onp.ToJustFloat64_ND,
+    u: onp.ToJustFloat64_ND,
+    k: onp.ToJustInt,
+    which: _Which = "row",
+    rcond: onp.ToFloat | None = None,
+    overwrite_qru: bool = False,
+    check_finite: bool = True,
+) -> _QR[np.float64]: ...
+@overload  # complex64 -> complex64
+def qr_insert(
+    Q: onp.ToArrayND[np.complex64, np.complex64],
+    R: onp.ToArrayND[np.complex64, np.complex64],
+    u: onp.ToArrayND[np.complex64, np.complex64],
+    k: onp.ToJustInt,
+    which: _Which = "row",
+    rcond: onp.ToFloat | None = None,
+    overwrite_qru: bool = False,
+    check_finite: bool = True,
+) -> _QR[np.complex64]: ...
+@overload  # complex128 -> complex128
+def qr_insert(
+    Q: onp.ToJustComplex128_ND,
+    R: onp.ToJustComplex128_ND,
+    u: onp.ToJustComplex128_ND,
+    k: onp.ToJustInt,
+    which: _Which = "row",
+    rcond: onp.ToFloat | None = None,
+    overwrite_qru: bool = False,
+    check_finite: bool = True,
+) -> _QR[np.complex128]: ...
+
+#
+@overload  # float32 -> float32
+def qr_update(
+    Q: onp.ToArrayND[np.float32, np.float32],
+    R: onp.ToArrayND[np.float32, np.float32],
+    u: onp.ToArrayND[np.float32, np.float32],
+    v: onp.ToArrayND[np.float32, np.float32],
     overwrite_qruv: bool = False,
     check_finite: bool = True,
-) -> _QR[SCT]: ...
+) -> _QR[np.float32]: ...
+@overload  # float64 -> float64
+def qr_update(
+    Q: onp.ToJustFloat64_ND,
+    R: onp.ToJustFloat64_ND,
+    u: onp.ToJustFloat64_ND,
+    v: onp.ToJustFloat64_ND,
+    overwrite_qruv: bool = False,
+    check_finite: bool = True,
+) -> _QR[np.float64]: ...
+@overload  # complex64 -> complex64
+def qr_update(
+    Q: onp.ToArrayND[np.complex64, np.complex64],
+    R: onp.ToArrayND[np.complex64, np.complex64],
+    u: onp.ToArrayND[np.complex64, np.complex64],
+    v: onp.ToArrayND[np.complex64, np.complex64],
+    overwrite_qruv: bool = False,
+    check_finite: bool = True,
+) -> _QR[np.complex64]: ...
+@overload  # complex128 -> complex128
+def qr_update(
+    Q: onp.ToJustComplex128_ND,
+    R: onp.ToJustComplex128_ND,
+    u: onp.ToJustComplex128_ND,
+    v: onp.ToJustComplex128_ND,
+    overwrite_qruv: bool = False,
+    check_finite: bool = True,
+) -> _QR[np.complex128]: ...

--- a/scipy-stubs/linalg/_decomp_update.pyi
+++ b/scipy-stubs/linalg/_decomp_update.pyi
@@ -1,31 +1,29 @@
-# NOTE: mypy incorrectly sees disjoint dtypes as overlapping
-# mypy: disable-error-code=overload-overlap
 from typing import Literal, overload
 
 import numpy as np
 import optype.numpy as onp
+import optype.numpy.compat as npc
 
 __all__ = ["qr_delete", "qr_insert", "qr_update"]
 
 ###
 
-type _Inexact = np.float32 | np.float64 | np.complex64 | np.complex128
-type _QR[SCT: _Inexact] = tuple[onp.ArrayND[SCT], onp.ArrayND[SCT]]
+type _QR[ScalarT: npc.inexact] = tuple[onp.ArrayND[ScalarT], onp.ArrayND[ScalarT]]
 type _Which = Literal["row", "col"]
 
 ###
 
-@overload  # float32 -> float32
-def qr_delete(
-    Q: onp.ToArrayND[np.float32, np.float32],
-    R: onp.ToArrayND[np.float32, np.float32],
+@overload  # ~f32 | ~c64
+def qr_delete[ScalarT: npc.inexact32](
+    Q: onp.ToArrayND[ScalarT, ScalarT],
+    R: onp.ToArrayND[ScalarT, ScalarT],
     k: onp.ToJustInt,
     p: onp.ToJustInt = 1,
     which: _Which = "row",
     overwrite_qr: bool = False,
     check_finite: bool = True,
-) -> _QR[np.float32]: ...
-@overload  # float64 -> float64
+) -> _QR[ScalarT]: ...
+@overload  # ~f64
 def qr_delete(
     Q: onp.ToJustFloat64_ND,
     R: onp.ToJustFloat64_ND,
@@ -35,17 +33,7 @@ def qr_delete(
     overwrite_qr: bool = False,
     check_finite: bool = True,
 ) -> _QR[np.float64]: ...
-@overload  # complex64 -> complex64
-def qr_delete(
-    Q: onp.ToArrayND[np.complex64, np.complex64],
-    R: onp.ToArrayND[np.complex64, np.complex64],
-    k: onp.ToJustInt,
-    p: onp.ToJustInt = 1,
-    which: _Which = "row",
-    overwrite_qr: bool = False,
-    check_finite: bool = True,
-) -> _QR[np.complex64]: ...
-@overload  # complex128 -> complex128
+@overload  # ~c128
 def qr_delete(
     Q: onp.ToJustComplex128_ND,
     R: onp.ToJustComplex128_ND,
@@ -57,18 +45,18 @@ def qr_delete(
 ) -> _QR[np.complex128]: ...
 
 #
-@overload  # float32 -> float32
-def qr_insert(
-    Q: onp.ToArrayND[np.float32, np.float32],
-    R: onp.ToArrayND[np.float32, np.float32],
-    u: onp.ToArrayND[np.float32, np.float32],
+@overload  # ~f32 | ~c64
+def qr_insert[ScalarT: npc.inexact32](
+    Q: onp.ToArrayND[ScalarT, ScalarT],
+    R: onp.ToArrayND[ScalarT, ScalarT],
+    u: onp.ToArrayND[ScalarT, ScalarT],
     k: onp.ToJustInt,
     which: _Which = "row",
     rcond: onp.ToFloat | None = None,
     overwrite_qru: bool = False,
     check_finite: bool = True,
-) -> _QR[np.float32]: ...
-@overload  # float64 -> float64
+) -> _QR[ScalarT]: ...
+@overload  # ~f64
 def qr_insert(
     Q: onp.ToJustFloat64_ND,
     R: onp.ToJustFloat64_ND,
@@ -79,18 +67,7 @@ def qr_insert(
     overwrite_qru: bool = False,
     check_finite: bool = True,
 ) -> _QR[np.float64]: ...
-@overload  # complex64 -> complex64
-def qr_insert(
-    Q: onp.ToArrayND[np.complex64, np.complex64],
-    R: onp.ToArrayND[np.complex64, np.complex64],
-    u: onp.ToArrayND[np.complex64, np.complex64],
-    k: onp.ToJustInt,
-    which: _Which = "row",
-    rcond: onp.ToFloat | None = None,
-    overwrite_qru: bool = False,
-    check_finite: bool = True,
-) -> _QR[np.complex64]: ...
-@overload  # complex128 -> complex128
+@overload  # ~c128
 def qr_insert(
     Q: onp.ToJustComplex128_ND,
     R: onp.ToJustComplex128_ND,
@@ -103,16 +80,16 @@ def qr_insert(
 ) -> _QR[np.complex128]: ...
 
 #
-@overload  # float32 -> float32
-def qr_update(
-    Q: onp.ToArrayND[np.float32, np.float32],
-    R: onp.ToArrayND[np.float32, np.float32],
-    u: onp.ToArrayND[np.float32, np.float32],
-    v: onp.ToArrayND[np.float32, np.float32],
+@overload  # ~f32 | ~c64
+def qr_update[ScalarT: npc.inexact32](
+    Q: onp.ToArrayND[ScalarT, ScalarT],
+    R: onp.ToArrayND[ScalarT, ScalarT],
+    u: onp.ToArrayND[ScalarT, ScalarT],
+    v: onp.ToArrayND[ScalarT, ScalarT],
     overwrite_qruv: bool = False,
     check_finite: bool = True,
-) -> _QR[np.float32]: ...
-@overload  # float64 -> float64
+) -> _QR[ScalarT]: ...
+@overload  # ~f64
 def qr_update(
     Q: onp.ToJustFloat64_ND,
     R: onp.ToJustFloat64_ND,
@@ -121,16 +98,7 @@ def qr_update(
     overwrite_qruv: bool = False,
     check_finite: bool = True,
 ) -> _QR[np.float64]: ...
-@overload  # complex64 -> complex64
-def qr_update(
-    Q: onp.ToArrayND[np.complex64, np.complex64],
-    R: onp.ToArrayND[np.complex64, np.complex64],
-    u: onp.ToArrayND[np.complex64, np.complex64],
-    v: onp.ToArrayND[np.complex64, np.complex64],
-    overwrite_qruv: bool = False,
-    check_finite: bool = True,
-) -> _QR[np.complex64]: ...
-@overload  # complex128 -> complex128
+@overload  # ~c128
 def qr_update(
     Q: onp.ToJustComplex128_ND,
     R: onp.ToJustComplex128_ND,

--- a/scipy-stubs/linalg/_decomp_update.pyi
+++ b/scipy-stubs/linalg/_decomp_update.pyi
@@ -1,3 +1,5 @@
+# NOTE: mypy incorrectly sees disjoint dtypes as overlapping
+# mypy: disable-error-code=overload-overlap
 from typing import Literal, overload
 
 import numpy as np

--- a/scipy-stubs/linalg/_decomp_update.pyi
+++ b/scipy-stubs/linalg/_decomp_update.pyi
@@ -54,7 +54,7 @@ def qr_delete(
     which: _Which = "row",
     overwrite_qr: bool = False,
     check_finite: bool = True,
-) -> _QR[npc.inexact]: ...
+) -> _QR[Any]: ...
 
 #
 @overload  # ~f32 | ~c64

--- a/scipy-stubs/linalg/_decomp_update.pyi
+++ b/scipy-stubs/linalg/_decomp_update.pyi
@@ -1,6 +1,6 @@
 # NOTE: mypy incorrectly sees disjoint dtypes as overlapping on numpy<2.5
 # mypy: disable-error-code=overload-overlap
-from typing import Literal, overload
+from typing import Any, Literal, overload
 
 import numpy as np
 import optype.numpy as onp

--- a/scipy-stubs/linalg/_decomp_update.pyi
+++ b/scipy-stubs/linalg/_decomp_update.pyi
@@ -1,3 +1,5 @@
+# NOTE: mypy incorrectly sees disjoint dtypes as overlapping
+# mypy: disable-error-code=overload-overlap
 from typing import Literal, overload
 
 import numpy as np
@@ -7,77 +9,141 @@ __all__ = ["qr_delete", "qr_insert", "qr_update"]
 
 ###
 
-type _FloatND = onp.ArrayND[np.float32 | np.float64]
-type _FloatQR = tuple[_FloatND, _FloatND]
-
-type _ComplexND = onp.ArrayND[np.complex64 | np.complex128]
-type _ComplexQR = _FloatQR | tuple[_ComplexND, _ComplexND]
+type _QR32 = tuple[onp.ArrayND[np.float32], onp.ArrayND[np.float32]]
+type _QR64 = tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64]]
+type _QRc64 = tuple[onp.ArrayND[np.complex64], onp.ArrayND[np.complex64]]
+type _QRc128 = tuple[onp.ArrayND[np.complex128], onp.ArrayND[np.complex128]]
 
 type _Which = Literal["row", "col"]
 
 ###
+# qr_delete
 
 @overload
 def qr_delete(
-    Q: onp.ToFloatND,
-    R: onp.ToFloatND,
+    Q: onp.ToJustFloat32_ND,
+    R: onp.ToJustFloat32_ND,
     k: onp.ToJustInt,
     p: onp.ToJustInt = 1,
     which: _Which = "row",
     overwrite_qr: bool = False,
     check_finite: bool = True,
-) -> _FloatQR: ...
+) -> _QR32: ...
 @overload
 def qr_delete(
-    Q: onp.ToComplexND,
-    R: onp.ToComplexND,
+    Q: onp.ToJustFloat64_ND,
+    R: onp.ToJustFloat64_ND,
     k: onp.ToJustInt,
     p: onp.ToJustInt = 1,
     which: _Which = "row",
     overwrite_qr: bool = False,
     check_finite: bool = True,
-) -> _ComplexQR: ...
+) -> _QR64: ...
+@overload
+def qr_delete(
+    Q: onp.ToJustComplex64_ND,
+    R: onp.ToJustComplex64_ND,
+    k: onp.ToJustInt,
+    p: onp.ToJustInt = 1,
+    which: _Which = "row",
+    overwrite_qr: bool = False,
+    check_finite: bool = True,
+) -> _QRc64: ...
+@overload
+def qr_delete(
+    Q: onp.ToJustComplex128_ND,
+    R: onp.ToJustComplex128_ND,
+    k: onp.ToJustInt,
+    p: onp.ToJustInt = 1,
+    which: _Which = "row",
+    overwrite_qr: bool = False,
+    check_finite: bool = True,
+) -> _QRc128: ...
 
-#
+###
+# qr_insert
+
 @overload
 def qr_insert(
-    Q: onp.ToFloatND,
-    R: onp.ToFloatND,
-    u: onp.ToFloatND,
+    Q: onp.ToJustFloat32_ND,
+    R: onp.ToJustFloat32_ND,
+    u: onp.ToJustFloat32_ND,
     k: onp.ToJustInt,
     which: _Which = "row",
     rcond: onp.ToFloat | None = None,
     overwrite_qru: bool = False,
     check_finite: bool = True,
-) -> _FloatQR: ...
+) -> _QR32: ...
 @overload
 def qr_insert(
-    Q: onp.ToComplexND,
-    R: onp.ToComplexND,
-    u: onp.ToComplexND,
+    Q: onp.ToJustFloat64_ND,
+    R: onp.ToJustFloat64_ND,
+    u: onp.ToJustFloat64_ND,
     k: onp.ToJustInt,
     which: _Which = "row",
     rcond: onp.ToFloat | None = None,
     overwrite_qru: bool = False,
     check_finite: bool = True,
-) -> _ComplexQR: ...
+) -> _QR64: ...
+@overload
+def qr_insert(
+    Q: onp.ToJustComplex64_ND,
+    R: onp.ToJustComplex64_ND,
+    u: onp.ToJustComplex64_ND,
+    k: onp.ToJustInt,
+    which: _Which = "row",
+    rcond: onp.ToFloat | None = None,
+    overwrite_qru: bool = False,
+    check_finite: bool = True,
+) -> _QRc64: ...
+@overload
+def qr_insert(
+    Q: onp.ToJustComplex128_ND,
+    R: onp.ToJustComplex128_ND,
+    u: onp.ToJustComplex128_ND,
+    k: onp.ToJustInt,
+    which: _Which = "row",
+    rcond: onp.ToFloat | None = None,
+    overwrite_qru: bool = False,
+    check_finite: bool = True,
+) -> _QRc128: ...
 
-#
+###
+# qr_update
+
 @overload
 def qr_update(
-    Q: onp.ToFloatND,
-    R: onp.ToFloatND,
-    u: onp.ToFloatND,
-    v: onp.ToFloatND,
+    Q: onp.ToJustFloat32_ND,
+    R: onp.ToJustFloat32_ND,
+    u: onp.ToJustFloat32_ND,
+    v: onp.ToJustFloat32_ND,
     overwrite_qruv: bool = False,
     check_finite: bool = True,
-) -> _FloatQR: ...
+) -> _QR32: ...
 @overload
 def qr_update(
-    Q: onp.ToComplexND,
-    R: onp.ToComplexND,
-    u: onp.ToComplexND,
-    v: onp.ToComplexND,
+    Q: onp.ToJustFloat64_ND,
+    R: onp.ToJustFloat64_ND,
+    u: onp.ToJustFloat64_ND,
+    v: onp.ToJustFloat64_ND,
     overwrite_qruv: bool = False,
     check_finite: bool = True,
-) -> _ComplexQR: ...
+) -> _QR64: ...
+@overload
+def qr_update(
+    Q: onp.ToJustComplex64_ND,
+    R: onp.ToJustComplex64_ND,
+    u: onp.ToJustComplex64_ND,
+    v: onp.ToJustComplex64_ND,
+    overwrite_qruv: bool = False,
+    check_finite: bool = True,
+) -> _QRc64: ...
+@overload
+def qr_update(
+    Q: onp.ToJustComplex128_ND,
+    R: onp.ToJustComplex128_ND,
+    u: onp.ToJustComplex128_ND,
+    v: onp.ToJustComplex128_ND,
+    overwrite_qruv: bool = False,
+    check_finite: bool = True,
+) -> _QRc128: ...

--- a/scipy-stubs/linalg/_decomp_update.pyi
+++ b/scipy-stubs/linalg/_decomp_update.pyi
@@ -1,6 +1,4 @@
-# NOTE: mypy incorrectly sees disjoint dtypes as overlapping
-# mypy: disable-error-code=overload-overlap
-from typing import Literal, overload
+from typing import Literal
 
 import numpy as np
 import optype.numpy as onp
@@ -9,141 +7,36 @@ __all__ = ["qr_delete", "qr_insert", "qr_update"]
 
 ###
 
-type _QR32 = tuple[onp.ArrayND[np.float32], onp.ArrayND[np.float32]]
-type _QR64 = tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64]]
-type _QRc64 = tuple[onp.ArrayND[np.complex64], onp.ArrayND[np.complex64]]
-type _QRc128 = tuple[onp.ArrayND[np.complex128], onp.ArrayND[np.complex128]]
-
+type _Inexact = np.float32 | np.float64 | np.complex64 | np.complex128
+type _QR[SCT: _Inexact] = tuple[onp.ArrayND[SCT], onp.ArrayND[SCT]]
 type _Which = Literal["row", "col"]
 
 ###
-# qr_delete
 
-@overload
-def qr_delete(
-    Q: onp.ToJustFloat32_ND,
-    R: onp.ToJustFloat32_ND,
+def qr_delete[SCT: _Inexact](
+    Q: onp.ArrayND[SCT],
+    R: onp.ArrayND[SCT],
     k: onp.ToJustInt,
     p: onp.ToJustInt = 1,
     which: _Which = "row",
     overwrite_qr: bool = False,
     check_finite: bool = True,
-) -> _QR32: ...
-@overload
-def qr_delete(
-    Q: onp.ToJustFloat64_ND,
-    R: onp.ToJustFloat64_ND,
-    k: onp.ToJustInt,
-    p: onp.ToJustInt = 1,
-    which: _Which = "row",
-    overwrite_qr: bool = False,
-    check_finite: bool = True,
-) -> _QR64: ...
-@overload
-def qr_delete(
-    Q: onp.ToJustComplex64_ND,
-    R: onp.ToJustComplex64_ND,
-    k: onp.ToJustInt,
-    p: onp.ToJustInt = 1,
-    which: _Which = "row",
-    overwrite_qr: bool = False,
-    check_finite: bool = True,
-) -> _QRc64: ...
-@overload
-def qr_delete(
-    Q: onp.ToJustComplex128_ND,
-    R: onp.ToJustComplex128_ND,
-    k: onp.ToJustInt,
-    p: onp.ToJustInt = 1,
-    which: _Which = "row",
-    overwrite_qr: bool = False,
-    check_finite: bool = True,
-) -> _QRc128: ...
-
-###
-# qr_insert
-
-@overload
-def qr_insert(
-    Q: onp.ToJustFloat32_ND,
-    R: onp.ToJustFloat32_ND,
-    u: onp.ToJustFloat32_ND,
+) -> _QR[SCT]: ...
+def qr_insert[SCT: _Inexact](
+    Q: onp.ArrayND[SCT],
+    R: onp.ArrayND[SCT],
+    u: onp.ArrayND[SCT],
     k: onp.ToJustInt,
     which: _Which = "row",
     rcond: onp.ToFloat | None = None,
     overwrite_qru: bool = False,
     check_finite: bool = True,
-) -> _QR32: ...
-@overload
-def qr_insert(
-    Q: onp.ToJustFloat64_ND,
-    R: onp.ToJustFloat64_ND,
-    u: onp.ToJustFloat64_ND,
-    k: onp.ToJustInt,
-    which: _Which = "row",
-    rcond: onp.ToFloat | None = None,
-    overwrite_qru: bool = False,
-    check_finite: bool = True,
-) -> _QR64: ...
-@overload
-def qr_insert(
-    Q: onp.ToJustComplex64_ND,
-    R: onp.ToJustComplex64_ND,
-    u: onp.ToJustComplex64_ND,
-    k: onp.ToJustInt,
-    which: _Which = "row",
-    rcond: onp.ToFloat | None = None,
-    overwrite_qru: bool = False,
-    check_finite: bool = True,
-) -> _QRc64: ...
-@overload
-def qr_insert(
-    Q: onp.ToJustComplex128_ND,
-    R: onp.ToJustComplex128_ND,
-    u: onp.ToJustComplex128_ND,
-    k: onp.ToJustInt,
-    which: _Which = "row",
-    rcond: onp.ToFloat | None = None,
-    overwrite_qru: bool = False,
-    check_finite: bool = True,
-) -> _QRc128: ...
-
-###
-# qr_update
-
-@overload
-def qr_update(
-    Q: onp.ToJustFloat32_ND,
-    R: onp.ToJustFloat32_ND,
-    u: onp.ToJustFloat32_ND,
-    v: onp.ToJustFloat32_ND,
+) -> _QR[SCT]: ...
+def qr_update[SCT: _Inexact](
+    Q: onp.ArrayND[SCT],
+    R: onp.ArrayND[SCT],
+    u: onp.ArrayND[SCT],
+    v: onp.ArrayND[SCT],
     overwrite_qruv: bool = False,
     check_finite: bool = True,
-) -> _QR32: ...
-@overload
-def qr_update(
-    Q: onp.ToJustFloat64_ND,
-    R: onp.ToJustFloat64_ND,
-    u: onp.ToJustFloat64_ND,
-    v: onp.ToJustFloat64_ND,
-    overwrite_qruv: bool = False,
-    check_finite: bool = True,
-) -> _QR64: ...
-@overload
-def qr_update(
-    Q: onp.ToJustComplex64_ND,
-    R: onp.ToJustComplex64_ND,
-    u: onp.ToJustComplex64_ND,
-    v: onp.ToJustComplex64_ND,
-    overwrite_qruv: bool = False,
-    check_finite: bool = True,
-) -> _QRc64: ...
-@overload
-def qr_update(
-    Q: onp.ToJustComplex128_ND,
-    R: onp.ToJustComplex128_ND,
-    u: onp.ToJustComplex128_ND,
-    v: onp.ToJustComplex128_ND,
-    overwrite_qruv: bool = False,
-    check_finite: bool = True,
-) -> _QRc128: ...
+) -> _QR[SCT]: ...

--- a/scipy-stubs/linalg/_decomp_update.pyi
+++ b/scipy-stubs/linalg/_decomp_update.pyi
@@ -1,4 +1,4 @@
-# NOTE: mypy incorrectly sees disjoint dtypes as overlapping
+# NOTE: mypy incorrectly sees disjoint dtypes as overlapping on numpy<2.5
 # mypy: disable-error-code=overload-overlap
 from typing import Literal, overload
 

--- a/scipy-stubs/linalg/_decomp_update.pyi
+++ b/scipy-stubs/linalg/_decomp_update.pyi
@@ -100,7 +100,7 @@ def qr_insert(
     rcond: onp.ToFloat | None = None,
     overwrite_qru: bool = False,
     check_finite: bool = True,
-) -> _QR[npc.inexact]: ...
+) -> _QR[Any]: ...
 
 #
 @overload  # ~f32 | ~c64
@@ -138,4 +138,4 @@ def qr_update(
     v: onp.ToArrayND[complex, npc.inexact],
     overwrite_qruv: bool = False,
     check_finite: bool = True,
-) -> _QR[npc.inexact]: ...
+) -> _QR[Any]: ...

--- a/tests/linalg/test__decomp_update.pyi
+++ b/tests/linalg/test__decomp_update.pyi
@@ -16,7 +16,7 @@ c64_nd: onp.ArrayND[np.complex64]
 c128_nd: onp.ArrayND[np.complex128]
 
 py_float_2d: list[list[float]]
-py_complex_2d: list[list[op.JustComplex]]
+py_complex_2d: list[list[complex]]
 
 type _QR32 = tuple[onp.ArrayND[np.float32], onp.ArrayND[np.float32]]
 type _QR64 = tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64]]

--- a/tests/linalg/test__decomp_update.pyi
+++ b/tests/linalg/test__decomp_update.pyi
@@ -25,29 +25,29 @@ type _QRc128 = tuple[onp.ArrayND[np.complex128], onp.ArrayND[np.complex128]]
 ###
 # qr_delete
 
-assert_type(qr_delete(f32_nd, f32_nd, 0), _QR32)
-assert_type(qr_delete(f64_nd, f64_nd, 0), _QR64)
+assert_type(qr_delete(f32_nd, f32_nd, 0), _QRf32)
+assert_type(qr_delete(f64_nd, f64_nd, 0), _QRf64)
 assert_type(qr_delete(c64_nd, c64_nd, 0), _QRc64)
 assert_type(qr_delete(c128_nd, c128_nd, 0), _QRc128)
-assert_type(qr_delete(py_float_2d, py_float_2d, 0), _QR64)
+assert_type(qr_delete(py_float_2d, py_float_2d, 0), _QRf64)
 assert_type(qr_delete(py_complex_2d, py_complex_2d, 0), _QRc128)
 
 ###
 # qr_insert
 
-assert_type(qr_insert(f32_nd, f32_nd, f32_nd, 0), _QR32)
-assert_type(qr_insert(f64_nd, f64_nd, f64_nd, 0), _QR64)
+assert_type(qr_insert(f32_nd, f32_nd, f32_nd, 0), _QRf32)
+assert_type(qr_insert(f64_nd, f64_nd, f64_nd, 0), _QRf64)
 assert_type(qr_insert(c64_nd, c64_nd, c64_nd, 0), _QRc64)
 assert_type(qr_insert(c128_nd, c128_nd, c128_nd, 0), _QRc128)
-assert_type(qr_insert(py_float_2d, py_float_2d, py_float_2d, 0), _QR64)
+assert_type(qr_insert(py_float_2d, py_float_2d, py_float_2d, 0), _QRf64)
 assert_type(qr_insert(py_complex_2d, py_complex_2d, py_complex_2d, 0), _QRc128)
 
 ###
 # qr_update
 
-assert_type(qr_update(f32_nd, f32_nd, f32_nd, f32_nd), _QR32)
-assert_type(qr_update(f64_nd, f64_nd, f64_nd, f64_nd), _QR64)
+assert_type(qr_update(f32_nd, f32_nd, f32_nd, f32_nd), _QRf32)
+assert_type(qr_update(f64_nd, f64_nd, f64_nd, f64_nd), _QRf64)
 assert_type(qr_update(c64_nd, c64_nd, c64_nd, c64_nd), _QRc64)
 assert_type(qr_update(c128_nd, c128_nd, c128_nd, c128_nd), _QRc128)
-assert_type(qr_update(py_float_2d, py_float_2d, py_float_2d, py_float_2d), _QR64)
+assert_type(qr_update(py_float_2d, py_float_2d, py_float_2d, py_float_2d), _QRf64)
 assert_type(qr_update(py_complex_2d, py_complex_2d, py_complex_2d, py_complex_2d), _QRc128)

--- a/tests/linalg/test__decomp_update.pyi
+++ b/tests/linalg/test__decomp_update.pyi
@@ -3,7 +3,6 @@
 from typing import assert_type
 
 import numpy as np
-import optype as op
 import optype.numpy as onp
 
 from scipy.linalg import qr_delete, qr_insert, qr_update

--- a/tests/linalg/test__decomp_update.pyi
+++ b/tests/linalg/test__decomp_update.pyi
@@ -9,29 +9,36 @@ from scipy.linalg import qr_delete, qr_insert, qr_update
 
 ###
 
+f32_nd: onp.ArrayND[np.float32]
 f64_nd: onp.ArrayND[np.float64]
+c64_nd: onp.ArrayND[np.complex64]
 c128_nd: onp.ArrayND[np.complex128]
 
-type _FloatQR = tuple[onp.ArrayND[np.float32 | np.float64], onp.ArrayND[np.float32 | np.float64]]
-type _ComplexQR = (
-    tuple[onp.ArrayND[np.float32 | np.float64], onp.ArrayND[np.float32 | np.float64]]
-    | tuple[onp.ArrayND[np.complex64 | np.complex128], onp.ArrayND[np.complex64 | np.complex128]]
-)
+type _QR32 = tuple[onp.ArrayND[np.float32], onp.ArrayND[np.float32]]
+type _QR64 = tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64]]
+type _QRc64 = tuple[onp.ArrayND[np.complex64], onp.ArrayND[np.complex64]]
+type _QRc128 = tuple[onp.ArrayND[np.complex128], onp.ArrayND[np.complex128]]
 
 ###
 # qr_delete
 
-assert_type(qr_delete(f64_nd, f64_nd, 0), _FloatQR)
-assert_type(qr_delete(c128_nd, c128_nd, 0), _ComplexQR)
+assert_type(qr_delete(f32_nd, f32_nd, 0), _QR32)
+assert_type(qr_delete(f64_nd, f64_nd, 0), _QR64)
+assert_type(qr_delete(c64_nd, c64_nd, 0), _QRc64)
+assert_type(qr_delete(c128_nd, c128_nd, 0), _QRc128)
 
 ###
 # qr_insert
 
-assert_type(qr_insert(f64_nd, f64_nd, f64_nd, 0), _FloatQR)
-assert_type(qr_insert(c128_nd, c128_nd, c128_nd, 0), _ComplexQR)
+assert_type(qr_insert(f32_nd, f32_nd, f32_nd, 0), _QR32)
+assert_type(qr_insert(f64_nd, f64_nd, f64_nd, 0), _QR64)
+assert_type(qr_insert(c64_nd, c64_nd, c64_nd, 0), _QRc64)
+assert_type(qr_insert(c128_nd, c128_nd, c128_nd, 0), _QRc128)
 
 ###
 # qr_update
 
-assert_type(qr_update(f64_nd, f64_nd, f64_nd, f64_nd), _FloatQR)
-assert_type(qr_update(c128_nd, c128_nd, c128_nd, c128_nd), _ComplexQR)
+assert_type(qr_update(f32_nd, f32_nd, f32_nd, f32_nd), _QR32)
+assert_type(qr_update(f64_nd, f64_nd, f64_nd, f64_nd), _QR64)
+assert_type(qr_update(c64_nd, c64_nd, c64_nd, c64_nd), _QRc64)
+assert_type(qr_update(c128_nd, c128_nd, c128_nd, c128_nd), _QRc128)

--- a/tests/linalg/test__decomp_update.pyi
+++ b/tests/linalg/test__decomp_update.pyi
@@ -17,8 +17,8 @@ c128_nd: onp.ArrayND[np.complex128]
 py_float_2d: list[list[float]]
 py_complex_2d: list[list[complex]]
 
-type _QR32 = tuple[onp.ArrayND[np.float32], onp.ArrayND[np.float32]]
-type _QR64 = tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64]]
+type _QRf32 = tuple[onp.ArrayND[np.float32], onp.ArrayND[np.float32]]
+type _QRf64 = tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64]]
 type _QRc64 = tuple[onp.ArrayND[np.complex64], onp.ArrayND[np.complex64]]
 type _QRc128 = tuple[onp.ArrayND[np.complex128], onp.ArrayND[np.complex128]]
 

--- a/tests/linalg/test__decomp_update.pyi
+++ b/tests/linalg/test__decomp_update.pyi
@@ -3,6 +3,7 @@
 from typing import assert_type
 
 import numpy as np
+import optype as op
 import optype.numpy as onp
 
 from scipy.linalg import qr_delete, qr_insert, qr_update
@@ -13,6 +14,9 @@ f32_nd: onp.ArrayND[np.float32]
 f64_nd: onp.ArrayND[np.float64]
 c64_nd: onp.ArrayND[np.complex64]
 c128_nd: onp.ArrayND[np.complex128]
+
+py_float_2d: list[list[float]]
+py_complex_2d: list[list[op.JustComplex]]
 
 type _QR32 = tuple[onp.ArrayND[np.float32], onp.ArrayND[np.float32]]
 type _QR64 = tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64]]
@@ -26,6 +30,8 @@ assert_type(qr_delete(f32_nd, f32_nd, 0), _QR32)
 assert_type(qr_delete(f64_nd, f64_nd, 0), _QR64)
 assert_type(qr_delete(c64_nd, c64_nd, 0), _QRc64)
 assert_type(qr_delete(c128_nd, c128_nd, 0), _QRc128)
+assert_type(qr_delete(py_float_2d, py_float_2d, 0), _QR64)
+assert_type(qr_delete(py_complex_2d, py_complex_2d, 0), _QRc128)
 
 ###
 # qr_insert
@@ -34,6 +40,8 @@ assert_type(qr_insert(f32_nd, f32_nd, f32_nd, 0), _QR32)
 assert_type(qr_insert(f64_nd, f64_nd, f64_nd, 0), _QR64)
 assert_type(qr_insert(c64_nd, c64_nd, c64_nd, 0), _QRc64)
 assert_type(qr_insert(c128_nd, c128_nd, c128_nd, 0), _QRc128)
+assert_type(qr_insert(py_float_2d, py_float_2d, py_float_2d, 0), _QR64)
+assert_type(qr_insert(py_complex_2d, py_complex_2d, py_complex_2d, 0), _QRc128)
 
 ###
 # qr_update
@@ -42,3 +50,5 @@ assert_type(qr_update(f32_nd, f32_nd, f32_nd, f32_nd), _QR32)
 assert_type(qr_update(f64_nd, f64_nd, f64_nd, f64_nd), _QR64)
 assert_type(qr_update(c64_nd, c64_nd, c64_nd, c64_nd), _QRc64)
 assert_type(qr_update(c128_nd, c128_nd, c128_nd, c128_nd), _QRc128)
+assert_type(qr_update(py_float_2d, py_float_2d, py_float_2d, py_float_2d), _QR64)
+assert_type(qr_update(py_complex_2d, py_complex_2d, py_complex_2d, py_complex_2d), _QRc128)


### PR DESCRIPTION
Fixes #1325 

In this PR we have added overlaods for `qr_delete`, `qr_insert`, `qr_update` as per supported dtypes

- float32 -> float32
- float64 -> float 64
- complex64 -> complex64
- complex128 -> complex128

combined to single generic type as they all share same structure

