### PR TITLE
🐛 `optimize.differential_evolution`: accept more valid `bounds` types

### DIFF
--- a/scipy-stubs/optimize/_differentialevolution.pyi
+++ b/scipy-stubs/optimize/_differentialevolution.pyi
@@ -46,7 +46,7 @@ class OptimizeResult(_OptimizeResult):
 
 def differential_evolution(
     func: Callable[Concatenate[onp.Array1D[np.float64], ...], onp.ToFloat],
-    bounds: tuple[onp.ToFloat | onp.ToFloat1D, onp.ToFloat | onp.ToFloat1D] | Bounds,
+    bounds: onp.ToFloat2D | Bounds,
     args: tuple[object, ...] = (),
     strategy: _StrategyName | Callable[[int, onp.Array2D[np.float64], np.random.Generator], onp.ToFloat1D] = "best1bin",
     maxiter: onp.ToJustInt = 1000,

--- a/tests/optimize/test_differentialevolution.pyi
+++ b/tests/optimize/test_differentialevolution.pyi
@@ -6,6 +6,12 @@ import optype.numpy as onp
 from scipy.optimize import differential_evolution
 from scipy.optimize._differentialevolution import OptimizeResult
 
-def obj(x: onp.Array1D[np.float64]) -> float: ...
+###
 
-assert_type(differential_evolution(obj, bounds=([-5.0], [5.0])), OptimizeResult)
+def _obj(x: onp.Array1D[np.float64]) -> float: ...
+
+###
+
+assert_type(differential_evolution(_obj, bounds=([-5.0], [5.0])), OptimizeResult)
+assert_type(differential_evolution(_obj, bounds=[(-5.0, 5.0), (-2.0, 2.0)]), OptimizeResult)
+assert_type(differential_evolution(_obj, bounds=[[-5.0, 5.0], [-2.0, 2.0]]), OptimizeResult)


### PR DESCRIPTION
Passing e.g. `bound=[(-5., 5.), (-2., 2.)]` to `scipy.optimize.differential_evolution` was rejected, even though it's valid at runtime. The fix is straightforward.