### PR TITLE
🐛 `special`: fix ufunc f32 co-promotion

### DIFF
--- a/scipy-stubs/special/_ufuncs.pyi
+++ b/scipy-stubs/special/_ufuncs.pyi
@@ -324,7 +324,7 @@ type _ToSubComplex = op.JustComplex | _ToSubFloat  # does not overlap with compl
 
 type _ToND[CoT: np.generic, ToT] = onp.CanArrayND[CoT] | onp.SequenceND[onp.CanArrayND[CoT]] | onp.SequenceND[ToT]
 
-type _ToFloat32 = int | np.float32 | _SubFloat
+type _ToFloat32 = np.float32 | _ToSubFloat
 type _ToFloat64OrND = onp.ToFloat64 | onp.ToFloat64_ND
 
 type _ToComplex64 = np.complex64 | _ToFloat32

--- a/tests/special/test_ufuncs.pyi
+++ b/tests/special/test_ufuncs.pyi
@@ -151,7 +151,22 @@ sp.logit.at(_c16, _i)  # type:ignore[arg-type]  # pyright: ignore[reportArgument
 
 ###
 
-# _UFunc21 - TODO
+# _UFunc21f
+assert_type(sp.beta(_f4, 2.0), np.float32)
+assert_type(sp.beta(2.0, _f4), np.float32)
+assert_type(sp.beta(1, _f4), np.float32)
+assert_type(sp.beta(_f8, 2.0), np.float64)
+assert_type(sp.beta(2.0, _f8), np.float64)
+
+# _UFunc21fc1
+assert_type(sp.jv(2.0, _f4), np.float32)
+assert_type(sp.jv(_f4, 2.0), np.float32 | np.float64)
+assert_type(sp.jv(2.0, _c8), np.complex64)
+
+# _UFunc21fc2
+assert_type(sp.xlogy(_f4_nd, 2.0), _Float32ND)
+assert_type(sp.xlogy(_f8_nd, 2.0), _Float64ND)
+
 # _UFunc22 - TODO
 # _UFunc24 - TODO
 


### PR DESCRIPTION
Calls like `beta(np.float32(1), 2.0)` were previously falsely rejected.