### PR TITLE
🐛 `optimize.direct`: accept more valid `bounds` types

### DIFF
--- a/scipy-stubs/optimize/_direct_py.pyi
+++ b/scipy-stubs/optimize/_direct_py.pyi
@@ -25,7 +25,7 @@ SUCCESS_MESSAGES: tuple[str, str, str] = ...
 
 def direct(
     func: Callable[Concatenate[onp.Array1D[np.float64], ...], onp.ToFloat],
-    bounds: tuple[onp.ToFloat1D, onp.ToFloat1D] | Bounds,
+    bounds: onp.ToFloat2D | Bounds,
     *,
     args: tuple[object, ...] = (),
     eps: onp.ToFloat = 1e-4,

--- a/tests/optimize/test__direct_py.pyi
+++ b/tests/optimize/test__direct_py.pyi
@@ -10,7 +10,14 @@ from scipy.optimize import direct
 
 def _func(x: onp.Array1D[np.float64]) -> float: ...
 
-_res = direct(_func, bounds=([0.0, 0.0], [1.0, 1.0]))
+_bounds_2d: onp.Array2D[np.float64]
+
+direct(_func, bounds=((0.0, 1.0), (0.0, 1.0)))
+direct(_func, bounds=[[0.0, 1.0], [0.0, 1.0]])
+direct(_func, bounds=[(0, 1), (0, 1)])
+direct(_func, bounds=_bounds_2d)
+
+_res = direct(_func, bounds=[(0.0, 1.0), (0.0, 1.0)])
 assert_type(_res.x, onp.Array1D[np.float64])
 assert_type(_res.fun, float | np.float64)
 assert_type(_res.status, int)


### PR DESCRIPTION
same story as #2172