### PR TITLE
`sparse.bsr`: Mark as deprecated for coverage detection

### DIFF
--- a/scripts/test_coverage.py
+++ b/scripts/test_coverage.py
@@ -145,6 +145,7 @@ _PACKAGES_DEPRECATED: Final = (
     "signal.wavelets",
     "signal.windows.windows",
     "sparse.base",
+    "sparse.bsr",
     "sparse.compressed",
     "sparse.construct",
     "sparse.coo",


### PR DESCRIPTION
Towards(ish) https://github.com/scipy/scipy-stubs/issues/1099
I noticed that `scipy.sparse.bsr` is unticked in the test coverage report, but is already fully tested.
Mark it as deprecated in the coverage script (as mentioned in the stub file) to fix this very(!) important issue and to make a number go up :rocket: