### PR TITLE
🐛 `ndimage.value_indices`: propagate `integer` scalar types

### DIFF
--- a/scipy-stubs/ndimage/_measurements.pyi
+++ b/scipy-stubs/ndimage/_measurements.pyi
@@ -72,9 +72,18 @@ def find_objects(input: onp.ToInt, max_label: int = 0) -> list[tuple[()] | None]
 def find_objects(input: onp.ToIntND, max_label: int = 0) -> list[tuple[slice[int, int, None], ...] | None]: ...
 
 #
+@overload  # <known integer scalar-type>
+def value_indices[IntT: npc.integer](
+    arr: onp.ArrayND[IntT], *, ignore_value: int | None = None
+) -> dict[IntT, tuple[onp.ArrayND[np.intp], ...]]: ...
+@overload  # ~int
+def value_indices(
+    arr: int | onp.ToJustInt64_ND, *, ignore_value: int | None = None
+) -> dict[np.int_, tuple[onp.ArrayND[np.intp], ...]]: ...
+@overload  # +int
 def value_indices(
     arr: onp.ToInt | onp.ToIntND, *, ignore_value: int | None = None
-) -> dict[np.intp, tuple[onp.ArrayND[np.intp], ...]]: ...
+) -> dict[np.int_ | Any, tuple[onp.ArrayND[np.intp], ...]]: ...
 
 #
 @overload

--- a/tests/ndimage/test__measurements.pyi
+++ b/tests/ndimage/test__measurements.pyi
@@ -70,7 +70,9 @@ assert_type(find_objects(_i32_2d), list[tuple[slice[int, int, None], ...] | None
 ###
 # value_indices
 
-assert_type(value_indices(_i32_2d), dict[np.intp, tuple[onp.ArrayND[np.intp], ...]])
+assert_type(value_indices(_i32_2d), dict[np.int32, tuple[onp.ArrayND[np.intp], ...]])
+assert_type(value_indices(_u8_2d), dict[np.uint8, tuple[onp.ArrayND[np.intp], ...]])
+assert_type(value_indices(_py_i_2d), dict[np.intp, tuple[onp.ArrayND[np.intp], ...]])
 
 ###
 # labeled_comprehension


### PR DESCRIPTION
fixes #1830