### PR TITLE
🐛 `optimize.differential_evolution`: fix `jac` result attribute type

### DIFF
--- a/scipy-stubs/optimize/_differentialevolution.pyi
+++ b/scipy-stubs/optimize/_differentialevolution.pyi
@@ -1,5 +1,6 @@
 from collections.abc import Callable, Iterable
-from typing import Concatenate, Literal, Protocol, type_check_only
+from typing import Concatenate, Generic, Literal, Protocol, overload, type_check_only
+from typing_extensions import TypeVar
 
 import numpy as np
 import optype.numpy as onp
@@ -8,6 +9,10 @@ from ._constraints import Bounds, LinearConstraint, NonlinearConstraint
 from ._optimize import OptimizeResult as _OptimizeResult
 
 __all__ = ["differential_evolution"]
+
+###
+
+_JacT_co = TypeVar("_JacT_co", default=onp.Array1D[np.float64] | list[onp.Array2D[np.float64]] | None, covariant=True)
 
 ###
 
@@ -32,18 +37,19 @@ class _DoesMap(Protocol):
 
 ###
 
-class OptimizeResult(_OptimizeResult):
+class OptimizeResult(_OptimizeResult, Generic[_JacT_co]):
     x: onp.Array1D[np.float64]
     fun: float | np.float64
     population: onp.Array2D[np.float64]
     population_energies: onp.Array1D[np.float64]
-    jac: onp.Array2D[np.float64]  # only if `polish=True`
+    jac: _JacT_co  # only set when the polish step improved the result
 
     success: bool
     message: str
     nit: int
     nfev: int
 
+@overload  # constraints=() (default)
 def differential_evolution(
     func: Callable[Concatenate[onp.Array1D[np.float64], ...], onp.ToFloat],
     bounds: onp.ToFloat2D | Bounds,
@@ -62,10 +68,36 @@ def differential_evolution(
     atol: onp.ToFloat = 0,
     updating: Literal["immediate", "deferred"] = "immediate",
     workers: int | _DoesMap = 1,
-    constraints: NonlinearConstraint | LinearConstraint | Bounds | tuple[()] = (),
+    constraints: tuple[()] = (),
     x0: onp.ToArray1D | None = None,
     *,
     integrality: onp.ToBool1D | None = None,
     vectorized: bool = False,
     seed: onp.random.ToRNG | None = None,
-) -> OptimizeResult: ...
+) -> OptimizeResult[onp.Array1D[np.float64] | None]: ...
+@overload  # constraints=<given>
+def differential_evolution(
+    func: Callable[Concatenate[onp.Array1D[np.float64], ...], onp.ToFloat],
+    bounds: onp.ToFloat2D | Bounds,
+    args: tuple[object, ...] = (),
+    strategy: _StrategyName | Callable[[int, onp.Array2D[np.float64], np.random.Generator], onp.ToFloat1D] = "best1bin",
+    maxiter: onp.ToJustInt = 1000,
+    popsize: onp.ToJustInt = 15,
+    tol: onp.ToFloat = 0.01,
+    mutation: onp.ToFloat | tuple[onp.ToFloat, onp.ToFloat] = (0.5, 1),
+    recombination: onp.ToFloat = 0.7,
+    rng: onp.random.ToRNG | None = None,
+    callback: Callable[[OptimizeResult], None] | Callable[[onp.Array1D[np.float64], onp.ToFloat], None] | None = None,
+    disp: bool = False,
+    polish: bool = True,
+    init: onp.ToFloat2D | Literal["sobol", "halton", "random", "latinhypercube"] = "latinhypercube",
+    atol: onp.ToFloat = 0,
+    updating: Literal["immediate", "deferred"] = "immediate",
+    workers: int | _DoesMap = 1,
+    *,
+    constraints: NonlinearConstraint | LinearConstraint | Bounds,
+    x0: onp.ToArray1D | None = None,
+    integrality: onp.ToBool1D | None = None,
+    vectorized: bool = False,
+    seed: onp.random.ToRNG | None = None,
+) -> OptimizeResult[list[onp.Array2D[np.float64]] | None]: ...

--- a/tests/optimize/test_differentialevolution.pyi
+++ b/tests/optimize/test_differentialevolution.pyi
@@ -3,15 +3,32 @@ from typing import assert_type
 import numpy as np
 import optype.numpy as onp
 
-from scipy.optimize import differential_evolution
+from scipy.optimize import Bounds, NonlinearConstraint, differential_evolution
 from scipy.optimize._differentialevolution import OptimizeResult
 
 ###
 
+type _ResultUnconstrained = OptimizeResult[onp.Array1D[np.float64] | None]
+type _ResultConstrained = OptimizeResult[list[onp.Array2D[np.float64]] | None]
+
 def _obj(x: onp.Array1D[np.float64]) -> float: ...
+
+_b: list[tuple[float, float]]
+_nlc: NonlinearConstraint
 
 ###
 
-assert_type(differential_evolution(_obj, bounds=([-5.0], [5.0])), OptimizeResult)
-assert_type(differential_evolution(_obj, bounds=[(-5.0, 5.0), (-2.0, 2.0)]), OptimizeResult)
-assert_type(differential_evolution(_obj, bounds=[[-5.0, 5.0], [-2.0, 2.0]]), OptimizeResult)
+assert_type(differential_evolution(_obj, bounds=([-5.0], [5.0])), _ResultUnconstrained)
+assert_type(differential_evolution(_obj, bounds=[(-5.0, 5.0), (-2.0, 2.0)]), _ResultUnconstrained)
+assert_type(differential_evolution(_obj, bounds=[[-5.0, 5.0], [-2.0, 2.0]]), _ResultUnconstrained)
+assert_type(differential_evolution(_obj, _b, constraints=_nlc), _ResultConstrained)
+assert_type(differential_evolution(_obj, _b, constraints=Bounds(0, 1)), _ResultConstrained)
+
+_res: OptimizeResult
+
+assert_type(_res.x, onp.Array1D[np.float64])
+assert_type(_res.fun, float | np.float64)
+assert_type(_res.population, onp.Array2D[np.float64])
+assert_type(_res.jac, onp.Array1D[np.float64] | list[onp.Array2D[np.float64]] | None)
+assert_type(differential_evolution(_obj, _b).jac, onp.Array1D[np.float64] | None)
+assert_type(differential_evolution(_obj, _b, constraints=_nlc).jac, list[onp.Array2D[np.float64]] | None)


### PR DESCRIPTION
Depending on whether `constraints` is given, it can be a 1d array or list of 2d arrays, and in both cases could be None.