### PR TITLE
🐛 `signal.freq{s,z}_zpk`: fix input type of `k`

### DIFF
--- a/scipy-stubs/signal/_filter_design.pyi
+++ b/scipy-stubs/signal/_filter_design.pyi
@@ -110,12 +110,10 @@ def freqs(
 
 #
 @overload  # worN: real
-def freqs_zpk(
-    z: onp.ToComplex1D, p: onp.ToComplex1D, k: onp.ToComplex1D, worN: _WorNReal = 200
-) -> tuple[_Float1D, _Complex1D]: ...
+def freqs_zpk(z: onp.ToComplex1D, p: onp.ToComplex1D, k: onp.ToFloat, worN: _WorNReal = 200) -> tuple[_Float1D, _Complex1D]: ...
 @overload  # worN: complex
 def freqs_zpk(
-    z: onp.ToComplex1D, p: onp.ToComplex1D, k: onp.ToComplex1D, worN: onp.ToJustComplex1D
+    z: onp.ToComplex1D, p: onp.ToComplex1D, k: onp.ToFloat, worN: onp.ToJustComplex1D
 ) -> tuple[_Complex1D, _Complex1D]: ...
 
 #
@@ -156,7 +154,7 @@ def freqz(
 def freqz_zpk(
     z: onp.ToComplex1D,
     p: onp.ToComplex1D,
-    k: onp.ToComplex1D,
+    k: onp.ToFloat,
     worN: _WorNReal = 512,
     whole: bool = False,
     fs: float = 6.283185307179586,
@@ -165,7 +163,7 @@ def freqz_zpk(
 def freqz_zpk(
     z: onp.ToComplex1D,
     p: onp.ToComplex1D,
-    k: onp.ToComplex1D,
+    k: onp.ToFloat,
     worN: onp.ToJustComplex1D,
     whole: bool = False,
     fs: float = 6.283185307179586,

--- a/tests/signal/test_filter_design.pyi
+++ b/tests/signal/test_filter_design.pyi
@@ -59,6 +59,7 @@ from scipy.signal import (
 ###
 
 _f32: np.float32
+_f64: np.float64
 
 _i64_1d: onp.Array1D[np.int64]
 _f32_1d: onp.Array1D[np.float32]
@@ -93,9 +94,9 @@ assert_type(freqs(_f64_1d, _f64_1d, _f64_1d), tuple[onp.Array1D[np.float64], onp
 assert_type(freqs(_f64_1d, _f64_1d, _c128_1d), tuple[onp.Array1D[np.complex128], onp.Array1D[np.complex128]])
 
 # freqs_zpk
-assert_type(freqs_zpk(_f64_1d, _f64_1d, _f64_1d), tuple[onp.Array1D[np.float64], onp.Array1D[np.complex128]])
-assert_type(freqs_zpk(_f64_1d, _f64_1d, _f64_1d, _f64_1d), tuple[onp.Array1D[np.float64], onp.Array1D[np.complex128]])
-assert_type(freqs_zpk(_f64_1d, _f64_1d, _f64_1d, _c128_1d), tuple[onp.Array1D[np.complex128], onp.Array1D[np.complex128]])
+assert_type(freqs_zpk(_f64_1d, _f64_1d, _f64), tuple[onp.Array1D[np.float64], onp.Array1D[np.complex128]])
+assert_type(freqs_zpk(_f64_1d, _f64_1d, _f64, _f64_1d), tuple[onp.Array1D[np.float64], onp.Array1D[np.complex128]])
+assert_type(freqs_zpk(_f64_1d, _f64_1d, _f64, _c128_1d), tuple[onp.Array1D[np.complex128], onp.Array1D[np.complex128]])
 
 # freqz
 assert_type(freqz(_f64_1d), tuple[onp.ArrayND[np.float64], onp.ArrayND[np.complex128]])
@@ -105,9 +106,9 @@ assert_type(freqz(_f64_1d, _f64_1d, _c128_1d), tuple[onp.ArrayND[np.complex128],
 assert_type(freqz(_f64_1d, worN=_c128_1d), tuple[onp.ArrayND[np.complex128], onp.ArrayND[np.complex128]])
 
 # freqz_zpk
-assert_type(freqz_zpk(_f64_1d, _f64_1d, _f64_1d), tuple[onp.ArrayND[np.float64], onp.ArrayND[np.complex128]])
-assert_type(freqz_zpk(_f64_1d, _f64_1d, _f64_1d, _f64_1d), tuple[onp.ArrayND[np.float64], onp.ArrayND[np.complex128]])
-assert_type(freqz_zpk(_f64_1d, _f64_1d, _f64_1d, _c128_1d), tuple[onp.ArrayND[np.complex128], onp.ArrayND[np.complex128]])
+assert_type(freqz_zpk(_f64_1d, _f64_1d, _f64), tuple[onp.ArrayND[np.float64], onp.ArrayND[np.complex128]])
+assert_type(freqz_zpk(_f64_1d, _f64_1d, _f64, _f64_1d), tuple[onp.ArrayND[np.float64], onp.ArrayND[np.complex128]])
+assert_type(freqz_zpk(_f64_1d, _f64_1d, _f64, _c128_1d), tuple[onp.ArrayND[np.complex128], onp.ArrayND[np.complex128]])
 
 # group_delay
 assert_type(group_delay((_f64_1d, _f64_1d)), tuple[onp.Array1D[np.float64], onp.Array1D[np.float64]])


### PR DESCRIPTION
The `k` param of `freqs_zpk` and `freqz_zpk` accepts only real scalars at runtime, but scipy-stubs annotated it as a 1d complex array-like.