### PR TITLE
🐛 `optimize.shgo`: accept more valid `bounds` types

### DIFF
--- a/scipy-stubs/optimize/_shgo.pyi
+++ b/scipy-stubs/optimize/_shgo.pyi
@@ -14,7 +14,7 @@ __all__ = ["shgo"]
 
 type _Fun1D[_RT] = Callable[Concatenate[onp.Array1D[np.float64], ...], _RT]
 
-type _ToBounds = tuple[onp.ToFloat | onp.ToFloat1D, onp.ToFloat | onp.ToFloat1D] | Bounds
+type _ToBounds = Sequence[tuple[onp.ToFloat | None, onp.ToFloat | None]] | onp.ToFloat2D | Bounds
 type _SamplingMethod = Callable[[int, int], onp.ToFloat2D] | Literal["simplicial", "halton", "sobol"]
 
 @type_check_only

--- a/tests/optimize/test_shgo.pyi
+++ b/tests/optimize/test_shgo.pyi
@@ -3,9 +3,21 @@ from typing import assert_type
 import numpy as np
 import optype.numpy as onp
 
-from scipy.optimize import shgo
+from scipy.optimize import Bounds, shgo
 from scipy.optimize._shgo import OptimizeResult
 
-def obj(x: onp.Array1D[np.float64]) -> float: ...
+###
 
-assert_type(shgo(obj, bounds=([-5.0], [5.0])), OptimizeResult)
+def _obj(x: onp.Array1D[np.float64]) -> float: ...
+
+_f64_2d: onp.Array2D[np.float64]
+
+###
+
+assert_type(shgo(_obj, bounds=[(-5.0, 5.0), (-2.0, 2.0)]), OptimizeResult)
+assert_type(shgo(_obj, bounds=((-5.0, 5.0), (-2.0, 2.0))), OptimizeResult)
+assert_type(shgo(_obj, bounds=[(-5, 5), (-2, 2)]), OptimizeResult)
+assert_type(shgo(_obj, bounds=[(None, None), (None, None)]), OptimizeResult)
+assert_type(shgo(_obj, bounds=[(0.0, None), (None, 1.0)]), OptimizeResult)
+assert_type(shgo(_obj, bounds=_f64_2d), OptimizeResult)
+assert_type(shgo(_obj, bounds=Bounds([-5.0], [5.0])), OptimizeResult)


### PR DESCRIPTION
same story as #2176 and #2172