### PR TITLE
🐛 `linalg.norm`: fix return type when `axis` is given and `keepdims=False`

### DIFF
--- a/scipy-stubs/linalg/_misc.pyi
+++ b/scipy-stubs/linalg/_misc.pyi
@@ -68,6 +68,29 @@ def norm(
     keepdims: Literal[False] = False,
     check_finite: bool = True,
 ) -> np.float64 | Any: ...
+@overload  # Nd +inexact64, axis: <given>
+def norm(
+    a: onp.ToArrayND[complex, _SubScalar],
+    ord: _Order | None = None,
+    *,
+    axis: _Axis,
+    keepdims: Literal[False] = False,
+    check_finite: bool = True,
+) -> onp.ArrayND[np.float64]: ...
+@overload  # Nd ~inexact32, axis: <given>
+def norm(
+    a: _AsInexact32ND, ord: _Order | None = None, *, axis: _Axis, keepdims: Literal[False] = False, check_finite: bool = True
+) -> onp.ArrayND[np.float32]: ...
+@overload  # Nd ~bool | ~f16 | ~f80 | ~c160, axis: <given>
+@deprecated("bool, float16, longdouble, and clongdouble input will no longer be supported in SciPy 2.1")
+def norm(
+    a: _AsBoolF16Inexact80ND,
+    ord: _Order | None = None,
+    *,
+    axis: _Axis,
+    keepdims: Literal[False] = False,
+    check_finite: bool = True,
+) -> onp.ArrayND[np.float64 | Any]: ...
 @overload  # Nd +inexact64, keepdims: True, shape known
 def norm[ShapeT: tuple[int, ...]](
     a: onp.ArrayND[_SubScalar, ShapeT],

--- a/tests/linalg/test__misc.pyi
+++ b/tests/linalg/test__misc.pyi
@@ -76,3 +76,15 @@ assert_type(norm(c256_nd, keepdims=True), onp.ArrayND[np.float64 | Any])  # pyri
 
 assert_type(norm(f64_2d, keepdims=True), onp.Array2D[np.float64])
 assert_type(norm(f32_2d, keepdims=True), onp.Array2D[np.float32])
+
+assert_type(norm(f64_2d, axis=0), onp.ArrayND[np.float64])
+assert_type(norm(f64_3d, axis=(0, 1)), onp.ArrayND[np.float64])
+assert_type(norm(i32_nd, axis=0), onp.ArrayND[np.float64])
+assert_type(norm(c128_nd, axis=0), onp.ArrayND[np.float64])
+assert_type(norm(py_f_2d, axis=0), onp.ArrayND[np.float64])
+assert_type(norm(f32_2d, axis=0), onp.ArrayND[np.float32])
+assert_type(norm(c64_nd, axis=0), onp.ArrayND[np.float32])
+assert_type(norm(b1_nd, axis=0), onp.ArrayND[np.float64 | Any])  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]
+assert_type(norm(f16_nd, axis=0), onp.ArrayND[np.float64 | Any])  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]
+assert_type(norm(f80_nd, axis=0), onp.ArrayND[np.float64 | Any])  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]
+assert_type(norm(c256_nd, axis=0), onp.ArrayND[np.float64 | Any])  # pyright:ignore[reportDeprecated] # pyrefly:ignore[deprecated]


### PR DESCRIPTION
It doesn't always return a scalar in that case; it could also return an array.