### PR TITLE
✨ `stats.mstats.{trima,trimr}`: improve shape-typing and return dtypes

### DIFF
--- a/scipy-stubs/stats/_mstats_basic.pyi
+++ b/scipy-stubs/stats/_mstats_basic.pyi
@@ -98,6 +98,7 @@ type _ToJustF64 = np.float64 | np.float32 | np.float16
 
 type _ToLimits = onp.ToJustFloat64 | onp.ToFloat1D | tuple[onp.ToFloat | None, onp.ToFloat | None] | None
 type _ToInclusive = tuple[op.CanBool, op.CanBool]
+type _ToMinMax = tuple[onp.ToComplex | None, onp.ToComplex | None] | None
 
 type _JustAnyShape = tuple[Never, Never, Never, Never]  # workaround for https://github.com/microsoft/pyright/issues/10232
 type _ToFloatStrictND = onp.ArrayND[npc.floating | npc.integer | np.bool, _JustAnyShape]
@@ -695,28 +696,38 @@ def kstest(
 ) -> _KstestResultAny: ...
 
 #
-@overload
+@overload  # 1d bool
+def trima(a: list[bool], limits: _ToMinMax = None, inclusive: _ToInclusive = (True, True)) -> onp.MArray1D[np.bool]: ...
+@overload  # ?d bool
 def trima(
-    a: onp.SequenceND[bool], limits: tuple[onp.ToInt, onp.ToInt] | None = None, inclusive: tuple[bool, bool] = (True, True)
+    a: onp.SequenceND[list[bool]], limits: _ToMinMax = None, inclusive: _ToInclusive = (True, True)
 ) -> onp.MArray[np.bool]: ...
-@overload
+@overload  # 1d ~int
+def trima(a: list[int], limits: _ToMinMax = None, inclusive: _ToInclusive = (True, True)) -> onp.MArray1D[np.int_]: ...
+@overload  # ?d ~int
 def trima(
-    a: onp.SequenceND[op.JustInt], limits: tuple[onp.ToInt, onp.ToInt] | None = None, inclusive: tuple[bool, bool] = (True, True)
+    a: onp.SequenceND[list[int]], limits: _ToMinMax = None, inclusive: _ToInclusive = (True, True)
 ) -> onp.MArray[np.int_]: ...
-@overload
+@overload  # 1d ~float
+def trima(a: list[float], limits: _ToMinMax = None, inclusive: _ToInclusive = (True, True)) -> onp.MArray1D[np.float64]: ...
+@overload  # ?d ~float
 def trima(
-    a: onp.SequenceND[float], limits: tuple[onp.ToFloat, onp.ToFloat] | None = None, inclusive: tuple[bool, bool] = (True, True)
-) -> onp.MArray[np.float64 | np.int_ | np.bool]: ...
-@overload
+    a: onp.SequenceND[list[float]], limits: _ToMinMax = None, inclusive: _ToInclusive = (True, True)
+) -> onp.MArray[np.float64]: ...
+@overload  # 1d ~complex
+def trima(a: list[complex], limits: _ToMinMax = None, inclusive: _ToInclusive = (True, True)) -> onp.MArray1D[np.complex128]: ...
+@overload  # ?d ~complex
 def trima(
-    a: onp.SequenceND[complex],
-    limits: tuple[onp.ToComplex, onp.ToComplex] | None = None,
-    inclusive: tuple[bool, bool] = (True, True),
-) -> onp.MArray[np.complex128 | np.float64 | np.int_ | np.bool]: ...
-@overload
+    a: onp.SequenceND[list[complex]], limits: _ToMinMax = None, inclusive: _ToInclusive = (True, True)
+) -> onp.MArray[np.complex128]: ...
+@overload  # ?d T@+number
+def trima[ShapeT: tuple[int, ...], ScalarT: npc.number | np.bool](
+    a: onp.ArrayND[ScalarT, ShapeT], limits: _ToMinMax = None, inclusive: _ToInclusive = (True, True)
+) -> onp.MArray[ScalarT, ShapeT]: ...
+@overload  # Nd T@+number
 def trima[ScalarT: npc.number | np.bool](
-    a: _ArrayLike[ScalarT], limits: tuple[onp.ToComplex, onp.ToComplex] | None = None, inclusive: tuple[bool, bool] = (True, True)
-) -> onp.MArray[ScalarT]: ...
+    a: onp.ToArrayND[ScalarT, ScalarT], limits: _ToMinMax = None, inclusive: _ToInclusive = (True, True)
+) -> onp.MArray[ScalarT, _WorkaroundForPyright]: ...
 
 #
 @overload

--- a/scipy-stubs/stats/_mstats_basic.pyi
+++ b/scipy-stubs/stats/_mstats_basic.pyi
@@ -730,34 +730,64 @@ def trima[ScalarT: npc.number | np.bool](
 ) -> onp.MArray[ScalarT, _WorkaroundForPyright]: ...
 
 #
-@overload
+@overload  # 1d bool
 def trimr(
-    a: onp.SequenceND[op.JustInt | np.int_],
-    limits: tuple[onp.ToFloat, onp.ToFloat] | None = None,
-    inclusive: tuple[bool, bool] = (True, True),
+    a: list[bool], limits: _ToMinMax = None, inclusive: _ToInclusive = (True, True), axis: SupportsIndex | None = None
+) -> onp.MArray1D[np.bool]: ...
+@overload  # ?d bool
+def trimr(
+    a: onp.SequenceND[list[bool]],
+    limits: _ToMinMax = None,
+    inclusive: _ToInclusive = (True, True),
+    axis: SupportsIndex | None = None,
+) -> onp.MArray[np.bool]: ...
+@overload  # 1d ~int
+def trimr(
+    a: list[int], limits: _ToMinMax = None, inclusive: _ToInclusive = (True, True), axis: SupportsIndex | None = None
+) -> onp.MArray1D[np.int_]: ...
+@overload  # ?d ~int
+def trimr(
+    a: onp.SequenceND[list[int]],
+    limits: _ToMinMax = None,
+    inclusive: _ToInclusive = (True, True),
     axis: SupportsIndex | None = None,
 ) -> onp.MArray[np.int_]: ...
-@overload
+@overload  # 1d ~float
 def trimr(
-    a: onp.SequenceND[float],
-    limits: tuple[onp.ToFloat, onp.ToFloat] | None = None,
-    inclusive: tuple[bool, bool] = (True, True),
-    axis: SupportsIndex | None = None,
-) -> onp.MArray[np.float64 | np.int_]: ...
-@overload
+    a: list[float], limits: _ToMinMax = None, inclusive: _ToInclusive = (True, True), axis: SupportsIndex | None = None
+) -> onp.MArray1D[np.float64]: ...
+@overload  # ?d ~float
 def trimr(
-    a: onp.SequenceND[complex],
-    limits: tuple[onp.ToComplex, onp.ToComplex] | None = None,
-    inclusive: tuple[bool, bool] = (True, True),
+    a: onp.SequenceND[list[float]],
+    limits: _ToMinMax = None,
+    inclusive: _ToInclusive = (True, True),
     axis: SupportsIndex | None = None,
-) -> onp.MArray[np.complex128 | np.float64 | np.int_]: ...
-@overload
+) -> onp.MArray[np.float64]: ...
+@overload  # 1d ~complex
+def trimr(
+    a: list[complex], limits: _ToMinMax = None, inclusive: _ToInclusive = (True, True), axis: SupportsIndex | None = None
+) -> onp.MArray1D[np.complex128]: ...
+@overload  # ?d ~complex
+def trimr(
+    a: onp.SequenceND[list[complex]],
+    limits: _ToMinMax = None,
+    inclusive: _ToInclusive = (True, True),
+    axis: SupportsIndex | None = None,
+) -> onp.MArray[np.complex128]: ...
+@overload  # ?d T@+number
+def trimr[ShapeT: tuple[int, ...], ScalarT: npc.number | np.bool](
+    a: onp.ArrayND[ScalarT, ShapeT],
+    limits: _ToMinMax = None,
+    inclusive: _ToInclusive = (True, True),
+    axis: SupportsIndex | None = None,
+) -> onp.MArray[ScalarT, ShapeT]: ...
+@overload  # Nd T@+number
 def trimr[ScalarT: npc.number | np.bool](
-    a: _ArrayLike[ScalarT],
-    limits: tuple[onp.ToComplex, onp.ToComplex] | None = None,
-    inclusive: tuple[bool, bool] = (True, True),
+    a: onp.ToArrayND[ScalarT, ScalarT],
+    limits: _ToMinMax = None,
+    inclusive: _ToInclusive = (True, True),
     axis: SupportsIndex | None = None,
-) -> onp.MArray[ScalarT]: ...
+) -> onp.MArray[ScalarT, _WorkaroundForPyright]: ...
 
 #
 @overload  # 1d bool

--- a/tests/stats/test_mstats.pyi
+++ b/tests/stats/test_mstats.pyi
@@ -55,6 +55,7 @@ from scipy.stats.mstats import (
     trimmed_std,
     trimmed_stde,
     trimmed_var,
+    trimr,
     trimtail,
     tsem,
     ttest_1samp,
@@ -285,7 +286,12 @@ assert_type(trima(_i8_3d, (2, 18)), onp.MArray3D[np.int8])
 assert_type(trima(_c160_2d, (None, 18)), onp.MArray2D[np.complex256])
 
 # trimr
-# TODO
+assert_type(trimr(_py_b_1d), onp.MArray1D[np.bool])
+assert_type(trimr(_py_i_2d, (0.1, 0.2)), onp.MArray[np.int_])
+assert_type(trimr(_py_f_1d), onp.MArray1D[np.float64])
+assert_type(trimr(_py_c_2d), onp.MArray[np.complex128])
+assert_type(trimr(_f32_3d, (0.1, 0.2), axis=1), onp.MArray3D[np.float32])
+assert_type(trimr(_c160_2d, (None, 0.2)), onp.MArray2D[np.complex256])
 
 # trim
 assert_type(trim(_py_b_1d), onp.MArray1D[np.bool])

--- a/tests/stats/test_mstats.pyi
+++ b/tests/stats/test_mstats.pyi
@@ -48,6 +48,7 @@ from scipy.stats.mstats import (
     tmean,
     tmin,
     trim,
+    trima,
     trimboth,
     trimmed_mean,
     trimmed_mean_ci,
@@ -276,7 +277,12 @@ assert_type(kstest(_f64_1d, _cdf2, (1.0,)).statistic, np.float64)
 assert_type(kstest(_f64_2d, _cdf2, (1.0,)).statistic, onp.Array1D[np.float64])
 
 # trima
-# TODO
+assert_type(trima(_py_b_1d), onp.MArray1D[np.bool])
+assert_type(trima(_py_i_2d, (2, 18)), onp.MArray[np.int_])
+assert_type(trima(_py_f_1d), onp.MArray1D[np.float64])
+assert_type(trima(_py_c_2d), onp.MArray[np.complex128])
+assert_type(trima(_i8_3d, (2, 18)), onp.MArray3D[np.int8])
+assert_type(trima(_c160_2d, (None, 18)), onp.MArray2D[np.complex256])
 
 # trimr
 # TODO


### PR DESCRIPTION
towards #1146