### PR TITLE
🐛 `spatial.transform.Rotation.create_group`: broaden input types and fix output shape

### DIFF
--- a/scipy-stubs/spatial/transform/_rotation.pyi
+++ b/scipy-stubs/spatial/transform/_rotation.pyi
@@ -10,14 +10,12 @@ import optype.numpy.compat as npc
 ###
 
 type _RotOrder = L["e", "extrinsic", "i", "intrinsic"]
-type _RotGroup = L["I", "O", "T", "D", "Dn", "C", "Cn"]
 type _RotAxisSeq = L[
     "xyz", "xzy", "yxz", "yzx", "zxy", "zyx",
     "xyx", "xzx", "yxy", "yzy", "zxz", "zyz",
     "XYZ", "XZY", "YXZ", "YZX", "ZXY", "ZYX",
     "XYX", "XZX", "YXY", "YZY", "ZXZ", "ZYZ",
 ]  # fmt: skip
-type _RotAxis = L["X", "Y", "Z"]
 
 type _JustAnyShape = tuple[Never, Never, Never, Never]
 type _ToFloatStrictND = onp.ArrayND[npc.floating | npc.integer, _JustAnyShape]
@@ -358,7 +356,7 @@ class Rotation(Generic[_ShapeT_co]):
 
     #
     @classmethod
-    def create_group(cls, group: _RotGroup, axis: _RotAxis = "Z") -> Rotation[tuple[()]]: ...
+    def create_group(cls, group: str, axis: L["x", "y", "z", "X", "Y", "Z"] = "Z") -> Rotation[tuple[int]]: ...
 
     #
     @overload

--- a/tests/spatial/test__rotation.pyi
+++ b/tests/spatial/test__rotation.pyi
@@ -83,8 +83,9 @@ assert_subtype[Rotation](Rotation.concatenate([_rot_nd, _rot_nd]))
 
 # create_group
 
-assert_type(Rotation.create_group("I"), Rotation[tuple[()]])
-assert_type(Rotation.create_group("Dn", "X"), Rotation[tuple[()]])
+assert_type(Rotation.create_group("I"), Rotation[tuple[int]])
+assert_type(Rotation.create_group("D4", "X"), Rotation[tuple[int]])
+assert_type(Rotation.create_group("I", "z"), Rotation[tuple[int]])
 
 # properties
 


### PR DESCRIPTION
Both classmethod parameters were too narrow and have been broadened, and the return type had the wrong ndim.