### PR TITLE
🔨 `stats.mstats`: ignore already-tested function aliases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ stubdefaulter = { git = "https://github.com/JelleZijlstra/stubdefaulter.git", re
 
 [tool.typos]
 files = { extend-exclude = ["*.pyi", ".mypyignore"] }
-default = { extend-ignore-identifiers-re = ['ND|Nd|Theis|TtestResult|SeQUeNCe|whos'] }
+default = { extend-ignore-identifiers-re = ['ND|Nd|Theis|ttest|TtestResult|SeQUeNCe|whos'] }
 
 # mypy
 

--- a/scripts/test_coverage.py
+++ b/scripts/test_coverage.py
@@ -23,6 +23,12 @@ _IGNORED_QUALNAMES: Final = {
     "scipy.stats.mstats.hmean",
     "scipy.stats.mstats.zmap",
     "scipy.stats.mstats.zscore",
+    # direct aliases of other `scipy.stats.mstats` functions
+    "scipy.stats.mstats.kruskalwallis",
+    "scipy.stats.mstats.ks_twosamp",
+    "scipy.stats.mstats.meppf",
+    "scipy.stats.mstats.trim1",
+    "scipy.stats.mstats.ttest_onesamp",
 }
 
 _PACKAGES_PUBLIC: Final = (


### PR DESCRIPTION
towards #1099 i guess