### PR TITLE
✨ `stats.mstats.tvar`: improved input signature and return type

### DIFF
--- a/scipy-stubs/stats/_mstats_basic.pyi
+++ b/scipy-stubs/stats/_mstats_basic.pyi
@@ -1517,13 +1517,22 @@ def tmean[InexactT: npc.inexact80 | np.float16](
 ) -> onp.MArray[InexactT] | Any: ...
 
 #
+@overload  # limits=None (default), requires a mask
 def tvar(
-    a: onp.MArray[npc.floating | npc.integer],
-    limits: tuple[onp.ToFloat, onp.ToFloat] | None = None,
+    a: onp.MArray[npc.number | np.bool],
+    limits: None = None,
     inclusive: tuple[bool, bool] = (True, True),
     axis: SupportsIndex | None = 0,
     ddof: onp.ToInt = 1,
-) -> _MArrayOrND[npc.floating]: ...
+) -> np.float64: ...
+@overload  # limits=<given>
+def tvar(
+    a: onp.ArrayND[npc.number | np.bool],
+    limits: tuple[onp.ToFloat | None, onp.ToFloat | None],
+    inclusive: tuple[bool, bool] = (True, True),
+    axis: SupportsIndex | None = 0,
+    ddof: onp.ToInt = 1,
+) -> np.float64: ...
 
 #
 @overload

--- a/tests/stats/test_mstats.pyi
+++ b/tests/stats/test_mstats.pyi
@@ -58,6 +58,7 @@ from scipy.stats.mstats import (
     ttest_1samp,
     ttest_ind,
     ttest_rel,
+    tvar,
     variation,
     winsorize,
 )
@@ -444,7 +445,9 @@ assert_type(tmean(_f32_3d, axis=0), onp.MArray[np.float64] | Any)
 assert_type(tmean(_f64_nd, (0.0, 1.0), (True, True), 0), onp.MArray[np.float64] | Any)
 
 # tvar
-# TODO
+assert_type(tvar(_m_f32_nd), np.float64)
+assert_type(tvar(_c128_2d, (2.0, 18.0)), np.float64)
+assert_type(tvar(_i8_nd, (None, 18.0)), np.float64)
 
 # tmin
 assert_type(tmin(_py_i_1d), np.int_ | onp.MArray[np.int_])


### PR DESCRIPTION
towards #1146