### PR TITLE
🐛 `stats.sampling.FastGeneratorInversion.evaluate_error`: fix return type when `x_error=False`

### DIFF
--- a/scipy-stubs/stats/_sampling.pyi
+++ b/scipy-stubs/stats/_sampling.pyi
@@ -96,8 +96,13 @@ class FastGeneratorInversion:
     def ppf(self, /, q: onp.ToFloatND) -> onp.ArrayND[np.float64]: ...
 
     #
+    @overload  # x_error=False (default)
     def evaluate_error(
-        self, /, size: int = 100_000, random_state: onp.random.ToRNG | None = None, x_error: bool = False
+        self, /, size: int = 100_000, random_state: onp.random.ToRNG | None = None, x_error: onp.ToFalse = False
+    ) -> tuple[np.float64, float]: ...
+    @overload  # x_error=True
+    def evaluate_error(
+        self, /, size: int = 100_000, random_state: onp.random.ToRNG | None = None, *, x_error: onp.ToTrue
     ) -> tuple[np.float64, np.float64]: ...
 
     #

--- a/tests/stats/test_sampling.pyi
+++ b/tests/stats/test_sampling.pyi
@@ -71,7 +71,11 @@ assert_type(_fgi.qrvs(), np.float64)
 assert_type(_fgi.qrvs(4, d=1, qmc_engine=Halton(1)), onp.ArrayND[np.float64])
 assert_type(_fgi.ppf(0.5), np.float64)
 assert_type(_fgi.ppf(_f64_1d), onp.ArrayND[np.float64])
-assert_type(_fgi.evaluate_error(), tuple[np.float64, np.float64])
+assert_type(_fgi.evaluate_error(), tuple[np.float64, float])
+assert_type(_fgi.evaluate_error(1_000, 0), tuple[np.float64, float])
+assert_type(_fgi.evaluate_error(x_error=False), tuple[np.float64, float])
+assert_type(_fgi.evaluate_error(x_error=True), tuple[np.float64, np.float64])
+assert_type(_fgi.evaluate_error(1_000, random_state=0, x_error=True), tuple[np.float64, np.float64])
 assert_type(_fgi.support(), tuple[float, float] | tuple[np.float64, np.float64])
 
 ###


### PR DESCRIPTION
fix #1864