### PR TITLE
🐛 `stats.norm`: propagate `floc`/`fscale` dtypes

### DIFF
--- a/scipy-stubs/stats/_continuous_distns.pyi
+++ b/scipy-stubs/stats/_continuous_distns.pyi
@@ -326,16 +326,25 @@ class maxwell_gen(_rv_continuous_0): ...
 class moyal_gen(_rv_continuous_0): ...
 
 class norm_gen(_rv_continuous_0):
-    @override
-    def fit(  # type: ignore[override] # pyright: ignore[reportIncompatibleMethodOverride] # pyrefly: ignore [bad-override]
+    @override  # type:ignore[override]
+    @overload  # floc=None, fscale=None  (default)
+    def fit(  # pyrefly:ignore[bad-override]
         self,
         /,
         data: onp.ToFloat64_ND | CensoredData[np.float64],
         *,
-        floc: onp.ToFloat64 | None = None,
-        fscale: onp.ToFloat64 | None = None,
+        floc: None = None,
+        fscale: None = None,
         **kwds: onp.ToFloat64,
-    ) -> tuple[np.float64, np.float64]: ...  # ty: ignore[invalid-method-override]
+    ) -> tuple[np.float64, np.float64]: ...
+    @overload  # floc=<given>
+    def fit[LocT: onp.ToFloat64](
+        self, /, data: onp.ToFloat64_ND | CensoredData[np.float64], *, floc: LocT, fscale: None = None, **kwds: onp.ToFloat64
+    ) -> tuple[LocT, np.float64]: ...
+    @overload  # fscale=<given>
+    def fit[ScaleT: onp.ToFloat64](  # pyright:ignore[reportIncompatibleMethodOverride] # ty:ignore[invalid-method-override]
+        self, /, data: onp.ToFloat64_ND | CensoredData[np.float64], *, floc: None = None, fscale: ScaleT, **kwds: onp.ToFloat64
+    ) -> tuple[np.float64, ScaleT]: ...
 
 class rayleigh_gen(_rv_continuous_0): ...
 class semicircular_gen(_rv_continuous_0): ...

--- a/tests/stats/test_continuous_distns.pyi
+++ b/tests/stats/test_continuous_distns.pyi
@@ -119,6 +119,17 @@ from scipy.stats import (
     wrapcauchy,
 )
 
+###
+
+_f32: np.float32
+_f64_nd: onp.ArrayND[np.float64]
+
+_n: int
+_shape_nd: tuple[int, ...]
+_np_shape: tuple[np.intp, np.intp]
+
+###
+
 assert_subtype[rv_continuous](alpha)
 assert_subtype[rv_continuous](anglit)
 assert_subtype[rv_continuous](arcsine)
@@ -243,10 +254,7 @@ assert_subtype[type[rv_continuous]](rv_histogram)
 
 ###
 
-_f64_nd: onp.ArrayND[np.float64]
-_n: int
-_shape_nd: tuple[int, ...]
-_np_shape: tuple[np.intp, np.intp]
+# .rvs
 
 assert_type(norm.rvs(), np.float64)
 assert_type(norm.rvs(size=None), np.float64)
@@ -265,3 +273,12 @@ assert_type(norm.rvs(size=_np_shape), onp.ArrayND[np.float64] | Any)
 assert_type(norm.rvs(_f64_nd), onp.ArrayND[np.float64])
 assert_type(norm.rvs(loc=_f64_nd), onp.ArrayND[np.float64])
 assert_type(norm.rvs(scale=_f64_nd), onp.ArrayND[np.float64])
+
+# .fit
+
+assert_type(norm.fit(_f64_nd), tuple[np.float64, np.float64])
+assert_type(norm.fit(_f64_nd, floc=0), tuple[int, np.float64])
+assert_type(norm.fit(_f64_nd, floc=0.0), tuple[float, np.float64])
+assert_type(norm.fit(_f64_nd, floc=_f32), tuple[np.float32, np.float64])
+assert_type(norm.fit(_f64_nd, fscale=1), tuple[np.float64, int])
+assert_type(norm.fit(_f64_nd, fscale=2.0), tuple[np.float64, float])


### PR DESCRIPTION
fixes #1790