### PR TITLE
🐛 `optimize.line_search`: fix last return type

### DIFF
--- a/scipy-stubs/optimize/_linesearch.pyi
+++ b/scipy-stubs/optimize/_linesearch.pyi
@@ -38,7 +38,7 @@ def line_search_wolfe1(
     amax: onp.ToJustInt = 50,
     amin: onp.ToFloat = 1e-08,
     xtol: onp.ToFloat = 1e-14,
-) -> tuple[_Float | None, int, int, _Float | None, _Float, _Float | None]: ...
+) -> tuple[_Float | None, int, int, _Float | None, _Float, _Float1D]: ...
 
 # NOTE: exported as `scipy.optimize.line_search`
 def line_search_wolfe2(
@@ -55,7 +55,7 @@ def line_search_wolfe2(
     amax: onp.ToFloat | None = None,
     extra_condition: Callable[[float, _Float1D, float, _Float1D], bool] | None = None,
     maxiter: onp.ToJustInt = 10,
-) -> tuple[_Float | None, int, int, _Float | None, _Float, _Float | None]: ...
+) -> tuple[_Float | None, int, int, _Float | None, _Float, _Float1D | None]: ...
 
 #
 def line_search_armijo(

--- a/tests/optimize/test__optimize.pyi
+++ b/tests/optimize/test__optimize.pyi
@@ -188,5 +188,6 @@ assert_type(show_options(disp=False), str)
 # line_search
 
 assert_type(
-    line_search(_f, _fprime, _f64_1d, _f64_1d, _f64_1d), tuple[_Float | None, int, int, _Float | None, _Float, _Float | None]
+    line_search(_f, _fprime, _f64_1d, _f64_1d, _f64_1d), tuple[_Float | None, int, int, _Float | None, _Float, _Float1D | None]
 )
+assert_type(line_search(_f, _fprime, _f64_1d, _f64_1d)[5], _Float1D | None)


### PR DESCRIPTION
The last (fifth) return type of `scipy.optimize.line_search` should be a 1d array, not a scalar.