### PR TITLE
✨ `interpolate.interp1d` (legacy): generic dtype parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ See the `scipy` columns below for which classes are subscriptable at runtime.
 | *`CubicSpline[T: f64 \| c128]`*                     | `>=1.14.1.4`  | `>=1.17`   | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.CubicSpline.html)                |
 | `CubicSpline[T: f64 \| c128, S: (int, ...)]`        | `>=1.18.0.1`  | `>=1.17`   | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.CubicSpline.html)                |
 | `FloaterHormannInterpolator[T: f64 \| c128]`        | `>=1.15.0.0`  | `>=1.17`   | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.FloaterHormannInterpolator.html) |
+| `interp1d[T: f64 \| c128]`                          | `>=1.18.1.0`  | `>=1.17`   | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.interp1d.html)                   |
 | `KroghInterpolator[T: f64 \| c128, S: (int, ...)]`  | `>=1.16.0.1`  | `>=1.17`   | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.KroghInterpolator.html)          |
 | `LinearNDInterpolator[T: f64 \| c128]`              | `>=1.15.0.0`  | `>=1.17`   | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.LinearNDInterpolator.html)       |
 | `NdBSpline[T: f64 \| c128]`                         | `>=1.15.2.1`  | `>=1.17`   | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.NdBSpline.html)                  |
@@ -227,7 +228,7 @@ See the `scipy` columns below for which classes are subscriptable at runtime.
 | `InverseJacobian[T: inexact]`                       | `>=1.15.2.0`  | `>=1.17` | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.InverseJacobian.html)     |
 | `KrylovJacobian[T: inexact]`                        | `>=1.15.2.0`  | `>=1.17` | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.KrylovJacobian.html)      |
 | `Bounds[S: (int, int, ...), T: scalar]`             | `>=1.16.0.1`  | `>=1.17` | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.Bounds.html)              |
-| `NonlinearConstraint[B: float scalar/1d, K = bool]` | `>=1.18.0.1`  | `>=1.19` | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.NonlinearConstraint.html) |
+| `NonlinearConstraint[B: float scalar/1d, K = bool]` | `>=1.18.0.1`  | `>=2.0`  | [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.NonlinearConstraint.html) |
 
 ### `scipy.signal`
 

--- a/scipy-stubs/interpolate/_interpolate.pyi
+++ b/scipy-stubs/interpolate/_interpolate.pyi
@@ -13,6 +13,7 @@ __all__ = ["BPoly", "NdPPoly", "PPoly", "interp1d", "interp2d", "lagrange"]
 ###
 
 _CT_co = TypeVar("_CT_co", bound=np.float64 | np.complex128, default=np.float64, covariant=True)
+_YT_co = TypeVar("_YT_co", bound=np.float64 | np.complex128, default=Any, covariant=True)
 _ShapeT_co = TypeVar("_ShapeT_co", bound=tuple[int, ...], default=tuple[Any, ...], covariant=True)
 
 type _ToAxis = int | npc.integer
@@ -57,13 +58,12 @@ class interp2d:
         fill_value: object = None,
     ) -> Never: ...
 
-# TODO(@jorenham): make generic for dtypes of `x` and `y` (separately) and `y` shape-type
-class interp1d(_Interpolator1D):  # legacy
+class interp1d(_Interpolator1D[_YT_co], Generic[_YT_co]):  # legacy
     copy: bool
     bounds_error: bool
     axis: int
     x: onp.Array1D[Any]  # floating | integer | bool
-    y: onp.ArrayND[Any]  # inexact
+    y: onp.ArrayND[_YT_co]
     x_bds: onp.Array1D[npc.floating]  # only set if `kind in {"nearest", "nearest-up"}`
 
     @property
@@ -72,8 +72,35 @@ class interp1d(_Interpolator1D):  # legacy
     def fill_value(self, fill_value: _Interp1dFillValue | Literal["extrapolate"], /) -> None: ...
 
     #
+    @overload  # +float
     def __init__(
-        self,
+        self: interp1d[np.float64],
+        /,
+        x: onp.ToFloat1D,
+        y: onp.ToFloatND,
+        kind: _Interp1dKind | int = "linear",
+        axis: _ToAxis = -1,
+        copy: bool = True,
+        bounds_error: bool | None = None,
+        fill_value: _Interp1dFillValue | Literal["extrapolate"] = ...,  # np.nan
+        assume_sorted: bool = False,
+    ) -> None: ...
+    @overload  # ~complex
+    def __init__(
+        self: interp1d[np.complex128],
+        /,
+        x: onp.ToFloat1D,
+        y: onp.ToJustComplexND,
+        kind: _Interp1dKind | int = "linear",
+        axis: _ToAxis = -1,
+        copy: bool = True,
+        bounds_error: bool | None = None,
+        fill_value: _Interp1dFillValue | Literal["extrapolate"] = ...,  # np.nan
+        assume_sorted: bool = False,
+    ) -> None: ...
+    @overload  # ?complex
+    def __init__(
+        self: interp1d[Any],
         /,
         x: onp.ToFloat1D,
         y: onp.ToComplexND,

--- a/tests/interpolate/test_interpolate.pyi
+++ b/tests/interpolate/test_interpolate.pyi
@@ -1,6 +1,6 @@
 # type-tests for `interpolate/_interpolate.pyi`
 
-from typing import assert_type
+from typing import Any, assert_type
 
 import numpy as np
 import optype.numpy as onp
@@ -9,10 +9,12 @@ from scipy.interpolate import BPoly, NdPPoly, PPoly, interp1d, interp2d, lagrang
 
 ###
 
+_i64_1d: onp.Array1D[np.int64]
 _f64_1d: onp.Array1D[np.float64]
 _f64_2d: onp.Array2D[np.float64]
 _f64_3d: onp.Array3D[np.float64]
 _f64_nd: onp.ArrayND[np.float64]
+_c128_1d: onp.Array1D[np.complex128]
 _c128_2d: onp.Array2D[np.complex128]
 
 ###
@@ -70,8 +72,12 @@ assert_type(_ndppoly.integrate(((0.0, 1.0),)), onp.ArrayND[np.float64])
 # interp1d
 
 interp1d_f: interp1d
-assert_type(interp1d(_f64_1d, _f64_1d), interp1d)
-assert_type(interp1d_f(0.5), onp.ArrayND[np.float64 | np.complex128])
+assert_type(interp1d(_f64_1d, _f64_1d), interp1d[np.float64])
+assert_type(interp1d(_f64_1d, _i64_1d), interp1d[np.float64])
+assert_type(interp1d(_f64_1d, _c128_1d), interp1d[np.complex128])
+assert_type(interp1d(_f64_1d, _f64_1d)(0.5), onp.ArrayND[np.float64])
+assert_type(interp1d(_f64_1d, _c128_1d)(0.5), onp.ArrayND[np.complex128])
+assert_type(interp1d_f(0.5), onp.ArrayND[Any])
 
 ###
 # interp2d (deprecated, __init__ takes Never)


### PR DESCRIPTION
Even though it's legacy funcitonality, it's still used **a lot**, so I think it's still worth doing this.