### PR TITLE
✨ 🐛 `stats.sampling.RatioUniforms`: fix `pdf` callable and `rvs` shape-typing

### DIFF
--- a/scipy-stubs/stats/_sampling.pyi
+++ b/scipy-stubs/stats/_sampling.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Callable, Sequence
-from typing import Any, Concatenate, Final, Generic, Literal, overload
+from typing import Any, Concatenate, Final, Generic, Literal, SupportsIndex, overload
 from typing_extensions import TypeVar
 
 import numpy as np
@@ -11,6 +11,11 @@ from .qmc import QMCEngine
 from scipy._typing import AnyShape
 
 __all__ = ["FastGeneratorInversion", "RatioUniforms"]
+
+###
+
+# workaround for a strange bug in pyright's overlapping overload detection with `numpy<2.1`
+type _WorkaroundForPyright = tuple[int] | tuple[Any, ...]
 
 _RT_co = TypeVar("_RT_co", bound=onp.ToFloat, default=float, covariant=True)
 
@@ -26,7 +31,7 @@ class RatioUniforms:
     def __init__(
         self,
         /,
-        pdf: Callable[Concatenate[onp.ToFloat, ...], onp.ToFloat],
+        pdf: Callable[[onp.Array1D[np.float64]], onp.ToFloat1D],
         *,
         umax: onp.ToFloat,
         vmin: onp.ToFloat,
@@ -34,7 +39,14 @@ class RatioUniforms:
         c: onp.ToFloat = 0,
         random_state: onp.random.ToRNG | None = None,
     ) -> None: ...
-    def rvs(self, /, size: AnyShape = 1) -> onp.ArrayND[np.float64]: ...
+
+    #
+    @overload  # 1d
+    def rvs(self, /, size: SupportsIndex = 1) -> onp.Array1D[np.float64]: ...
+    @overload  # Nd
+    def rvs[ShapeT: tuple[int, *tuple[int, ...]]](self, /, size: ShapeT) -> onp.ArrayND[np.float64, ShapeT]: ...
+    @overload  # ?d
+    def rvs(self, /, size: AnyShape) -> onp.ArrayND[np.float64, _WorkaroundForPyright]: ...
 
 class FastGeneratorInversion:
     def __init__(

--- a/tests/stats/test_sampling.pyi
+++ b/tests/stats/test_sampling.pyi
@@ -7,10 +7,22 @@ import optype.numpy as onp
 
 from scipy.stats.sampling import RatioUniforms
 
-def _pdf(x: onp.ToFloat) -> onp.ToFloat: ...
+###
 
-_ru = RatioUniforms(_pdf, umax=1.0, vmin=-1.0, vmax=1.0)
+_1d: tuple[int]
+_2d: tuple[int, int]
+_3d: tuple[int, int, int]
 
+def _f(x: onp.ArrayND[np.float64]) -> list[float]: ...
+
+###
+# RatioUniforms
+
+_ru = RatioUniforms(_f, umax=1.0, vmin=-1.0, vmax=1.0)
 assert_type(_ru, RatioUniforms)
-assert_type(_ru.rvs(), onp.ArrayND[np.float64])
-assert_type(_ru.rvs(size=3), onp.ArrayND[np.float64])
+assert_type(_ru.rvs(), onp.Array1D[np.float64])
+assert_type(_ru.rvs(3), onp.Array1D[np.float64])
+assert_type(_ru.rvs(3), onp.Array1D[np.float64])
+assert_type(_ru.rvs(_1d), onp.Array1D[np.float64])
+assert_type(_ru.rvs(_2d), onp.Array2D[np.float64])
+assert_type(_ru.rvs(_3d), onp.Array3D[np.float64])


### PR DESCRIPTION
The `pdf` callable type that the `RatioUniforms` constructor accepts was incorrect, and rejected valid functions accepting (1d) arrays and returning a 1d array-like.

This also improves `RatioUniforms.rvs` to propagate the shape-type of `size`, and closes #1673