### PR TITLE
🐛 `optimize.minimize`: accept 2d array-likes for `bounds`

### DIFF
--- a/scipy-stubs/optimize/_typing.pyi
+++ b/scipy-stubs/optimize/_typing.pyi
@@ -33,8 +33,8 @@ type _Float1D = onp.Array1D[np.float64]
 type _Args = tuple[object, ...]
 
 # bounds
-type Bound = tuple[onp.ToFloat | None, onp.ToFloat | None]
-type Bounds = Sequence[Bound] | _Bounds
+type Bound = Sequence[onp.ToFloat | None]
+type Bounds = Sequence[Bound] | onp.ToFloat2D | _Bounds
 
 # constaints
 @type_check_only

--- a/tests/optimize/test_minimize.pyi
+++ b/tests/optimize/test_minimize.pyi
@@ -3,7 +3,7 @@ from typing import Literal, assert_type, overload
 import numpy as np
 import optype.numpy as onp
 
-from scipy.optimize import minimize
+from scipy.optimize import Bounds, minimize
 
 ###
 
@@ -20,6 +20,7 @@ def _f_jac_over(x: onp.Array1D[np.float64], extra: Literal[False] = False) -> tu
 def _f_jac_over(x: onp.Array1D[np.float64], extra: Literal[True]) -> tuple[float, onp.Array1D[np.float64], np.float64]: ...
 
 _f64_1d: onp.Array1D[np.float64]
+_f64_2d: onp.Array2D[np.float64]
 _f64_nd: onp.ArrayND[np.float64]
 
 ###
@@ -40,3 +41,9 @@ assert_type(minimize(_f_jac_over, _f64_1d, (), "L-BFGS-B", True).fun, float)
 assert_type(minimize(_f_f32, _f64_1d, method="Nelder-Mead").fun, np.float64)
 assert_type(minimize(_f_f32, _f64_1d, method="cobyqa").fun, np.float64)
 assert_type(minimize(_f_f32, _f64_1d, (), "COBYLA").fun, np.float64)
+
+assert_type(minimize(_f_float, _f64_1d, bounds=[(0, 1), (0, 1)]).fun, float)
+assert_type(minimize(_f_float, _f64_1d, bounds=[[0, 1], [0, 1]]).fun, float)
+assert_type(minimize(_f_float, _f64_1d, bounds=_f64_2d).fun, float)
+assert_type(minimize(_f_float, _f64_1d, bounds=[(0, None), (None, 1)]).fun, float)
+assert_type(minimize(_f_float, _f64_1d, bounds=Bounds(0, 1)).fun, float)


### PR DESCRIPTION
related: #2214 and #2215