### PR TITLE
🐛 `stats.monte_carlo_test`: propagate non-float64 floating dtypes

### DIFF
--- a/scipy-stubs/stats/_resampling.pyi
+++ b/scipy-stubs/stats/_resampling.pyi
@@ -14,7 +14,6 @@ __all__ = ["bootstrap", "monte_carlo_test", "permutation_test"]
 
 ###
 
-type _FloatND = float | np.float64 | onp.ArrayND[np.float64]
 type _BootstrapMethod = Literal["percentile", "basic", "bca", "BCa"]
 type _PermutationType = Literal["independent", "samples", "pairings"]
 
@@ -22,7 +21,7 @@ type _Statistic = Callable[..., onp.ToFloat] | Callable[..., onp.ToFloatND]
 
 type _JustAnyShape = tuple[Never, Never, Never, Never]
 
-_FloatNDT = TypeVar("_FloatNDT", bound=_FloatND, default=Any)
+_FloatNDT = TypeVar("_FloatNDT", bound=float | npc.floating | onp.ArrayND[npc.floating], default=Any)
 _DistT = TypeVar("_DistT", bound=onp.ArrayND[np.float64], default=onp.ArrayND[np.float64])
 
 @type_check_only
@@ -346,9 +345,21 @@ def permutation_test(
 ) -> PermutationTestResult[onp.ArrayND[np.float64] | Any, onp.ArrayND[np.float64]]: ...
 
 #
-@overload
+@overload  # ?d ~floating  (workaround)
+def monte_carlo_test[FloatT: npc.floating](
+    data: onp.ArrayND[FloatT, _JustAnyShape],
+    rvs: _RVSCallable,
+    statistic: _Statistic,
+    *,
+    vectorized: bool | None = None,
+    n_resamples: int = 9_999,
+    batch: int | None = None,
+    alternative: Alternative = "two-sided",
+    axis: int = 0,
+) -> MonteCarloTestResult[onp.ArrayND[FloatT] | FloatT, onp.ArrayND[np.float64]]: ...
+@overload  # ?d +f64  (workaround)
 def monte_carlo_test(
-    data: onp.ArrayND[npc.floating | npc.integer, _JustAnyShape],
+    data: onp.ArrayND[npc.integer, _JustAnyShape],
     rvs: _RVSCallable,
     statistic: _Statistic,
     *,
@@ -358,9 +369,21 @@ def monte_carlo_test(
     alternative: Alternative = "two-sided",
     axis: int = 0,
 ) -> MonteCarloTestResult[onp.ArrayND[np.float64] | np.float64, onp.ArrayND[np.float64]]: ...
-@overload
+@overload  # 1d ~floating
+def monte_carlo_test[FloatT: npc.floating](
+    data: onp.ToArrayStrict1D[FloatT, FloatT],
+    rvs: _RVSCallable,
+    statistic: _Statistic,
+    *,
+    vectorized: bool | None = None,
+    n_resamples: int = 9_999,
+    batch: int | None = None,
+    alternative: Alternative = "two-sided",
+    axis: Literal[0, -1] = 0,
+) -> MonteCarloTestResult[FloatT, onp.Array1D[np.float64]]: ...
+@overload  # 1d +f64
 def monte_carlo_test(
-    data: onp.ToFloatStrict1D,
+    data: onp.ToArrayStrict1D[float, npc.integer],
     rvs: _RVSCallable,
     statistic: _Statistic,
     *,
@@ -370,9 +393,21 @@ def monte_carlo_test(
     alternative: Alternative = "two-sided",
     axis: Literal[0, -1] = 0,
 ) -> MonteCarloTestResult[np.float64, onp.Array1D[np.float64]]: ...
-@overload
+@overload  # 2d ~floating
+def monte_carlo_test[FloatT: npc.floating](
+    data: onp.ToArrayStrict2D[FloatT, FloatT],
+    rvs: _RVSCallable,
+    statistic: _Statistic,
+    *,
+    vectorized: bool | None = None,
+    n_resamples: int = 9_999,
+    batch: int | None = None,
+    alternative: Alternative = "two-sided",
+    axis: Literal[0, 1, -1, -2] = 0,
+) -> MonteCarloTestResult[onp.Array1D[FloatT], onp.Array2D[np.float64]]: ...
+@overload  # 2d +f64
 def monte_carlo_test(
-    data: onp.ToFloatStrict2D,
+    data: onp.ToArrayStrict2D[float, npc.integer],
     rvs: _RVSCallable,
     statistic: _Statistic,
     *,
@@ -382,9 +417,21 @@ def monte_carlo_test(
     alternative: Alternative = "two-sided",
     axis: Literal[0, 1, -1, -2] = 0,
 ) -> MonteCarloTestResult[onp.Array1D[np.float64], onp.Array2D[np.float64]]: ...
-@overload
+@overload  # 3d ~floating
+def monte_carlo_test[FloatT: npc.floating](
+    data: onp.ToArrayStrict3D[FloatT, FloatT],
+    rvs: _RVSCallable,
+    statistic: _Statistic,
+    *,
+    vectorized: bool | None = None,
+    n_resamples: int = 9_999,
+    batch: int | None = None,
+    alternative: Alternative = "two-sided",
+    axis: Literal[0, 1, 2, -1, -2, -3] = 0,
+) -> MonteCarloTestResult[onp.Array2D[FloatT], onp.Array3D[np.float64]]: ...
+@overload  # 3d +f64
 def monte_carlo_test(
-    data: onp.ToFloatStrict3D,
+    data: onp.ToArrayStrict3D[float, npc.integer],
     rvs: _RVSCallable,
     statistic: _Statistic,
     *,
@@ -394,9 +441,21 @@ def monte_carlo_test(
     alternative: Alternative = "two-sided",
     axis: Literal[0, 1, 2, -1, -2, -3] = 0,
 ) -> MonteCarloTestResult[onp.Array2D[np.float64], onp.Array3D[np.float64]]: ...
-@overload
+@overload  # nd ~floating
+def monte_carlo_test[FloatT: npc.floating](
+    data: onp.ToArrayND[FloatT, FloatT],
+    rvs: _RVSCallable,
+    statistic: _Statistic,
+    *,
+    vectorized: bool | None = None,
+    n_resamples: int = 9_999,
+    batch: int | None = None,
+    alternative: Alternative = "two-sided",
+    axis: int = 0,
+) -> MonteCarloTestResult[onp.ArrayND[FloatT] | Any, onp.ArrayND[np.float64]]: ...
+@overload  # nd +f64
 def monte_carlo_test(
-    data: onp.ToFloatND,
+    data: onp.ToArrayND[float, npc.integer],
     rvs: _RVSCallable,
     statistic: _Statistic,
     *,

--- a/tests/stats/test_resampling.pyi
+++ b/tests/stats/test_resampling.pyi
@@ -14,6 +14,10 @@ _py_f_1d: list[float]
 _py_f_2d: list[list[float]]
 _py_f_3d: list[list[list[float]]]
 
+_i64_1d: onp.Array1D[np.int64]
+_f16_1d: onp.Array1D[np.float16]
+_f32_1d: onp.Array1D[np.float32]
+_f32_2d: onp.Array2D[np.float32]
 _f64_1d: onp.Array1D[np.float64]
 _f64_2d: onp.Array2D[np.float64]
 _f64_3d: onp.Array3D[np.float64]
@@ -70,6 +74,19 @@ assert_type(
 assert_type(
     monte_carlo_test(_f64_nd, np.random.standard_normal, np.mean),
     MonteCarloTestResult[onp.ArrayND[np.float64] | np.float64, onp.ArrayND[np.float64]],
+)
+assert_type(
+    monte_carlo_test(_f32_1d, np.random.standard_normal, np.mean), MonteCarloTestResult[np.float32, onp.Array1D[np.float64]]
+)
+assert_type(
+    monte_carlo_test(_f16_1d, np.random.standard_normal, np.mean), MonteCarloTestResult[np.float16, onp.Array1D[np.float64]]
+)
+assert_type(
+    monte_carlo_test(_f32_2d, np.random.standard_normal, np.mean),
+    MonteCarloTestResult[onp.Array1D[np.float32], onp.Array2D[np.float64]],
+)
+assert_type(
+    monte_carlo_test(_i64_1d, np.random.standard_normal, np.mean), MonteCarloTestResult[np.float64, onp.Array1D[np.float64]]
 )
 
 # BootstrapMethod


### PR DESCRIPTION
towards #1789