### PR TITLE
✨ `integrate.solve_ivp`: gradual `t_events` and `y_events` union type

### DIFF
--- a/scipy-stubs/integrate/_ivp/ivp.pyi
+++ b/scipy-stubs/integrate/_ivp/ivp.pyi
@@ -65,8 +65,8 @@ class OdeResult(_RichResult[Any], Generic[_Inexact64T_co]):
     t: _Float1D
     y: onp.Array2D[_Inexact64T_co]
     sol: OdeSolution | None
-    t_events: list[_Float1D] | None
-    y_events: list[onp.ArrayND[_Inexact64T_co]] | None
+    t_events: list[_Float1D] | Any
+    y_events: list[onp.ArrayND[_Inexact64T_co]] | Any
     nfev: int
     njev: int
     nlu: int


### PR DESCRIPTION
Claude called this a high priority bug, which is complete nonsense in every way you could possibly look at it. But still, it might be a bit nicer to use `| Any` instead of `| None` here, so i figured I might as well open a PR.