### PR TITLE
🐛 `signal`: accept array-likes for `window` params of certain spectrai functions

### DIFF
--- a/scipy-stubs/signal/_signaltools.pyi
+++ b/scipy-stubs/signal/_signaltools.pyi
@@ -74,6 +74,7 @@ type _FilterType = L["iir", "fir"] | dlti
 
 type _C64_128 = np.complex128 | np.complex64
 
+type _ToWindowOrArray = _ToWindow | onp.ToFloat1D
 type _ToResampleWindow[InexactT: npc.inexact] = Callable[[onp.Array1D[InexactT]], onp.ToFloat1D] | onp.ToFloat1D | _ToWindow
 
 # workaround for a strange bug in pyright's overlapping overload detection with `numpy<2.1`
@@ -1290,7 +1291,7 @@ def resample_poly[ShapeT: tuple[int, ...], InexactT2: np.float32 | np.float64 | 
     up: int,
     down: int,
     axis: int = 0,
-    window: _ToWindow = ("kaiser", 5.0),
+    window: _ToWindowOrArray = ("kaiser", 5.0),
     padtype: _PadType = "constant",
     cval: float | None = None,
 ) -> onp.ArrayND[InexactT2, ShapeT]: ...
@@ -1300,7 +1301,7 @@ def resample_poly[ShapeT: tuple[int, ...]](
     up: int,
     down: int,
     axis: int = 0,
-    window: _ToWindow = ("kaiser", 5.0),
+    window: _ToWindowOrArray = ("kaiser", 5.0),
     padtype: _PadType = "constant",
     cval: float | None = None,
 ) -> onp.ArrayND[np.float64, ShapeT]: ...
@@ -1310,7 +1311,7 @@ def resample_poly[ShapeT: tuple[int, ...]](
     up: int,
     down: int,
     axis: int = 0,
-    window: _ToWindow = ("kaiser", 5.0),
+    window: _ToWindowOrArray = ("kaiser", 5.0),
     padtype: _PadType = "constant",
     cval: float | None = None,
 ) -> onp.ArrayND[np.float32, ShapeT]: ...
@@ -1320,7 +1321,7 @@ def resample_poly(
     up: int,
     down: int,
     axis: int = 0,
-    window: _ToWindow = ("kaiser", 5.0),
+    window: _ToWindowOrArray = ("kaiser", 5.0),
     padtype: _PadType = "constant",
     cval: float | None = None,
 ) -> onp.Array1D[np.float64]: ...
@@ -1330,7 +1331,7 @@ def resample_poly(
     up: int,
     down: int,
     axis: int = 0,
-    window: _ToWindow = ("kaiser", 5.0),
+    window: _ToWindowOrArray = ("kaiser", 5.0),
     padtype: _PadType = "constant",
     cval: float | None = None,
 ) -> onp.ArrayND[np.float64]: ...
@@ -1340,7 +1341,7 @@ def resample_poly(
     up: int,
     down: int,
     axis: int = 0,
-    window: _ToWindow = ("kaiser", 5.0),
+    window: _ToWindowOrArray = ("kaiser", 5.0),
     padtype: _PadType = "constant",
     cval: float | None = None,
 ) -> onp.Array1D[np.complex128]: ...
@@ -1350,7 +1351,7 @@ def resample_poly(
     up: int,
     down: int,
     axis: int = 0,
-    window: _ToWindow = ("kaiser", 5.0),
+    window: _ToWindowOrArray = ("kaiser", 5.0),
     padtype: _PadType = "constant",
     cval: float | None = None,
 ) -> onp.ArrayND[np.complex128]: ...
@@ -1360,7 +1361,7 @@ def resample_poly(
     up: int,
     down: int,
     axis: int = 0,
-    window: _ToWindow = ("kaiser", 5.0),
+    window: _ToWindowOrArray = ("kaiser", 5.0),
     padtype: _PadType = "constant",
     cval: float | None = None,
 ) -> onp.ArrayND[Any, _WorkaroundForPyright]: ...

--- a/scipy-stubs/signal/_spectral_py.pyi
+++ b/scipy-stubs/signal/_spectral_py.pyi
@@ -7,8 +7,7 @@ import optype as op
 import optype.numpy as onp
 import optype.numpy.compat as npc
 
-from ._signaltools import _TrendType
-from .windows._windows import _ToWindow
+from ._signaltools import _ToWindowOrArray, _TrendType
 
 __all__ = ["check_COLA", "check_NOLA", "coherence", "csd", "istft", "lombscargle", "periodogram", "spectrogram", "stft", "welch"]
 
@@ -70,7 +69,7 @@ def lombscargle(
 def periodogram(
     x: _ToInexact64ND,
     fs: float = 1.0,
-    window: _ToWindow | None = "boxcar",
+    window: _ToWindowOrArray | None = "boxcar",
     nfft: int | None = None,
     detrend: _Detrend = "constant",
     return_onesided: bool = True,
@@ -81,7 +80,7 @@ def periodogram(
 def periodogram(
     x: _ToInexact32ND,
     fs: float = 1.0,
-    window: _ToWindow | None = "boxcar",
+    window: _ToWindowOrArray | None = "boxcar",
     nfft: int | None = None,
     detrend: _Detrend = "constant",
     return_onesided: bool = True,
@@ -92,7 +91,7 @@ def periodogram(
 def periodogram(
     x: _ToInexact80ND,
     fs: float = 1.0,
-    window: _ToWindow | None = "boxcar",
+    window: _ToWindowOrArray | None = "boxcar",
     nfft: int | None = None,
     detrend: _Detrend = "constant",
     return_onesided: bool = True,
@@ -105,7 +104,7 @@ def periodogram(
 def welch(
     x: _ToInexact64ND,
     fs: float = 1.0,
-    window: _ToWindow = "hann_periodic",
+    window: _ToWindowOrArray = "hann_periodic",
     nperseg: int | None = None,
     noverlap: int | None = None,
     nfft: int | None = None,
@@ -119,7 +118,7 @@ def welch(
 def welch(
     x: _ToInexact32ND,
     fs: float = 1.0,
-    window: _ToWindow = "hann_periodic",
+    window: _ToWindowOrArray = "hann_periodic",
     nperseg: int | None = None,
     noverlap: int | None = None,
     nfft: int | None = None,
@@ -133,7 +132,7 @@ def welch(
 def welch(
     x: _ToInexact80ND,
     fs: float = 1.0,
-    window: _ToWindow = "hann_periodic",
+    window: _ToWindowOrArray = "hann_periodic",
     nperseg: int | None = None,
     noverlap: int | None = None,
     nfft: int | None = None,
@@ -151,7 +150,7 @@ def csd(
     x: _ToInexact64ND,
     y: _ToInexact64ND,
     fs: float = 1.0,
-    window: _ToWindow = "hann_periodic",
+    window: _ToWindowOrArray = "hann_periodic",
     nperseg: int | None = None,
     noverlap: int | None = None,
     nfft: int | None = None,
@@ -166,7 +165,7 @@ def csd(
     x: _ToInexact32ND,
     y: _ToInexact32ND,
     fs: float = 1.0,
-    window: _ToWindow = "hann_periodic",
+    window: _ToWindowOrArray = "hann_periodic",
     nperseg: int | None = None,
     noverlap: int | None = None,
     nfft: int | None = None,
@@ -181,7 +180,7 @@ def csd(
     x: _ToInexact80ND,
     y: _ToInexact80ND,
     fs: float = 1.0,
-    window: _ToWindow = "hann_periodic",
+    window: _ToWindowOrArray = "hann_periodic",
     nperseg: int | None = None,
     noverlap: int | None = None,
     nfft: int | None = None,
@@ -196,7 +195,7 @@ def csd(
     x: onp.ToComplexND,
     y: onp.ToComplexND,
     fs: float = 1.0,
-    window: _ToWindow = "hann_periodic",
+    window: _ToWindowOrArray = "hann_periodic",
     nperseg: int | None = None,
     noverlap: int | None = None,
     nfft: int | None = None,
@@ -213,7 +212,7 @@ def csd(
 def spectrogram(
     x: _ToInexact64ND,
     fs: float = 1.0,
-    window: _ToWindow = ("tukey_periodic", 0.25),
+    window: _ToWindowOrArray = ("tukey_periodic", 0.25),
     nperseg: int | None = None,
     noverlap: int | None = None,
     nfft: int | None = None,
@@ -227,7 +226,7 @@ def spectrogram(
 def spectrogram(
     x: _ToInexact64ND,
     fs: float = 1.0,
-    window: _ToWindow = ("tukey_periodic", 0.25),
+    window: _ToWindowOrArray = ("tukey_periodic", 0.25),
     nperseg: int | None = None,
     noverlap: int | None = None,
     nfft: int | None = None,
@@ -242,7 +241,7 @@ def spectrogram(
 def spectrogram(
     x: _ToInexact32ND,
     fs: float = 1.0,
-    window: _ToWindow = ("tukey_periodic", 0.25),
+    window: _ToWindowOrArray = ("tukey_periodic", 0.25),
     nperseg: int | None = None,
     noverlap: int | None = None,
     nfft: int | None = None,
@@ -256,7 +255,7 @@ def spectrogram(
 def spectrogram(
     x: _ToInexact32ND,
     fs: float = 1.0,
-    window: _ToWindow = ("tukey_periodic", 0.25),
+    window: _ToWindowOrArray = ("tukey_periodic", 0.25),
     nperseg: int | None = None,
     noverlap: int | None = None,
     nfft: int | None = None,
@@ -271,7 +270,7 @@ def spectrogram(
 def spectrogram(
     x: _ToInexact80ND,
     fs: float = 1.0,
-    window: _ToWindow = ("tukey_periodic", 0.25),
+    window: _ToWindowOrArray = ("tukey_periodic", 0.25),
     nperseg: int | None = None,
     noverlap: int | None = None,
     nfft: int | None = None,
@@ -285,7 +284,7 @@ def spectrogram(
 def spectrogram(
     x: _ToInexact80ND,
     fs: float = 1.0,
-    window: _ToWindow = ("tukey_periodic", 0.25),
+    window: _ToWindowOrArray = ("tukey_periodic", 0.25),
     nperseg: int | None = None,
     noverlap: int | None = None,
     nfft: int | None = None,
@@ -300,7 +299,7 @@ def spectrogram(
 def spectrogram(
     x: onp.ToComplexND,
     fs: float = 1.0,
-    window: _ToWindow = ("tukey_periodic", 0.25),
+    window: _ToWindowOrArray = ("tukey_periodic", 0.25),
     nperseg: int | None = None,
     noverlap: int | None = None,
     nfft: int | None = None,
@@ -312,15 +311,15 @@ def spectrogram(
 ) -> tuple[_float64_1d, _float64_1d, onp.Array]: ...
 
 #
-def check_COLA(window: _ToWindow, nperseg: int, noverlap: int, tol: float = 1e-10) -> np.bool: ...
-def check_NOLA(window: _ToWindow, nperseg: int, noverlap: int, tol: float = 1e-10) -> np.bool: ...
+def check_COLA(window: _ToWindowOrArray, nperseg: int, noverlap: int, tol: float = 1e-10) -> np.bool: ...
+def check_NOLA(window: _ToWindowOrArray, nperseg: int, noverlap: int, tol: float = 1e-10) -> np.bool: ...
 
 #
 @overload  # c128
 def stft(
     x: _ToInexact64ND,
     fs: float = 1.0,
-    window: _ToWindow = "hann_periodic",
+    window: _ToWindowOrArray = "hann_periodic",
     nperseg: int = 256,
     noverlap: int | None = None,
     nfft: int | None = None,
@@ -335,7 +334,7 @@ def stft(
 def stft(
     x: _ToInexact32ND,
     fs: float = 1.0,
-    window: _ToWindow = "hann_periodic",
+    window: _ToWindowOrArray = "hann_periodic",
     nperseg: int = 256,
     noverlap: int | None = None,
     nfft: int | None = None,
@@ -350,7 +349,7 @@ def stft(
 def stft(
     x: _ToInexact80ND,
     fs: float = 1.0,
-    window: _ToWindow = "hann_periodic",
+    window: _ToWindowOrArray = "hann_periodic",
     nperseg: int = 256,
     noverlap: int | None = None,
     nfft: int | None = None,
@@ -365,7 +364,7 @@ def stft(
 def stft(
     x: onp.ToComplexND,
     fs: float = 1.0,
-    window: _ToWindow = "hann_periodic",
+    window: _ToWindowOrArray = "hann_periodic",
     nperseg: int = 256,
     noverlap: int | None = None,
     nfft: int | None = None,
@@ -383,7 +382,7 @@ def stft(
 def istft(
     Zxx: _ToInexact64ND,
     fs: float = 1.0,
-    window: _ToWindow = "hann_periodic",
+    window: _ToWindowOrArray = "hann_periodic",
     nperseg: int | None = None,
     noverlap: int | None = None,
     nfft: int | None = None,
@@ -397,7 +396,7 @@ def istft(
 def istft(
     Zxx: _ToInexact64ND,
     fs: float = 1.0,
-    window: _ToWindow = "hann_periodic",
+    window: _ToWindowOrArray = "hann_periodic",
     nperseg: int | None = None,
     noverlap: int | None = None,
     nfft: int | None = None,
@@ -412,7 +411,7 @@ def istft(
 def istft(
     Zxx: _ToInexact32ND,
     fs: float = 1.0,
-    window: _ToWindow = "hann_periodic",
+    window: _ToWindowOrArray = "hann_periodic",
     nperseg: int | None = None,
     noverlap: int | None = None,
     nfft: int | None = None,
@@ -426,7 +425,7 @@ def istft(
 def istft(
     Zxx: _ToInexact32ND,
     fs: float = 1.0,
-    window: _ToWindow = "hann_periodic",
+    window: _ToWindowOrArray = "hann_periodic",
     nperseg: int | None = None,
     noverlap: int | None = None,
     nfft: int | None = None,
@@ -441,7 +440,7 @@ def istft(
 def istft(
     Zxx: _ToInexact80ND,
     fs: float = 1.0,
-    window: _ToWindow = "hann_periodic",
+    window: _ToWindowOrArray = "hann_periodic",
     nperseg: int | None = None,
     noverlap: int | None = None,
     nfft: int | None = None,
@@ -455,7 +454,7 @@ def istft(
 def istft(
     Zxx: _ToInexact80ND,
     fs: float = 1.0,
-    window: _ToWindow = "hann_periodic",
+    window: _ToWindowOrArray = "hann_periodic",
     nperseg: int | None = None,
     noverlap: int | None = None,
     nfft: int | None = None,
@@ -470,7 +469,7 @@ def istft(
 def istft(
     Zxx: onp.ToComplexND,
     fs: float = 1.0,
-    window: _ToWindow = "hann_periodic",
+    window: _ToWindowOrArray = "hann_periodic",
     nperseg: int | None = None,
     noverlap: int | None = None,
     nfft: int | None = None,
@@ -488,7 +487,7 @@ def coherence(
     x: _ToInexact64ND,
     y: _ToInexact64ND,
     fs: float = 1.0,
-    window: _ToWindow = "hann_periodic",
+    window: _ToWindowOrArray = "hann_periodic",
     nperseg: int | None = None,
     noverlap: int | None = None,
     nfft: int | None = None,
@@ -500,7 +499,7 @@ def coherence(
     x: _ToInexact32ND,
     y: _ToInexact32ND,
     fs: float = 1.0,
-    window: _ToWindow = "hann_periodic",
+    window: _ToWindowOrArray = "hann_periodic",
     nperseg: int | None = None,
     noverlap: int | None = None,
     nfft: int | None = None,
@@ -512,7 +511,7 @@ def coherence(
     x: _ToInexact80ND,
     y: _ToInexact80ND,
     fs: float = 1.0,
-    window: _ToWindow = "hann_periodic",
+    window: _ToWindowOrArray = "hann_periodic",
     nperseg: int | None = None,
     noverlap: int | None = None,
     nfft: int | None = None,
@@ -524,7 +523,7 @@ def coherence(
     x: onp.ToComplexND,
     y: onp.ToComplexND,
     fs: float = 1.0,
-    window: _ToWindow = "hann_periodic",
+    window: _ToWindowOrArray = "hann_periodic",
     nperseg: int | None = None,
     noverlap: int | None = None,
     nfft: int | None = None,

--- a/scipy-stubs/signal/windows/_windows.pyi
+++ b/scipy-stubs/signal/windows/_windows.pyi
@@ -44,8 +44,13 @@ type _DeviceNP = Literal["cpu"]
 type _Norm = Literal[2, "approximate", "subsample"]
 
 type _ToWindow = (
-    float | str | tuple[str] | tuple[str, float | onp.ToFloat1D] | tuple[str, float, float | int] | tuple[str, int, int, bool]
-)
+    float
+    | str
+    | tuple[str]
+    | tuple[str, float | onp.ToFloat1D]
+    | tuple[str, float, float]
+    | tuple[str, int, int, bool]
+)  # fmt: skip
 
 ###
 

--- a/tests/signal/test_signaltools.pyi
+++ b/tests/signal/test_signaltools.pyi
@@ -467,6 +467,9 @@ assert_type(resample_poly(_c128_2d, 1, 1), onp.Array2D[np.complex128])
 # pyrefly: ignore [no-matching-overload]
 resample_poly(_c160_2d, 1, 1)  # type: ignore[type-var]  # pyright: ignore[reportArgumentType, reportCallIssue]
 
+assert_type(resample_poly(_f64_1d, 1, 1, window=_f64_1d), onp.Array1D[np.float64])
+assert_type(resample_poly(_f64_1d, 1, 1, window=[1.0, 2.0, 3.0]), onp.Array1D[np.float64])
+
 # sosfilt
 
 assert_type(sosfilt(_py_i_2d, _py_i_1d), onp.ArrayND[np.float64])

--- a/tests/signal/test_spectral.pyi
+++ b/tests/signal/test_spectral.pyi
@@ -50,6 +50,7 @@ assert_type(periodogram(_f80_1d), tuple[_F64_1D, _F80_ND])
 assert_type(periodogram(_c64_1d), tuple[_F64_1D, _F32_ND])
 assert_type(periodogram(_c128_1d), tuple[_F64_1D, _F64_ND])
 assert_type(periodogram(_c160_1d), tuple[_F64_1D, _F80_ND])
+assert_type(periodogram(_f64_1d, window=_f64_1d), tuple[_F64_1D, _F64_ND])
 
 # welch
 
@@ -61,6 +62,8 @@ assert_type(welch(_f80_1d), tuple[_F64_1D, _F80_ND])
 assert_type(welch(_c64_1d), tuple[_F64_1D, _F32_ND])
 assert_type(welch(_c128_1d), tuple[_F64_1D, _F64_ND])
 assert_type(welch(_c160_1d), tuple[_F64_1D, _F80_ND])
+assert_type(welch(_f64_1d, window=_f64_1d), tuple[_F64_1D, _F64_ND])
+assert_type(welch(_f64_1d, window=[1.0, 2.0, 3.0]), tuple[_F64_1D, _F64_ND])
 
 # csd
 
@@ -72,6 +75,7 @@ assert_type(csd(_f80_1d, _f80_1d), tuple[_F64_1D, _C160_ND])
 assert_type(csd(_c64_1d, _c64_1d), tuple[_F64_1D, _C64_ND])
 assert_type(csd(_c128_1d, _c128_1d), tuple[_F64_1D, _C128_ND])
 assert_type(csd(_c160_1d, _c160_1d), tuple[_F64_1D, _C160_ND])
+assert_type(csd(_f64_1d, _f64_1d, window=_f64_1d), tuple[_F64_1D, _C128_ND])
 
 # spectrogram
 
@@ -93,10 +97,14 @@ assert_type(spectrogram(_c64_1d, mode="complex"), tuple[_F64_1D, _F64_1D, _C64_N
 assert_type(spectrogram(_c128_1d, mode="complex"), tuple[_F64_1D, _F64_1D, _C128_ND])
 assert_type(spectrogram(_c160_1d, mode="complex"), tuple[_F64_1D, _F64_1D, _C160_ND])
 
+assert_type(spectrogram(_f64_1d, window=_f64_1d), tuple[_F64_1D, _F64_1D, _F64_ND])
+
 # check_{COLA,NOLA}
 
 assert_type(check_COLA(256, 128, 256), np.bool)
 assert_type(check_NOLA(256, 128, 256), np.bool)
+assert_type(check_COLA(_f64_1d, 8, 4), np.bool)
+assert_type(check_NOLA(_f64_1d, 8, 4), np.bool)
 
 # stft
 
@@ -108,6 +116,8 @@ assert_type(stft(_f80_1d), tuple[_F64_1D, _F64_1D, _C160_ND])
 assert_type(stft(_c64_1d), tuple[_F64_1D, _F64_1D, _C64_ND])
 assert_type(stft(_c128_1d), tuple[_F64_1D, _F64_1D, _C128_ND])
 assert_type(stft(_c160_1d), tuple[_F64_1D, _F64_1D, _C160_ND])
+
+assert_type(stft(_f64_1d, window=_f64_1d), tuple[_F64_1D, _F64_1D, _C128_ND])
 
 # istft
 
@@ -129,6 +139,8 @@ assert_type(istft(_c64_1d, input_onesided=False), tuple[_F64_1D, _C64_ND])
 assert_type(istft(_c128_1d, input_onesided=False), tuple[_F64_1D, _C128_ND])
 assert_type(istft(_c160_1d, input_onesided=False), tuple[_F64_1D, _C160_ND])
 
+assert_type(istft(_c128_1d, window=_f64_1d), tuple[_F64_1D, _F64_ND])
+
 # coherence
 
 assert_type(coherence(_i64_1d, _i64_1d), tuple[_F64_1D, _F64_ND])
@@ -139,3 +151,5 @@ assert_type(coherence(_f80_1d, _f80_1d), tuple[_F64_1D, _F80_ND])
 assert_type(coherence(_c64_1d, _c64_1d), tuple[_F64_1D, _F32_ND])
 assert_type(coherence(_c128_1d, _c128_1d), tuple[_F64_1D, _F64_ND])
 assert_type(coherence(_c160_1d, _c160_1d), tuple[_F64_1D, _F80_ND])
+
+assert_type(coherence(_f64_1d, _f64_1d, window=_f64_1d), tuple[_F64_1D, _F64_ND])


### PR DESCRIPTION
This fixes false positives for valid things like `welch(x, window=np.hanning(256), nperseg=256)` and `resample_poly(x, 3, 2, window=np.ones(11))`.

Affected public `scipy.signal` functions:

- `periodogram`
- `welch`
- `csd`
- `spectrogram`
- `check_{COLA,NOLA}`
- `stft`
- `istft`
- `coherence`
- `resample_poly`