### PR TITLE
🐛 `signal.windows.dpss`: fix return type when `return_ratios=True` or `xp=np`

### DIFF
--- a/scipy-stubs/signal/windows/_windows.pyi
+++ b/scipy-stubs/signal/windows/_windows.pyi
@@ -36,6 +36,7 @@ __all__ = [
 
 ###
 
+type _Float64_0D = onp.Array0D[np.float64]
 type _Float64_1D = onp.Array1D[np.float64]
 type _Float64_2D = onp.Array2D[np.float64]
 
@@ -256,7 +257,7 @@ def dpss(
     *,
     xp: None = None,
     device: _DeviceNP | None = None,
-) -> tuple[_Float64_1D, np.float64]: ...
+) -> tuple[_Float64_1D, _Float64_0D]: ...
 @overload  # Kmax=None, *, return_ratios=True
 def dpss(
     M: int,
@@ -268,7 +269,7 @@ def dpss(
     return_ratios: Literal[True],
     xp: None = None,
     device: _DeviceNP | None = None,
-) -> tuple[_Float64_1D, np.float64]: ...
+) -> tuple[_Float64_1D, _Float64_0D]: ...
 @overload  # Kmax, return_ratios=False
 def dpss(
     M: int,
@@ -305,6 +306,18 @@ def dpss(
     xp: None = None,
     device: _DeviceNP | None = None,
 ) -> tuple[_Float64_2D, _Float64_1D]: ...
+@overload  # xp: ModuleType, return_ratios=True
+def dpss(
+    M: int,
+    NW: float,
+    Kmax: int | None = None,
+    sym: bool = True,
+    norm: _Norm | None = None,
+    *,
+    return_ratios: Literal[True],
+    xp: ModuleType,
+    device: Incomplete | None = None,
+) -> tuple[Incomplete, Incomplete]: ...
 @overload  # xp: ModuleType
 def dpss(
     M: int,
@@ -312,8 +325,8 @@ def dpss(
     Kmax: int | None = None,
     sym: bool = True,
     norm: _Norm | None = None,
-    return_ratios: bool = False,
+    return_ratios: Literal[False] = False,
     *,
     xp: ModuleType,
     device: Incomplete | None = None,
-) -> tuple[Incomplete, Incomplete]: ...
+) -> Incomplete: ...

--- a/tests/signal/windows/test_windows.pyi
+++ b/tests/signal/windows/test_windows.pyi
@@ -154,11 +154,10 @@ assert_type(taylor(64), onp.Array1D[np.float64])
 assert_type(taylor(64, nbar=6, sll=25, norm=False, sym=False), onp.Array1D[np.float64])
 assert_type(taylor(64, xp=np), Any)
 
-# ... other window functions ...
-
 # dpss
 assert_type(dpss(64, 3), onp.Array1D[np.float64])
 assert_type(dpss(64, 3, 2), onp.Array2D[np.float64])
-assert_type(dpss(64, 3, return_ratios=True), tuple[onp.Array1D[np.float64], np.float64])
+assert_type(dpss(64, 3, return_ratios=True), tuple[onp.Array1D[np.float64], onp.Array0D[np.float64]])
 assert_type(dpss(64, 3, 2, return_ratios=True), tuple[onp.Array2D[np.float64], onp.Array1D[np.float64]])
-assert_type(dpss(64, 3, 2, xp=np), tuple[Any, Any])
+assert_type(dpss(64, 3, 2, xp=np), Any)
+assert_type(dpss(64, 3, 2, return_ratios=True, xp=np), tuple[Any, Any])


### PR DESCRIPTION
fixes #1848