### PR TITLE
✨ `ndimage.label`: narrow return dtype when `output=None` (default)

### DIFF
--- a/scipy-stubs/ndimage/_measurements.pyi
+++ b/scipy-stubs/ndimage/_measurements.pyi
@@ -63,7 +63,7 @@ def label(
 @overload
 def label(
     input: onp.ToComplex | onp.ToComplexND, structure: onp.ToComplex | onp.ToComplexND | None = None, output: None = None
-) -> tuple[onp.ArrayND[np.int32 | np.intp], int]: ...
+) -> tuple[onp.ArrayND[np.int32], int]: ...
 
 #
 @overload

--- a/tests/ndimage/test__measurements.pyi
+++ b/tests/ndimage/test__measurements.pyi
@@ -58,8 +58,8 @@ assert_type(label(_f64_2d, output=_i32_i64_nd), int)
 assert_type(label(_i32_2d, output=_i32_i64_nd), int)
 
 # no output -> (labeled_array, num_features)
-assert_type(label(_f64_2d), tuple[onp.ArrayND[np.int32 | np.intp], int])
-assert_type(label(_i32_2d), tuple[onp.ArrayND[np.int32 | np.intp], int])
+assert_type(label(_f64_2d), tuple[onp.ArrayND[np.int32], int])
+assert_type(label(_i32_2d), tuple[onp.ArrayND[np.int32], int])
 
 ###
 # find_objects


### PR DESCRIPTION
`int64` is only used when there are `>2^31` labels, which isn't a realistic scenario, so it can be narrowed to just `int32`