### PR TITLE
✨ `stats`: improve `.rvs()` return type of simple continuous distributions

### DIFF
--- a/scipy-stubs/stats/_distn_infrastructure.pyi
+++ b/scipy-stubs/stats/_distn_infrastructure.pyi
@@ -1355,9 +1355,67 @@ class _rv_continuous_0(rv_continuous):
 
     #
     @override
+    @overload  # size: () | None  (default)
     def rvs(
-        self, /, loc: onp.ToFloat = 0, scale: onp.ToFloat = 1, size: AnyShape = 1, random_state: onp.random.ToRNG | None = None
-    ) -> _FloatOrND: ...
+        self,
+        /,
+        loc: onp.ToFloat = 0,
+        scale: onp.ToFloat = 1,
+        size: tuple[()] | None = None,
+        random_state: onp.random.ToRNG | None = None,
+    ) -> np.float64: ...
+    @overload  # size: int
+    def rvs(
+        self,
+        /,
+        loc: onp.ToFloat = 0,
+        scale: onp.ToFloat = 1,
+        *,
+        size: SupportsIndex,
+        random_state: onp.random.ToRNG | None = None,
+    ) -> onp.Array1D[np.float64]: ...
+    @overload  # size: (int, [int, ...])
+    def rvs[ShapeT: tuple[int, *tuple[int, ...]]](
+        self, /, loc: onp.ToFloat = 0, scale: onp.ToFloat = 1, *, size: ShapeT, random_state: onp.random.ToRNG | None = None
+    ) -> onp.ArrayND[np.float64, ShapeT]: ...
+    @overload  # size: (index, ...)
+    def rvs(
+        self,
+        /,
+        loc: onp.ToFloat = 0,
+        scale: onp.ToFloat = 1,
+        *,
+        size: tuple[SupportsIndex, ...],
+        random_state: onp.random.ToRNG | None = None,
+    ) -> onp.ArrayND[np.float64] | Any: ...
+    @overload  # loc: Nd
+    def rvs(
+        self,
+        /,
+        loc: onp.ToFloatND,
+        scale: onp.ToFloat | onp.ToFloatND = 1,
+        size: AnyShape | None = None,
+        random_state: onp.random.ToRNG | None = None,
+    ) -> onp.ArrayND[np.float64]: ...
+    @overload  # scale: Nd
+    def rvs(
+        self,
+        /,
+        loc: onp.ToFloat = 0,
+        *,
+        scale: onp.ToFloatND,
+        size: AnyShape | None = None,
+        random_state: onp.random.ToRNG | None = None,
+    ) -> onp.ArrayND[np.float64]: ...
+    @overload  # size: <unknown>
+    def rvs(
+        self,
+        /,
+        loc: onp.ToFloat | onp.ToFloatND = 0,
+        scale: onp.ToFloat | onp.ToFloatND = 1,
+        size: AnyShape | None = None,
+        random_state: onp.random.ToRNG | None = None,
+    ) -> onp.ArrayND[np.float64] | Any: ...
 
     #
     @override

--- a/tests/stats/test_continuous_distns.pyi
+++ b/tests/stats/test_continuous_distns.pyi
@@ -1,3 +1,7 @@
+from typing import Any, assert_type
+
+import numpy as np
+import optype.numpy as onp
 from optype.test import assert_subtype
 
 from scipy.stats import (
@@ -236,3 +240,28 @@ assert_subtype[rv_continuous](weibull_min)
 assert_subtype[rv_continuous](wrapcauchy)
 
 assert_subtype[type[rv_continuous]](rv_histogram)
+
+###
+
+_f64_nd: onp.ArrayND[np.float64]
+_n: int
+_shape_nd: tuple[int, ...]
+_np_shape: tuple[np.intp, np.intp]
+
+assert_type(norm.rvs(), np.float64)
+assert_type(norm.rvs(size=None), np.float64)
+assert_type(norm.rvs(size=()), np.float64)
+assert_type(norm.rvs(0.5, 1.2), np.float64)
+assert_type(norm.rvs(loc=0.5, scale=1.2), np.float64)
+assert_type(expon.rvs(), np.float64)
+
+assert_type(norm.rvs(size=4), onp.Array1D[np.float64])
+assert_type(norm.rvs(size=(_n,)), onp.Array1D[np.float64])
+assert_type(norm.rvs(size=(_n, _n)), onp.Array2D[np.float64])
+assert_type(norm.rvs(size=(_n, _n, _n)), onp.Array3D[np.float64])
+assert_type(uniform.rvs(size=4), onp.Array1D[np.float64])
+assert_type(norm.rvs(size=_np_shape), onp.ArrayND[np.float64] | Any)
+
+assert_type(norm.rvs(_f64_nd), onp.ArrayND[np.float64])
+assert_type(norm.rvs(loc=_f64_nd), onp.ArrayND[np.float64])
+assert_type(norm.rvs(scale=_f64_nd), onp.ArrayND[np.float64])


### PR DESCRIPTION
It no longer returns a union of scalar and array, but is now overloaded to return the most specific variant and shape-type as is statically feasible.