### PR TITLE
✨ `optimize.fsolve`: mark `full_output=True` infodict `njev` key as not required

### DIFF
--- a/scipy-stubs/optimize/_minpack_py.pyi
+++ b/scipy-stubs/optimize/_minpack_py.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Callable, Mapping
-from typing import Concatenate, Literal, TypedDict, Unpack, final, overload, type_check_only
+from typing import Concatenate, Literal, NotRequired, TypedDict, Unpack, final, overload, type_check_only
 
 import numpy as np
 import optype.numpy as onp
@@ -62,7 +62,7 @@ class _InfoDictBase(TypedDict):
 
 @type_check_only
 class _InfoDictSolve(_InfoDictBase, TypedDict):
-    njev: int
+    njev: NotRequired[int]  # only if `fprime` is given
     fjac: _Float2D
     r: _Float1D
     qtf: _Float1D

--- a/tests/optimize/test__minpack_py.pyi
+++ b/tests/optimize/test__minpack_py.pyi
@@ -25,6 +25,11 @@ assert_type(fsolve(_func, [1.0, 2.0]), _Float1D)
 assert_type(fsolve(_func, [1.0, 2.0], (), None, True), tuple[_Float1D, _InfoDictSolve, _IERFlag, str])
 assert_type(fsolve(_func, [1.0, 2.0], full_output=True), tuple[_Float1D, _InfoDictSolve, _IERFlag, str])
 
+_info: _InfoDictSolve
+assert_type(_info["nfev"], int)
+assert_type(_info["fjac"], _Float2D)
+assert_type(_info.get("njev"), int | None)
+
 ###
 # leastsq
 


### PR DESCRIPTION
It's only set if `fprime` is given.