### PR TITLE
🐛 `optimize.minimize_scalar`: accept 1d array-likes for `bounds` and `bracket`

### DIFF
--- a/scipy-stubs/optimize/_minimize.pyi
+++ b/scipy-stubs/optimize/_minimize.pyi
@@ -17,8 +17,6 @@ __all__ = ["minimize", "minimize_scalar"]
 
 ###
 
-type _Tuple2[T] = tuple[T, T]
-type _Tuple3[T] = tuple[T, T, T]
 type _Args = tuple[object, ...]
 
 type _Floating = float | npc.floating
@@ -36,8 +34,6 @@ type _FDMethod = Literal["2-point", "3-point", "cs"]
 
 type _MethodF64 = Literal["Nelder-Mead", "nelder-mead", "COBYLA", "cobyla", "COBYQA", "cobyqa"]
 
-type _ToBracket = _Tuple2[onp.ToFloat] | _Tuple3[onp.ToFloat]
-type _ToBound = _Tuple2[onp.ToFloat]
 type _Ignored = object
 
 _MinimizeScalarResultT_co = TypeVar("_MinimizeScalarResultT_co", bound=_MinimizeScalarResultBase, covariant=True)
@@ -58,7 +54,7 @@ class _MinimizeMethodFun(Protocol):
 @type_check_only
 class _MinimizeScalarMethodFun(Protocol[_MinimizeScalarResultT_co]):
     def __call__(
-        self, fun: _Fun0D[onp.ToFloat], /, *, args: _Args, bracket: _ToBracket, bound: _ToBound
+        self, fun: _Fun0D[onp.ToFloat], /, *, args: _Args, bracket: onp.ToFloat1D, bound: onp.ToFloat1D
     ) -> _MinimizeScalarResultT_co: ...
 
 @type_check_only
@@ -283,7 +279,7 @@ def minimize[FunT: onp.ToFloat](
 @overload  # method="brent" or method="golden"
 def minimize_scalar(
     fun: _Fun0D[onp.ToFloat],
-    bracket: _ToBracket | None = None,
+    bracket: onp.ToFloat1D | None = None,
     bounds: None = None,
     args: _Args = (),
     method: Literal["brent", "golden"] | None = None,  # default: "brent"
@@ -294,7 +290,7 @@ def minimize_scalar(
 def minimize_scalar(
     fun: _Fun0D[onp.ToFloat],
     bracket: _Ignored | None,
-    bounds: _ToBound,
+    bounds: onp.ToFloat1D,
     args: _Args = (),
     method: Literal["bounded"] | None = None,
     tol: onp.ToFloat | None = None,
@@ -305,7 +301,7 @@ def minimize_scalar(
     fun: _Fun0D[onp.ToFloat],
     bracket: _Ignored | None = None,
     *,
-    bounds: _ToBound,
+    bounds: onp.ToFloat1D,
     args: _Args = (),
     method: Literal["bounded"] | None = None,
     tol: onp.ToFloat | None = None,
@@ -314,8 +310,8 @@ def minimize_scalar(
 @overload  # method=<custom>  (positional)
 def minimize_scalar[ResultT: _MinimizeScalarResultBase](
     fun: _Fun0D[onp.ToFloat],
-    bracket: _ToBracket | None,
-    bounds: _ToBound | None,
+    bracket: onp.ToFloat1D | None,
+    bounds: onp.ToFloat1D | None,
     args: _Args,
     method: _MinimizeScalarMethodFun[ResultT],
     tol: onp.ToFloat | None = None,
@@ -324,8 +320,8 @@ def minimize_scalar[ResultT: _MinimizeScalarResultBase](
 @overload  # method=<custom>  (keyword)
 def minimize_scalar[ResultT: _MinimizeScalarResultBase](
     fun: _Fun0D[onp.ToFloat],
-    bracket: _ToBracket | None = None,
-    bounds: _ToBound | None = None,
+    bracket: onp.ToFloat1D | None = None,
+    bounds: onp.ToFloat1D | None = None,
     args: _Args = (),
     *,
     method: _MinimizeScalarMethodFun[ResultT],

--- a/tests/optimize/test_minimize_scalar.pyi
+++ b/tests/optimize/test_minimize_scalar.pyi
@@ -1,6 +1,8 @@
 from typing import assert_type
 
+import numpy as np
 import numpy.polynomial as npp
+import optype.numpy as onp
 
 from scipy.optimize import minimize_scalar
 
@@ -8,6 +10,7 @@ def f(x: float, /) -> float: ...
 
 bracket: None
 bounds: tuple[float, float]
+arr_1d: onp.Array1D[np.float64]
 
 res = minimize_scalar(f)
 assert_type(res.success, bool)
@@ -17,6 +20,12 @@ assert_type(res.nfev, int)
 # https://github.com/scipy/scipy-stubs/issues/949
 res = minimize_scalar(f, bounds=bounds)
 res = minimize_scalar(f, bracket, bounds)
+
+res = minimize_scalar(f, bracket=[0, 2])
+res = minimize_scalar(f, bracket=[0, 1, 2])
+res = minimize_scalar(f, bracket=arr_1d)
+res = minimize_scalar(f, bounds=[0, 2], method="bounded")
+res = minimize_scalar(f, bounds=arr_1d, method="bounded")
 
 # https://github.com/scipy/scipy-stubs/issues/465
 p = npp.Polynomial([3, -2, 1, 1, 0.2])


### PR DESCRIPTION
related: #2214