### PR TITLE
🐛 `stats.fisher_exact`: broaden input type to also accept real array-likes

### DIFF
--- a/scipy-stubs/stats/_stats_py.pyi
+++ b/scipy-stubs/stats/_stats_py.pyi
@@ -6584,7 +6584,7 @@ def combine_pvalues(
 
 #
 def fisher_exact(
-    table: onp.ArrayND[_Real0D], alternative: Alternative | None = None, *, method: ResamplingMethod | None = None
+    table: onp.ToFloat2D, alternative: Alternative | None = None, *, method: ResamplingMethod | None = None
 ) -> SignificanceResult[float]: ...
 
 # undocumented

--- a/tests/stats/test__stats_py.pyi
+++ b/tests/stats/test__stats_py.pyi
@@ -1347,6 +1347,10 @@ assert_type(combine_pvalues(_f64_2d, keepdims=True), SignificanceResult[onp.Arra
 # fisher_exact
 
 assert_type(fisher_exact(_f64_2d), SignificanceResult[float])
+assert_type(fisher_exact(_i64_2d), SignificanceResult[float])
+assert_type(fisher_exact(_bool_2d), SignificanceResult[float])
+assert_type(fisher_exact(_py_i_2d), SignificanceResult[float])
+assert_type(fisher_exact([[8, 2], [1, 5]]), SignificanceResult[float])
 
 # quantile_test
 


### PR DESCRIPTION
The example from the docstring, `fisher_exact([[8, 2], [1, 5]])`, was rejected, because the `table` param was annotated to only accept ndarray types.