### PR TITLE
🐛 `sparse.trace`: fix `bool | int8` upcasting

### DIFF
--- a/scipy-stubs/sparse/_base.pyi
+++ b/scipy-stubs/sparse/_base.pyi
@@ -870,7 +870,18 @@ class _spbase(SparseABC, Generic[_ScalarT_co, _ShapeT_co]):
 
     #
     def diagonal(self, /, k: int = 0) -> onp.Array1D[_ScalarT_co]: ...  # only if 2-d
-    def trace(self, /, offset: int = 0) -> _ScalarT_co: ...
+
+    #
+    @overload
+    def trace(self: _spbase[Never], /, offset: int = 0) -> Any: ...
+    @overload
+    def trace(self: _spbase[np.bool | npc.signedinteger], /, offset: int = 0) -> np.int_: ...
+    @overload
+    def trace(self: _spbase[npc.unsignedinteger], /, offset: int = 0) -> np.uint64: ...
+    @overload
+    def trace[InexactT: npc.inexact](self: _spbase[InexactT], /, offset: int = 0) -> InexactT: ...
+    @overload
+    def trace(self, /, offset: int = 0) -> Any: ...
 
     #
     @overload  # out: array (keyword)

--- a/tests/sparse/test_spbase.pyi
+++ b/tests/sparse/test_spbase.pyi
@@ -1,6 +1,6 @@
 # ruff: file-ignore[commented-out-code]
 
-from typing import assert_type
+from typing import Any, assert_type
 
 import numpy as np
 import optype.numpy.compat as npc
@@ -156,3 +156,17 @@ assert_type(csr_arr.multiply(csr_arr), sparse.csr_array[ScalarType, tuple[int, i
 assert_type(csr_arr.multiply(dense_2d), sparse.coo_array[ScalarType, tuple[int, int]])
 
 # TODO(jorenham): test other arithmetic operations for all formats
+
+###
+
+_csr_arr_u8: sparse.csr_array[np.uint8, tuple[int, int]]
+_csr_arr_c64: sparse.csr_array[np.complex64, tuple[int, int]]
+_csr_arr_any: sparse.csr_array[Any, tuple[int, int]]
+
+assert_type(_csr_mat_bool.trace(), np.int_)
+assert_type(_csr_mat_i16.trace(), np.int_)
+assert_type(_csr_mat_i64.trace(), np.int_)
+assert_type(_csr_arr_u8.trace(), np.uint64)
+assert_type(_csr_mat_f64.trace(), np.float64)
+assert_type(_csr_arr_c64.trace(), np.complex64)
+assert_type(_csr_arr_any.trace(), Any)


### PR DESCRIPTION
fixes #1811