### PR TITLE
🐛 `stats`: propagate non-f64 floating dtypes in `bootstrap` and `permutation_test`

### DIFF
--- a/scipy-stubs/stats/_resampling.pyi
+++ b/scipy-stubs/stats/_resampling.pyi
@@ -22,7 +22,7 @@ type _Statistic = Callable[..., onp.ToFloat] | Callable[..., onp.ToFloatND]
 type _JustAnyShape = tuple[Never, Never, Never, Never]
 
 _FloatNDT = TypeVar("_FloatNDT", bound=float | npc.floating | onp.ArrayND[npc.floating], default=Any)
-_DistT = TypeVar("_DistT", bound=onp.ArrayND[np.float64], default=onp.ArrayND[np.float64])
+_DistT = TypeVar("_DistT", bound=onp.ArrayND[npc.floating], default=onp.ArrayND[np.float64])
 
 @type_check_only
 class _RVSCallable(Protocol):
@@ -186,9 +186,9 @@ def power(
 ###
 
 #
-@overload
+@overload  # ?d +f64
 def bootstrap(
-    data: Sequence[onp.ArrayND[npc.floating | npc.integer, _JustAnyShape]],
+    data: Sequence[onp.ArrayND[npc.integer, _JustAnyShape]],
     statistic: _Statistic,
     *,
     n_resamples: int = 9_999,
@@ -203,9 +203,26 @@ def bootstrap(
     rng: onp.random.ToRNG | None = None,
     random_state: onp.random.ToRNG | None = None,
 ) -> BootstrapResult[onp.ArrayND[np.float64] | np.float64, onp.ArrayND[np.float64]]: ...
-@overload
+@overload  # ?d floating
+def bootstrap[FloatT: (np.float64, np.float32, np.float16)](
+    data: Sequence[onp.ArrayND[FloatT, _JustAnyShape]],
+    statistic: _Statistic,
+    *,
+    n_resamples: int = 9_999,
+    batch: int | None = None,
+    vectorized: bool | None = None,
+    paired: bool = False,
+    axis: int = 0,
+    confidence_level: float = 0.95,
+    alternative: Alternative = "two-sided",
+    method: _BootstrapMethod = "BCa",
+    bootstrap_result: BootstrapResult | None = None,
+    rng: onp.random.ToRNG | None = None,
+    random_state: onp.random.ToRNG | None = None,
+) -> BootstrapResult[onp.ArrayND[FloatT] | FloatT, onp.ArrayND[FloatT]]: ...
+@overload  # 1d +f64
 def bootstrap(
-    data: Sequence[onp.ToFloatStrict1D],
+    data: Sequence[onp.ToArrayStrict1D[float, npc.integer]],
     statistic: _Statistic,
     *,
     n_resamples: int = 9_999,
@@ -220,9 +237,26 @@ def bootstrap(
     rng: onp.random.ToRNG | None = None,
     random_state: onp.random.ToRNG | None = None,
 ) -> BootstrapResult[np.float64, onp.Array1D[np.float64]]: ...
-@overload
+@overload  # 1d floating
+def bootstrap[FloatT: (np.float64, np.float32, np.float16)](
+    data: Sequence[onp.ToArrayStrict1D[FloatT, FloatT]],
+    statistic: _Statistic,
+    *,
+    n_resamples: int = 9_999,
+    batch: int | None = None,
+    vectorized: bool | None = None,
+    paired: bool = False,
+    axis: Literal[0, -1] = 0,
+    confidence_level: float = 0.95,
+    alternative: Alternative = "two-sided",
+    method: _BootstrapMethod = "BCa",
+    bootstrap_result: BootstrapResult | None = None,
+    rng: onp.random.ToRNG | None = None,
+    random_state: onp.random.ToRNG | None = None,
+) -> BootstrapResult[FloatT, onp.Array1D[FloatT]]: ...
+@overload  # 2d +f64
 def bootstrap(
-    data: Sequence[onp.ToFloatStrict2D],
+    data: Sequence[onp.ToArrayStrict2D[float, npc.integer]],
     statistic: _Statistic,
     *,
     n_resamples: int = 9_999,
@@ -237,9 +271,26 @@ def bootstrap(
     rng: onp.random.ToRNG | None = None,
     random_state: onp.random.ToRNG | None = None,
 ) -> BootstrapResult[onp.Array1D[np.float64], onp.Array2D[np.float64]]: ...
-@overload
+@overload  # 2d floating
+def bootstrap[FloatT: (np.float64, np.float32, np.float16)](
+    data: Sequence[onp.ToArrayStrict2D[FloatT, FloatT]],
+    statistic: _Statistic,
+    *,
+    n_resamples: int = 9_999,
+    batch: int | None = None,
+    vectorized: bool | None = None,
+    paired: bool = False,
+    axis: Literal[0, 1, -1, -2] = 0,
+    confidence_level: float = 0.95,
+    alternative: Alternative = "two-sided",
+    method: _BootstrapMethod = "BCa",
+    bootstrap_result: BootstrapResult | None = None,
+    rng: onp.random.ToRNG | None = None,
+    random_state: onp.random.ToRNG | None = None,
+) -> BootstrapResult[onp.Array1D[FloatT], onp.Array2D[FloatT]]: ...
+@overload  # 3d +f64
 def bootstrap(
-    data: Sequence[onp.ToFloatStrict3D],
+    data: Sequence[onp.ToArrayStrict3D[float, npc.integer]],
     statistic: _Statistic,
     *,
     n_resamples: int = 9_999,
@@ -254,7 +305,58 @@ def bootstrap(
     rng: onp.random.ToRNG | None = None,
     random_state: onp.random.ToRNG | None = None,
 ) -> BootstrapResult[onp.Array2D[np.float64], onp.Array3D[np.float64]]: ...
-@overload
+@overload  # 3d floating
+def bootstrap[FloatT: (np.float64, np.float32, np.float16)](
+    data: Sequence[onp.ToArrayStrict3D[FloatT, FloatT]],
+    statistic: _Statistic,
+    *,
+    n_resamples: int = 9_999,
+    batch: int | None = None,
+    vectorized: bool | None = None,
+    paired: bool = False,
+    axis: Literal[0, 1, 2, -1, -2, -3] = 0,
+    confidence_level: float = 0.95,
+    alternative: Alternative = "two-sided",
+    method: _BootstrapMethod = "BCa",
+    bootstrap_result: BootstrapResult | None = None,
+    rng: onp.random.ToRNG | None = None,
+    random_state: onp.random.ToRNG | None = None,
+) -> BootstrapResult[onp.Array2D[FloatT], onp.Array3D[FloatT]]: ...
+@overload  # Nd +f64
+def bootstrap(
+    data: Sequence[onp.ToArrayND[float, npc.integer]],
+    statistic: _Statistic,
+    *,
+    n_resamples: int = 9_999,
+    batch: int | None = None,
+    vectorized: bool | None = None,
+    paired: bool = False,
+    axis: int = 0,
+    confidence_level: float = 0.95,
+    alternative: Alternative = "two-sided",
+    method: _BootstrapMethod = "BCa",
+    bootstrap_result: BootstrapResult | None = None,
+    rng: onp.random.ToRNG | None = None,
+    random_state: onp.random.ToRNG | None = None,
+) -> BootstrapResult[onp.ArrayND[np.float64] | Any, onp.ArrayND[np.float64]]: ...
+@overload  # Nd floating
+def bootstrap[FloatT: (np.float64, np.float32, np.float16)](
+    data: Sequence[onp.ToArrayND[FloatT, FloatT]],
+    statistic: _Statistic,
+    *,
+    n_resamples: int = 9_999,
+    batch: int | None = None,
+    vectorized: bool | None = None,
+    paired: bool = False,
+    axis: int = 0,
+    confidence_level: float = 0.95,
+    alternative: Alternative = "two-sided",
+    method: _BootstrapMethod = "BCa",
+    bootstrap_result: BootstrapResult | None = None,
+    rng: onp.random.ToRNG | None = None,
+    random_state: onp.random.ToRNG | None = None,
+) -> BootstrapResult[onp.ArrayND[FloatT] | Any, onp.ArrayND[FloatT]]: ...
+@overload  # fallback
 def bootstrap(
     data: Sequence[onp.ToFloatND],
     statistic: _Statistic,
@@ -270,12 +372,12 @@ def bootstrap(
     bootstrap_result: BootstrapResult | None = None,
     rng: onp.random.ToRNG | None = None,
     random_state: onp.random.ToRNG | None = None,
-) -> BootstrapResult[onp.ArrayND[np.float64] | Any, onp.ArrayND[np.float64]]: ...
+) -> BootstrapResult[onp.ArrayND[np.float64] | Any, onp.ArrayND[np.float64 | Any]]: ...
 
 #
-@overload
+@overload  # ?d +f64
 def permutation_test(
-    data: Sequence[onp.ArrayND[npc.floating | npc.integer, _JustAnyShape]],
+    data: Sequence[onp.ArrayND[npc.integer, _JustAnyShape]],
     statistic: _Statistic,
     *,
     permutation_type: _PermutationType = "independent",
@@ -287,9 +389,23 @@ def permutation_test(
     rng: onp.random.ToRNG | None = None,
     random_state: onp.random.ToRNG | None = None,
 ) -> PermutationTestResult[onp.ArrayND[np.float64] | np.float64, onp.ArrayND[np.float64]]: ...
-@overload
+@overload  # ?d floating
+def permutation_test[FloatT: (np.float64, np.float32, np.float16)](
+    data: Sequence[onp.ArrayND[FloatT, _JustAnyShape]],
+    statistic: _Statistic,
+    *,
+    permutation_type: _PermutationType = "independent",
+    vectorized: bool | None = None,
+    n_resamples: int = 9_999,
+    batch: int | None = None,
+    alternative: Alternative = "two-sided",
+    axis: int = 0,
+    rng: onp.random.ToRNG | None = None,
+    random_state: onp.random.ToRNG | None = None,
+) -> PermutationTestResult[onp.ArrayND[FloatT] | FloatT, onp.ArrayND[FloatT]]: ...
+@overload  # 1d +f64
 def permutation_test(
-    data: Sequence[onp.ToFloatStrict1D],
+    data: Sequence[onp.ToArrayStrict1D[float, npc.integer]],
     statistic: _Statistic,
     *,
     permutation_type: _PermutationType = "independent",
@@ -301,9 +417,23 @@ def permutation_test(
     rng: onp.random.ToRNG | None = None,
     random_state: onp.random.ToRNG | None = None,
 ) -> PermutationTestResult[np.float64, onp.Array1D[np.float64]]: ...
-@overload
+@overload  # 1d floating
+def permutation_test[FloatT: (np.float64, np.float32, np.float16)](
+    data: Sequence[onp.ToArrayStrict1D[FloatT, FloatT]],
+    statistic: _Statistic,
+    *,
+    permutation_type: _PermutationType = "independent",
+    vectorized: bool | None = None,
+    n_resamples: int = 9_999,
+    batch: int | None = None,
+    alternative: Alternative = "two-sided",
+    axis: Literal[0, -1] = 0,
+    rng: onp.random.ToRNG | None = None,
+    random_state: onp.random.ToRNG | None = None,
+) -> PermutationTestResult[FloatT, onp.Array1D[FloatT]]: ...
+@overload  # 2d +f64
 def permutation_test(
-    data: Sequence[onp.ToFloatStrict2D],
+    data: Sequence[onp.ToArrayStrict2D[float, npc.integer]],
     statistic: _Statistic,
     *,
     permutation_type: _PermutationType = "independent",
@@ -315,9 +445,23 @@ def permutation_test(
     rng: onp.random.ToRNG | None = None,
     random_state: onp.random.ToRNG | None = None,
 ) -> PermutationTestResult[onp.Array1D[np.float64], onp.Array2D[np.float64]]: ...
-@overload
+@overload  # 2d floating
+def permutation_test[FloatT: (np.float64, np.float32, np.float16)](
+    data: Sequence[onp.ToArrayStrict2D[FloatT, FloatT]],
+    statistic: _Statistic,
+    *,
+    permutation_type: _PermutationType = "independent",
+    vectorized: bool | None = None,
+    n_resamples: int = 9_999,
+    batch: int | None = None,
+    alternative: Alternative = "two-sided",
+    axis: Literal[0, 1, -1, -2] = 0,
+    rng: onp.random.ToRNG | None = None,
+    random_state: onp.random.ToRNG | None = None,
+) -> PermutationTestResult[onp.Array1D[FloatT], onp.Array2D[FloatT]]: ...
+@overload  # 3d +f64
 def permutation_test(
-    data: Sequence[onp.ToFloatStrict3D],
+    data: Sequence[onp.ToArrayStrict3D[float, npc.integer]],
     statistic: _Statistic,
     *,
     permutation_type: _PermutationType = "independent",
@@ -329,7 +473,49 @@ def permutation_test(
     rng: onp.random.ToRNG | None = None,
     random_state: onp.random.ToRNG | None = None,
 ) -> PermutationTestResult[onp.Array2D[np.float64], onp.Array3D[np.float64]]: ...
-@overload
+@overload  # 3d floating
+def permutation_test[FloatT: (np.float64, np.float32, np.float16)](
+    data: Sequence[onp.ToArrayStrict3D[FloatT, FloatT]],
+    statistic: _Statistic,
+    *,
+    permutation_type: _PermutationType = "independent",
+    vectorized: bool | None = None,
+    n_resamples: int = 9_999,
+    batch: int | None = None,
+    alternative: Alternative = "two-sided",
+    axis: Literal[0, 1, 2, -1, -2, -3] = 0,
+    rng: onp.random.ToRNG | None = None,
+    random_state: onp.random.ToRNG | None = None,
+) -> PermutationTestResult[onp.Array2D[FloatT], onp.Array3D[FloatT]]: ...
+@overload  # Nd +f64
+def permutation_test(
+    data: Sequence[onp.ToArrayND[float, npc.integer]],
+    statistic: _Statistic,
+    *,
+    permutation_type: _PermutationType = "independent",
+    vectorized: bool | None = None,
+    n_resamples: int = 9_999,
+    batch: int | None = None,
+    alternative: Alternative = "two-sided",
+    axis: int = 0,
+    rng: onp.random.ToRNG | None = None,
+    random_state: onp.random.ToRNG | None = None,
+) -> PermutationTestResult[onp.ArrayND[np.float64] | Any, onp.ArrayND[np.float64]]: ...
+@overload  # Nd floating
+def permutation_test[FloatT: (np.float64, np.float32, np.float16)](
+    data: Sequence[onp.ToArrayND[FloatT, FloatT]],
+    statistic: _Statistic,
+    *,
+    permutation_type: _PermutationType = "independent",
+    vectorized: bool | None = None,
+    n_resamples: int = 9_999,
+    batch: int | None = None,
+    alternative: Alternative = "two-sided",
+    axis: int = 0,
+    rng: onp.random.ToRNG | None = None,
+    random_state: onp.random.ToRNG | None = None,
+) -> PermutationTestResult[onp.ArrayND[FloatT] | Any, onp.ArrayND[FloatT]]: ...
+@overload  # fallback
 def permutation_test(
     data: Sequence[onp.ToFloatND],
     statistic: _Statistic,
@@ -342,7 +528,7 @@ def permutation_test(
     axis: int = 0,
     rng: onp.random.ToRNG | None = None,
     random_state: onp.random.ToRNG | None = None,
-) -> PermutationTestResult[onp.ArrayND[np.float64] | Any, onp.ArrayND[np.float64]]: ...
+) -> PermutationTestResult[onp.ArrayND[np.float64] | Any, onp.ArrayND[np.float64 | Any]]: ...
 
 #
 @overload  # ?d ~floating  (workaround)

--- a/tests/stats/test_resampling.pyi
+++ b/tests/stats/test_resampling.pyi
@@ -39,6 +39,12 @@ assert_type(bootstrap((_f64_3d, _f64_3d), np.mean), BootstrapResult[onp.Array2D[
 assert_type(
     bootstrap((_f64_nd, _f64_nd), np.mean), BootstrapResult[onp.ArrayND[np.float64] | np.float64, onp.ArrayND[np.float64]]
 )
+assert_type(bootstrap((_i64_1d,), np.mean), BootstrapResult[np.float64, onp.Array1D[np.float64]])
+assert_type(bootstrap((_f16_1d,), np.mean), BootstrapResult[np.float16, onp.Array1D[np.float16]])
+assert_type(bootstrap((_f32_1d,), np.mean), BootstrapResult[np.float32, onp.Array1D[np.float32]])
+assert_type(bootstrap((_f64_1d,), np.mean), BootstrapResult[np.float64, onp.Array1D[np.float64]])
+assert_type(bootstrap((_f64_1d, _f32_1d), np.mean), BootstrapResult[onp.ArrayND[np.float64] | Any, onp.ArrayND[np.float64 | Any]])
+assert_type(bootstrap((_py_f_1d,), np.mean), BootstrapResult[np.float64, onp.Array1D[np.float64]])
 
 # permutation_test
 assert_type(permutation_test((_py_f_1d, _py_f_1d), _statistic_1d), PermutationTestResult[np.float64, onp.Array1D[np.float64]])
@@ -54,6 +60,8 @@ assert_type(
     permutation_test((_f64_nd, _f64_nd), _statistic_nd),
     PermutationTestResult[onp.ArrayND[np.float64] | np.float64, onp.ArrayND[np.float64]],
 )
+assert_type(permutation_test((_f16_1d, _f16_1d), _statistic_1d), PermutationTestResult[np.float16, onp.Array1D[np.float16]])
+assert_type(permutation_test((_f32_1d, _f32_1d), _statistic_1d), PermutationTestResult[np.float32, onp.Array1D[np.float32]])
 
 # monte_carlo_test
 assert_type(


### PR DESCRIPTION
fixes #1789