### PR TITLE
✨ `stats.mstats.ks_1samp`: improve shape-typing and return dtypes

### DIFF
--- a/scipy-stubs/stats/_mstats_basic.pyi
+++ b/scipy-stubs/stats/_mstats_basic.pyi
@@ -114,7 +114,9 @@ type _SiegelSlopesMethod = Literal["hierarchical", "separate"]
 
 type _KSMethod = Literal["auto", "exact", "asymp"]
 type _KTestMethod = Literal[_KSMethod, "approx"]
-type _ToCDF = str | Callable[[onp.ArrayND[np.float64]], onp.ToFloatND]
+
+type _CDF[**Tss] = Callable[Concatenate[onp.ArrayND[np.float64], Tss], onp.ToFloatND]
+type _ToCDF = str | _CDF[[]]
 
 # we can't use a generic shape-type here due to a variance bug in pyright
 type _KstestResult0 = KstestResult[np.float64, np.int8]
@@ -566,22 +568,58 @@ def mannwhitneyu(x: onp.ToFloatND, y: onp.ToFloatND, use_continuity: bool = True
 def kruskal(arg0: onp.ToFloat1D, /, *args: onp.ToFloat1D) -> KruskalResult: ...
 
 #
-@overload
+@overload  # ?d, args=()
 def ks_1samp(
-    x: onp.ToFloatND,
-    cdf: str | Callable[[float], onp.ToFloat],
+    x: _ToFloatStrictND, cdf: _CDF[[]], args: tuple[()] = (), alternative: Alternative = "two-sided", method: _KSMethod = "auto"
+) -> _KstestResultAny: ...
+@overload  # 1d, args=()
+def ks_1samp(
+    x: onp.ToFloatStrict1D,
+    cdf: _CDF[[]],
     args: tuple[()] = (),
     alternative: Alternative = "two-sided",
     method: _KSMethod = "auto",
-) -> KstestResult: ...
-@overload
+) -> _KstestResult0: ...
+@overload  # 2d, args=()
 def ks_1samp(
-    x: onp.ToFloatND,
-    cdf: str | Callable[Concatenate[float, ...], onp.ToFloat],
+    x: onp.ToFloatStrict2D,
+    cdf: _CDF[[]],
+    args: tuple[()] = (),
+    alternative: Alternative = "two-sided",
+    method: _KSMethod = "auto",
+) -> _KstestResult1: ...
+@overload  # Nd, args=()
+def ks_1samp(
+    x: onp.ToFloatND, cdf: _CDF[[]], args: tuple[()] = (), alternative: Alternative = "two-sided", method: _KSMethod = "auto"
+) -> _KstestResultAny: ...
+@overload  # ?d, args=<given>
+def ks_1samp(
+    x: _ToFloatStrictND,
+    cdf: _CDF[...],
     args: tuple[object, ...],
     alternative: Alternative = "two-sided",
     method: _KSMethod = "auto",
-) -> KstestResult: ...
+) -> _KstestResultAny: ...
+@overload  # 1d, args=<given>
+def ks_1samp(
+    x: onp.ToFloatStrict1D,
+    cdf: _CDF[...],
+    args: tuple[object, ...],
+    alternative: Alternative = "two-sided",
+    method: _KSMethod = "auto",
+) -> _KstestResult0: ...
+@overload  # 2d, args=<given>
+def ks_1samp(
+    x: onp.ToFloatStrict2D,
+    cdf: _CDF[...],
+    args: tuple[object, ...],
+    alternative: Alternative = "two-sided",
+    method: _KSMethod = "auto",
+) -> _KstestResult1: ...
+@overload  # Nd, args=<given>
+def ks_1samp(
+    x: onp.ToFloatND, cdf: _CDF[...], args: tuple[object, ...], alternative: Alternative = "two-sided", method: _KSMethod = "auto"
+) -> _KstestResultAny: ...
 
 #
 @overload  # ?d, ?d | 1d
@@ -673,7 +711,7 @@ def kstest(
 @overload  # 1d, args=<given>
 def kstest(
     data1: onp.ToFloatStrict1D,
-    data2: Callable[Concatenate[onp.ArrayND[np.float64], ...], onp.ToFloatND],
+    data2: _CDF[...],
     args: tuple[object, ...],
     alternative: Alternative = "two-sided",
     method: _KTestMethod = "auto",
@@ -681,7 +719,7 @@ def kstest(
 @overload  # 2d, args=<given>
 def kstest(
     data1: onp.ToFloatStrict2D,
-    data2: Callable[Concatenate[onp.ArrayND[np.float64], ...], onp.ToFloatND],
+    data2: _CDF[...],
     args: tuple[object, ...],
     alternative: Alternative = "two-sided",
     method: _KTestMethod = "auto",
@@ -689,7 +727,7 @@ def kstest(
 @overload  # fallback, args=<given>
 def kstest(
     data1: onp.ToFloatND,
-    data2: Callable[Concatenate[onp.ArrayND[np.float64], ...], onp.ToFloatND],
+    data2: _CDF[...],
     args: tuple[object, ...],
     alternative: Alternative = "two-sided",
     method: _KTestMethod = "auto",

--- a/tests/stats/test_mstats.pyi
+++ b/tests/stats/test_mstats.pyi
@@ -21,6 +21,7 @@ from scipy.stats.mstats import (
     kendalltau,
     kendalltau_seasonal,
     kruskal,
+    ks_1samp,
     ks_2samp,
     kstest,
     kurtosis,
@@ -123,6 +124,7 @@ _c128_2d: onp.Array2D[np.complex128]
 _c128_3d: onp.Array3D[np.complex128]
 _c128_nd: onp.ArrayND[np.complex128]
 
+def _cdf1(x: onp.ArrayND[np.float64], /) -> onp.ArrayND[np.float64]: ...
 def _cdf2(x: onp.ArrayND[np.float64], a: float, /) -> onp.ArrayND[np.float64]: ...
 
 _m_f32_nd: onp.MArray[np.float32]
@@ -258,7 +260,12 @@ assert_type(kruskal(_f64_1d, _i8_1d), KruskalResult)
 assert_type(kruskal(_py_f_1d, _f32_1d, _f16_1d), KruskalResult)
 
 # ks_1samp
-# TODO
+assert_type(ks_1samp(_f64_1d, _cdf1).statistic, np.float64)
+assert_type(ks_1samp(_f64_2d, _cdf1).statistic_sign, onp.Array1D[np.int8])
+assert_type(ks_1samp(_f64_nd, _cdf1).statistic, np.float64 | Any)
+assert_type(ks_1samp(_py_f_1d, _cdf2, (1.0,)).statistic, np.float64)
+assert_type(ks_1samp(_py_f_2d, _cdf2, (1.0,)).statistic, onp.Array1D[np.float64])
+assert_type(ks_1samp(_m_f64_nd, _cdf2, (1.0,)).statistic, np.float64 | Any)
 
 # ks_2samp
 assert_type(ks_2samp(_py_f_1d, _f64_1d).statistic, np.float64)


### PR DESCRIPTION
towards #1146