### PR TITLE
⬆️ bump basedpyright to 1.39.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ type = [
   "array-api-compat==1.14.0, !=1.15.0", # bundled as `_lib.array_api_compat`
   "pytest==9.1.1", # needed for `_lib._array_api.make_xp_pytest_*`
   "matplotlib==3.11.1", # needed for `spatial._plotutils` and `stats._fit.FitResult.plot`
-  "basedpyright==1.39.9",
+  "basedpyright==1.39.10",
   "mypy[faster-cache]==2.3.0",
   "pyrefly==1.2.0",
   "stubdefaulter>=0.1.0",

--- a/scipy-stubs/spatial/transform/_rigid_transform.pyi
+++ b/scipy-stubs/spatial/transform/_rigid_transform.pyi
@@ -225,7 +225,7 @@ class RigidTransform(Generic[_ShapeT_co]):
     def concatenate(transforms: Sequence[RigidTransform[tuple[int]]]) -> RigidTransform[tuple[int, int]]: ...
     @overload
     @staticmethod
-    def concatenate(transforms: Sequence[RigidTransform]) -> RigidTransform: ...  # pyright: ignore[reportOverlappingOverload]
+    def concatenate(transforms: Sequence[RigidTransform[tuple[int, ...]]]) -> RigidTransform: ...
 
     #
     @overload

--- a/scipy-stubs/spatial/transform/_rotation.pyi
+++ b/scipy-stubs/spatial/transform/_rotation.pyi
@@ -354,7 +354,7 @@ class Rotation(Generic[_ShapeT_co]):
     def concatenate(rotations: Sequence[Rotation[tuple[int]]]) -> Rotation[tuple[int, int]]: ...
     @overload
     @staticmethod
-    def concatenate(rotations: Sequence[Rotation]) -> Rotation: ...  # pyright: ignore[reportOverlappingOverload]
+    def concatenate(rotations: Sequence[Rotation[tuple[int, ...]]]) -> Rotation: ...
 
     #
     @classmethod

--- a/tests/spatial/test__rigid_transform.pyi
+++ b/tests/spatial/test__rigid_transform.pyi
@@ -4,6 +4,7 @@ from typing import Any, assert_type
 
 import numpy as np
 import optype.numpy as onp
+from optype.test import assert_subtype
 
 from scipy.spatial.transform import RigidTransform, Rotation
 
@@ -16,7 +17,7 @@ _tf_nd: RigidTransform
 
 _rot_0d: Rotation[tuple[()]]
 _rot_1d: Rotation[tuple[int]]
-_rot_nd: Rotation
+_rot_nd: Rotation[tuple[Any, ...]]
 
 _f64_1d: onp.Array1D[np.float64]
 _f64_2d: onp.Array2D[np.float64]
@@ -127,7 +128,7 @@ assert_type(RigidTransform.identity(shape=4), RigidTransform[tuple[int]])
 assert_type(RigidTransform.concatenate(_tf_nd), RigidTransform)
 assert_type(RigidTransform.concatenate([_tf_0d, _tf_0d]), RigidTransform[tuple[int]])
 assert_type(RigidTransform.concatenate([_tf_1d, _tf_1d]), RigidTransform[tuple[int, int]])
-assert_type(RigidTransform.concatenate([_tf_nd, _tf_nd]), RigidTransform)  # type: ignore[assert-type]
+assert_subtype[RigidTransform](RigidTransform.concatenate([_tf_nd, _tf_nd]))
 
 # inv
 assert_type(_tf_0d.inv(), RigidTransform[tuple[()]])

--- a/tests/spatial/test__rotation.pyi
+++ b/tests/spatial/test__rotation.pyi
@@ -4,6 +4,7 @@ from typing import Any, Literal, assert_type
 
 import numpy as np
 import optype.numpy as onp
+from optype.test import assert_subtype
 
 from scipy.spatial.transform import Rotation, Slerp
 
@@ -78,7 +79,7 @@ assert_type(Rotation.random(shape=_3d), Rotation[tuple[int, int, int]])
 assert_type(Rotation.concatenate(_rot_nd), Rotation)
 assert_type(Rotation.concatenate([_rot_0d, _rot_0d]), Rotation[tuple[int]])
 assert_type(Rotation.concatenate([_rot_1d, _rot_1d]), Rotation[tuple[int, int]])
-assert_type(Rotation.concatenate([_rot_nd, _rot_nd]), Rotation)  # type: ignore[assert-type]
+assert_subtype[Rotation](Rotation.concatenate([_rot_nd, _rot_nd]))
 
 # create_group
 

--- a/tests/stats/test__morestats.pyi
+++ b/tests/stats/test__morestats.pyi
@@ -235,8 +235,9 @@ assert_type(directional_stats(_c128_3d), DirectionalStats[onp.Array2D[np.complex
 assert_type(directional_stats(_c160_3d), DirectionalStats[onp.Array2D[np.clongdouble], onp.Array1D[np.longdouble]])
 
 assert_type(directional_stats(_i16_nd), DirectionalStats[onp.ArrayND[np.float64], np.float64 | onp.ArrayND[np.float64]])
-assert_type(directional_stats(_f32_nd), DirectionalStats[onp.ArrayND[np.float32], np.float32 | onp.ArrayND[np.float32]])
-assert_type(directional_stats(_f64_nd), DirectionalStats[onp.ArrayND[np.float64], np.float64 | onp.ArrayND[np.float64]])
+# pyright 1.1.412 regression workaround on numpy<2.1
+assert_subtype[DirectionalStats[onp.ArrayND[np.float32], np.float32 | onp.ArrayND[np.float32]]](directional_stats(_f32_nd))
+assert_subtype[DirectionalStats[onp.ArrayND[np.float64], np.float64 | onp.ArrayND[np.float64]]](directional_stats(_f64_nd))
 assert_type(directional_stats(_c64_nd), DirectionalStats[onp.ArrayND[np.complex64], np.float32 | onp.ArrayND[np.float32]])
 assert_type(directional_stats(_c128_nd), DirectionalStats[onp.ArrayND[np.complex128], np.float64 | onp.ArrayND[np.float64]])
 assert_type(

--- a/tests/stats/test__stats_py.pyi
+++ b/tests/stats/test__stats_py.pyi
@@ -6,6 +6,7 @@ from typing import Any, assert_type
 import numpy as np
 import optype.numpy as onp
 import optype.numpy.compat as npc
+from optype.test import assert_subtype
 
 from scipy.stats import (
     alexandergovern,
@@ -155,10 +156,11 @@ assert_type(gmean(_f64_2d), onp.Array1D[np.float64])
 assert_type(gmean(_c64_2d), onp.Array1D[np.complex64])
 assert_type(gmean(_c128_2d), onp.Array1D[np.complex128])
 assert_type(gmean(_i64_nd), np.float64 | onp.ArrayND[np.float64])
-assert_type(gmean(_f32_nd), np.float32 | onp.ArrayND[np.float32])
-assert_type(gmean(_f64_nd), np.float64 | onp.ArrayND[np.float64])
-assert_type(gmean(_c64_nd), np.complex64 | onp.ArrayND[np.complex64])
-assert_type(gmean(_c128_nd), np.complex128 | onp.ArrayND[np.complex128])
+# pyright 1.1.412 regression workaround on numpy<2.1
+assert_subtype[np.float32 | onp.ArrayND[np.float32]](gmean(_f32_nd))
+assert_subtype[np.float64 | onp.ArrayND[np.float64]](gmean(_f64_nd))
+assert_subtype[np.complex64 | onp.ArrayND[np.complex64]](gmean(_c64_nd))
+assert_subtype[np.complex128 | onp.ArrayND[np.complex128]](gmean(_c128_nd))
 
 assert_type(gmean(_py_i_1d, keepdims=True), onp.ArrayND[np.float64])
 assert_type(gmean(_py_f_1d, keepdims=True), onp.ArrayND[np.float64])
@@ -241,10 +243,11 @@ assert_type(hmean(_f64_2d), onp.Array1D[np.float64])
 assert_type(hmean(_c64_2d), onp.Array1D[np.complex64])
 assert_type(hmean(_c128_2d), onp.Array1D[np.complex128])
 assert_type(hmean(_i64_nd), np.float64 | onp.ArrayND[np.float64])
-assert_type(hmean(_f32_nd), np.float32 | onp.ArrayND[np.float32])
-assert_type(hmean(_f64_nd), np.float64 | onp.ArrayND[np.float64])
-assert_type(hmean(_c64_nd), np.complex64 | onp.ArrayND[np.complex64])
-assert_type(hmean(_c128_nd), np.complex128 | onp.ArrayND[np.complex128])
+# pyright 1.1.412 regression workaround on numpy<2.1
+assert_subtype[np.float32 | onp.ArrayND[np.float32]](hmean(_f32_nd))
+assert_subtype[np.float64 | onp.ArrayND[np.float64]](hmean(_f64_nd))
+assert_subtype[np.complex64 | onp.ArrayND[np.complex64]](hmean(_c64_nd))
+assert_subtype[np.complex128 | onp.ArrayND[np.complex128]](hmean(_c128_nd))
 
 assert_type(hmean(_py_i_1d, keepdims=True), onp.ArrayND[np.float64])
 assert_type(hmean(_py_f_1d, keepdims=True), onp.ArrayND[np.float64])
@@ -327,10 +330,11 @@ assert_type(pmean(_f64_2d, 2), onp.Array1D[np.float64])
 assert_type(pmean(_c64_2d, 2), onp.Array1D[np.complex64])
 assert_type(pmean(_c128_2d, 2), onp.Array1D[np.complex128])
 assert_type(pmean(_i64_nd, 2), np.float64 | onp.ArrayND[np.float64])
-assert_type(pmean(_f32_nd, 2), np.float32 | onp.ArrayND[np.float32])
-assert_type(pmean(_f64_nd, 2), np.float64 | onp.ArrayND[np.float64])
-assert_type(pmean(_c64_nd, 2), np.complex64 | onp.ArrayND[np.complex64])
-assert_type(pmean(_c128_nd, 2), np.complex128 | onp.ArrayND[np.complex128])
+# pyright 1.1.412 regression workaround on numpy<2.1
+assert_subtype[np.float32 | onp.ArrayND[np.float32]](pmean(_f32_nd, 2))
+assert_subtype[np.float64 | onp.ArrayND[np.float64]](pmean(_f64_nd, 2))
+assert_subtype[np.complex64 | onp.ArrayND[np.complex64]](pmean(_c64_nd, 2))
+assert_subtype[np.complex128 | onp.ArrayND[np.complex128]](pmean(_c128_nd, 2))
 
 assert_type(pmean(_py_i_1d, 2, keepdims=True), onp.ArrayND[np.float64])
 assert_type(pmean(_py_f_1d, 2, keepdims=True), onp.ArrayND[np.float64])

--- a/tests/stats/test_mannwhitneyu.pyi
+++ b/tests/stats/test_mannwhitneyu.pyi
@@ -4,6 +4,7 @@ from typing import assert_type
 
 import numpy as np
 import optype.numpy as onp
+from optype.test import assert_subtype
 
 from scipy.stats import mannwhitneyu
 
@@ -89,7 +90,8 @@ assert_type(mannwhitneyu(_f64_3d, _f64_3d, keepdims=True).statistic, onp.ArrayND
 
 # nd
 assert_type(mannwhitneyu(_i16_nd, _i16_nd).statistic, np.float64 | onp.ArrayND[np.float64])
-assert_type(mannwhitneyu(_f32_nd, _f32_nd).statistic, np.float32 | onp.ArrayND[np.float32])
+# pyright 1.1.412 regression workaround on numpy<2.1
+assert_subtype[np.float32 | onp.ArrayND[np.float32]](mannwhitneyu(_f32_nd, _f32_nd).statistic)
 assert_type(mannwhitneyu(_f64_nd, _f64_nd).statistic, np.float64 | onp.ArrayND[np.float64])
 assert_type(mannwhitneyu(_i16_nd, _i16_nd, axis=None).statistic, np.float64)
 assert_type(mannwhitneyu(_f32_nd, _f32_nd, axis=None).statistic, np.float32)
@@ -153,7 +155,8 @@ assert_type(mannwhitneyu(_f64_3d, _f64_3d, keepdims=True).pvalue, onp.ArrayND[np
 
 # nd
 assert_type(mannwhitneyu(_i16_nd, _i16_nd).pvalue, np.float64 | onp.ArrayND[np.float64])
-assert_type(mannwhitneyu(_f32_nd, _f32_nd).pvalue, np.float32 | onp.ArrayND[np.float32])
+# pyright 1.1.412 regression workaround on numpy<2.1
+assert_subtype[np.float32 | onp.ArrayND[np.float32]](mannwhitneyu(_f32_nd, _f32_nd).pvalue)
 assert_type(mannwhitneyu(_f64_nd, _f64_nd).pvalue, np.float64 | onp.ArrayND[np.float64])
 assert_type(mannwhitneyu(_i16_nd, _i16_nd, axis=None).pvalue, np.float64)
 assert_type(mannwhitneyu(_f32_nd, _f32_nd, axis=None).pvalue, np.float32)

--- a/uv.lock
+++ b/uv.lock
@@ -60,14 +60,14 @@ wheels = [
 
 [[package]]
 name = "basedpyright"
-version = "1.39.9"
+version = "1.39.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodejs-wheel-binaries" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7a/4b/c1f4e211e50389304d6af32b9280e026a7133e3ad59bbdf8f7a3250f8bee/basedpyright-1.39.9.tar.gz", hash = "sha256:32cbea5fc8273e89df3db20daea56cb7286e419ccdfdc479c64759d2dc071901", size = 24412216, upload-time = "2026-06-27T02:19:49.834Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/43/ad2999f3b09eb2b1e59931d88fac0f7bcc9c17fc18c903268779bd10cc97/basedpyright-1.39.10.tar.gz", hash = "sha256:c8eaf5302f3265e275c7df4fba194d7afa7c1cb53fbfd448e90098360aca2c2e", size = 24740347, upload-time = "2026-08-13T17:09:02.51Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/d4/e1fa108710d0498a18c77b1e13897f31eab47c69aa8cfe2d2a4df746541e/basedpyright-1.39.9-py3-none-any.whl", hash = "sha256:6b0837b9eba972c71895167ab9b127e6afdbc17abc92312e3f8d15ca82a5611c", size = 13374276, upload-time = "2026-06-27T02:19:54.431Z" },
+    { url = "https://files.pythonhosted.org/packages/be/2a/a224054d75a58786c482f63b8ff2a09fc3362268bd1ebd0a61fb3f982153/basedpyright-1.39.10-py3-none-any.whl", hash = "sha256:cbd75d83c0be841329bcfef2d2f1182f152a6d975b8eb199e75cf5b8e9a3de78", size = 13482322, upload-time = "2026-08-13T17:08:59.074Z" },
 ]
 
 [[package]]
@@ -1118,7 +1118,7 @@ provides-extras = ["scipy"]
 ci = [{ name = "packaging", specifier = ">=26.2" }]
 dev = [
     { name = "array-api-compat", specifier = "==1.14.0,!=1.15.0" },
-    { name = "basedpyright", specifier = "==1.39.9" },
+    { name = "basedpyright", specifier = "==1.39.10" },
     { name = "dprint-py", specifier = "==0.55.2.0" },
     { name = "matplotlib", specifier = "==3.11.1" },
     { name = "mypy", extras = ["faster-cache"], specifier = "==2.3.0" },
@@ -1141,7 +1141,7 @@ lint = [
 ]
 type = [
     { name = "array-api-compat", specifier = "==1.14.0,!=1.15.0" },
-    { name = "basedpyright", specifier = "==1.39.9" },
+    { name = "basedpyright", specifier = "==1.39.10" },
     { name = "matplotlib", specifier = "==3.11.1" },
     { name = "mypy", extras = ["faster-cache"], specifier = "==2.3.0" },
     { name = "packaging", specifier = ">=26.2" },


### PR DESCRIPTION
https://github.com/DetachHead/basedpyright/releases/tag/v1.39.10
https://github.com/microsoft/pyright/releases/tag/1.1.412

It seems like Pyright's overload selection mechanism became even worse that it already was...