### PR TITLE
🐛 `optimize.minimize`: propagate `fun` scalar type

### DIFF
--- a/scipy-stubs/optimize/_minimize.pyi
+++ b/scipy-stubs/optimize/_minimize.pyi
@@ -1,5 +1,6 @@
 from collections.abc import Callable, Mapping, Sequence
-from typing import Concatenate, Final, Literal, LiteralString, Protocol, TypeVar, TypedDict, overload, type_check_only
+from typing import Any, Concatenate, Final, Generic, Literal, LiteralString, Protocol, TypedDict, overload, type_check_only
+from typing_extensions import TypeVar
 
 import numpy as np
 import optype.numpy as onp
@@ -29,17 +30,22 @@ type _Fun0D[RT] = Callable[Concatenate[float, ...], RT] | Callable[Concatenate[n
 type _Fun1D[RT] = Callable[Concatenate[_Float1D, ...], RT]
 type _Fun1Dp[RT] = Callable[Concatenate[_Float1D, _Float1D, ...], RT]
 
+type _ToJac[T] = tuple[T, *tuple[onp.ToFloat1D, ...]]
+
 type _FDMethod = Literal["2-point", "3-point", "cs"]
+
+type _MethodF64 = Literal["Nelder-Mead", "nelder-mead", "COBYLA", "cobyla", "COBYQA", "cobyqa"]
 
 type _ToBracket = _Tuple2[onp.ToFloat] | _Tuple3[onp.ToFloat]
 type _ToBound = _Tuple2[onp.ToFloat]
 type _Ignored = object
 
 _MinimizeScalarResultT_co = TypeVar("_MinimizeScalarResultT_co", bound=_MinimizeScalarResultBase, covariant=True)
+_FunT_co = TypeVar("_FunT_co", bound=onp.ToFloat, default=float, covariant=True)
 
 @type_check_only
 class _CallbackResult(Protocol):
-    def __call__(self, /, intermediate_result: OptimizeResult) -> None: ...
+    def __call__(self, /, intermediate_result: OptimizeResult[Any]) -> None: ...
 
 @type_check_only
 class _CallbackVector(Protocol):
@@ -47,7 +53,7 @@ class _CallbackVector(Protocol):
 
 @type_check_only
 class _MinimizeMethodFun(Protocol):
-    def __call__(self, fun: _Fun1D[onp.ToFloat], x0: onp.ToFloat1D, /, args: _Args) -> OptimizeResult: ...
+    def __call__(self, fun: _Fun1D[onp.ToFloat], x0: onp.ToFloat1D, /, args: _Args) -> OptimizeResult[Any]: ...
 
 @type_check_only
 class _MinimizeScalarMethodFun(Protocol[_MinimizeScalarResultT_co]):
@@ -165,14 +171,14 @@ MINIMIZE_METHODS_NEW_CB: Final[list[MethodMimimize]] = ...
 MINIMIZE_SCALAR_METHODS: Final[list[MethodMinimizeScalar]] = ...
 
 # NOTE: This `OptimizeResult` specialization is specific to `minimize`
-class OptimizeResult(_OptimizeResult):
+class OptimizeResult(_OptimizeResult, Generic[_FunT_co]):
     success: bool
     status: int
     message: LiteralString
     x: _Float1D
     nit: int
     maxcv: float  # requires `bounds`
-    fun: float
+    fun: _FunT_co
     nfev: int
     jac: _Float1D | Sequence[_Float2D | csr_array[np.float32]]  # is a list when method="trust-constr"
     njev: int  # requires `jac`
@@ -194,10 +200,41 @@ def minimize[Float1DT: _Float1D](
     tol: onp.ToFloat | None = None,
     callback: _CallbackResult | _CallbackVector | None = None,
     options: _MinimizeOptions | None = None,
-) -> OptimizeResult: ...
-@overload  # `fun` return scalar, `jac` not truthy
+) -> OptimizeResult[np.float64]: ...
+@overload  # method={nelder-mead,cobyla,COBYQA}  (positional)
 def minimize(
     fun: _Fun1D[onp.ToFloat],
+    x0: onp.ToFloat | onp.ToFloat1D,
+    args: _Args,
+    method: _MethodF64,
+    jac: _Fun1D[onp.ToFloat1D] | _FDMethod | onp.ToFalse | None = None,
+    hess: _Fun1D[onp.ToFloat2D] | _FDMethod | HessianUpdateStrategy | None = None,
+    hessp: _Fun1Dp[onp.ToFloat1D] | None = None,
+    bounds: Bounds | None = None,
+    constraints: Constraints = (),
+    tol: onp.ToFloat | None = None,
+    callback: _CallbackResult | _CallbackVector | None = None,
+    options: _MinimizeOptions | None = None,
+) -> OptimizeResult[np.float64]: ...
+@overload  # method={nelder-mead,cobyla,COBYQA}  (keyword)
+def minimize(
+    fun: _Fun1D[onp.ToFloat],
+    x0: onp.ToFloat | onp.ToFloat1D,
+    args: _Args = (),
+    *,
+    method: _MethodF64,
+    jac: _Fun1D[onp.ToFloat1D] | _FDMethod | onp.ToFalse | None = None,
+    hess: _Fun1D[onp.ToFloat2D] | _FDMethod | HessianUpdateStrategy | None = None,
+    hessp: _Fun1Dp[onp.ToFloat1D] | None = None,
+    bounds: Bounds | None = None,
+    constraints: Constraints = (),
+    tol: onp.ToFloat | None = None,
+    callback: _CallbackResult | _CallbackVector | None = None,
+    options: _MinimizeOptions | None = None,
+) -> OptimizeResult[np.float64]: ...
+@overload  # `fun` return scalar, `jac` not truthy
+def minimize[FunT: onp.ToFloat](
+    fun: _Fun1D[FunT],
     x0: onp.ToFloat | onp.ToFloat1D,
     args: _Args = (),
     method: MethodMimimize | _MinimizeMethodFun | None = None,
@@ -209,10 +246,10 @@ def minimize(
     tol: onp.ToFloat | None = None,
     callback: _CallbackResult | _CallbackVector | None = None,
     options: _MinimizeOptions | None = None,
-) -> OptimizeResult: ...
+) -> OptimizeResult[FunT]: ...
 @overload  # fun` return (scalar, vector), `jac` truthy  (positional)
-def minimize(
-    fun: _Fun1D[tuple[onp.ToFloat, onp.ToFloat1D]],
+def minimize[FunT: onp.ToFloat](
+    fun: _Fun1D[_ToJac[FunT]],
     x0: onp.ToFloat | onp.ToFloat1D,
     args: _Args,
     method: MethodMimimize | _MinimizeMethodFun | None,
@@ -224,10 +261,10 @@ def minimize(
     tol: onp.ToFloat | None = None,
     callback: _CallbackResult | _CallbackVector | None = None,
     options: _MinimizeOptions | None = None,
-) -> OptimizeResult: ...
+) -> OptimizeResult[FunT]: ...
 @overload  # fun` return (scalar, vector), `jac` truthy  (keyword)
-def minimize(
-    fun: _Fun1D[tuple[onp.ToFloat, onp.ToFloat1D]],
+def minimize[FunT: onp.ToFloat](
+    fun: _Fun1D[_ToJac[FunT]],
     x0: onp.ToFloat | onp.ToFloat1D,
     args: _Args = (),
     method: MethodMimimize | _MinimizeMethodFun | None = None,
@@ -240,7 +277,7 @@ def minimize(
     tol: onp.ToFloat | None = None,
     callback: _CallbackResult | _CallbackVector | None = None,
     options: _MinimizeOptions | None = None,
-) -> OptimizeResult: ...
+) -> OptimizeResult[FunT]: ...
 
 #
 @overload  # method="brent" or method="golden"

--- a/tests/optimize/test_minimize.pyi
+++ b/tests/optimize/test_minimize.pyi
@@ -1,17 +1,42 @@
+from typing import Literal, assert_type, overload
+
 import numpy as np
-import numpy.typing as npt
+import optype.numpy as onp
 
 from scipy.optimize import minimize
 
 ###
 
-type NDArrayFloat = npt.NDArray[np.float16 | np.float32 | np.float64]
+def _f_f32(x: onp.Array1D[np.float64]) -> np.float32: ...
+def _f_f64(x: onp.Array1D[np.float64]) -> np.float64: ...
+def _f_f64_f64(CCT: onp.Array1D[np.float64], uv_: onp.ArrayND[np.float64]) -> np.float64: ...
+def _f_float(x: onp.Array1D[np.float64]) -> float: ...
+def _f_jac_f32(x: onp.Array1D[np.float64]) -> tuple[np.float32, onp.Array1D[np.float64]]: ...
 
-def objective_function(CCT: NDArrayFloat, uv_: NDArrayFloat) -> np.float64: ...
+#
+@overload
+def _f_jac_over(x: onp.Array1D[np.float64], extra: Literal[False] = False) -> tuple[float, onp.Array1D[np.float64]]: ...
+@overload
+def _f_jac_over(x: onp.Array1D[np.float64], extra: Literal[True]) -> tuple[float, onp.Array1D[np.float64], np.float64]: ...
 
-uv = np.atleast_1d([0.1978, 0.3124])
+_f64_1d: onp.Array1D[np.float64]
+_f64_nd: onp.ArrayND[np.float64]
 
-minimize(objective_function, x0=6400, args=(uv,), method="Nelder-Mead", options={"fatol": 1e-10})
+###
 
-# https://github.com/scipy/scipy-stubs/issues/635
 minimize(lambda x: x**2, 0.0)  # type: ignore[misc]  # pyrefly: ignore[implicit-any-lambda]
+
+minimize(_f_f64_f64, x0=6400, args=(_f64_nd,), method="Nelder-Mead", options={"fatol": 1e-10})
+
+assert_type(minimize(_f_f32, _f64_1d).fun, np.float32)
+assert_type(minimize(_f_f64, _f64_1d).fun, np.float64)
+assert_type(minimize(_f_float, _f64_1d).fun, float)
+assert_type(minimize(_f_f32, _f64_1d, method="BFGS").fun, np.float32)
+assert_type(minimize(_f_jac_f32, _f64_1d, jac=True).fun, np.float32)
+assert_type(minimize(_f_jac_f32, _f64_1d, (), "SLSQP", True).fun, np.float32)
+assert_type(minimize(_f_jac_over, _f64_1d, method="L-BFGS-B", jac=True).fun, float)
+assert_type(minimize(_f_jac_over, _f64_1d, (), "L-BFGS-B", True).fun, float)
+
+assert_type(minimize(_f_f32, _f64_1d, method="Nelder-Mead").fun, np.float64)
+assert_type(minimize(_f_f32, _f64_1d, method="cobyqa").fun, np.float64)
+assert_type(minimize(_f_f32, _f64_1d, (), "COBYLA").fun, np.float64)


### PR DESCRIPTION
fixes #1854