### PR TITLE
🐛 `optimize.elementwise`: fix `*_minimize`  returned bracket tuple type

### DIFF
--- a/scipy-stubs/optimize/_elementwise.pyi
+++ b/scipy-stubs/optimize/_elementwise.pyi
@@ -1,6 +1,6 @@
 from collections.abc import Callable, Mapping
-from typing import Any, Concatenate, Final, Generic, TypedDict, final, overload, type_check_only
-from typing_extensions import TypeVar
+from typing import Concatenate, Final, final, overload, type_check_only
+from typing_extensions import TypedDict
 
 import numpy as np
 import optype.numpy as onp
@@ -8,39 +8,46 @@ import optype.numpy.compat as npc
 
 from scipy._lib._util import _RichResult
 
-_ShapeT_co = TypeVar("_ShapeT_co", bound=tuple[int, ...], default=tuple[Any, ...], covariant=True)
-
-type _Bracket[T] = tuple[T, T]
+type _Tuple2[T] = tuple[T, T]
+type _Tuple3[T] = tuple[T, T, T]
 
 @type_check_only
-class _Tolerances(TypedDict, total=False):
+class _Tolerances(TypedDict, total=False, closed=True):
     xatol: onp.ToFloat
     xrtol: onp.ToFloat
     fatol: onp.ToFloat
     frtol: onp.ToFloat
 
 @type_check_only
-@final
-class _FindResult(_RichResult, Generic[_ShapeT_co]):
-    success: onp.ArrayND[np.bool, _ShapeT_co]
-    status: onp.ArrayND[np.int32, _ShapeT_co]
-    x: onp.ArrayND[np.float64, _ShapeT_co]
-    f_x: onp.ArrayND[np.float64, _ShapeT_co]
-    nfev: onp.ArrayND[np.int32, _ShapeT_co]
-    nit: onp.ArrayND[np.int32, _ShapeT_co]
-    bracket: _Bracket[onp.ArrayND[np.float64, _ShapeT_co]]
-    f_bracket: _Bracket[onp.ArrayND[np.float64, _ShapeT_co]]
+class _ResultBase[ShapeT: tuple[int, ...], BrackT](_RichResult):
+    success: onp.ArrayND[np.bool, ShapeT]
+    status: onp.ArrayND[np.int32, ShapeT]
+    nfev: onp.ArrayND[np.int32, ShapeT]
+    nit: onp.ArrayND[np.int32, ShapeT]
+    bracket: BrackT
+    f_bracket: BrackT
+
+@type_check_only
+class _FindResultBase[ShapeT: tuple[int, ...], BrackT](_ResultBase[ShapeT, BrackT]):
+    x: onp.ArrayND[np.float64, ShapeT]
+    f_x: onp.ArrayND[np.float64, ShapeT]
     _order_keys: Final = ["success", "status", "x", "f_x", "nfev", "nit", "bracket", "f_bracket"]
 
 @type_check_only
 @final
-class _BracketResult(_RichResult, Generic[_ShapeT_co]):
-    success: onp.ArrayND[np.bool, _ShapeT_co]
-    status: onp.ArrayND[np.int32, _ShapeT_co]
-    bracket: _Bracket[onp.ArrayND[np.float64, _ShapeT_co]]
-    f_bracket: _Bracket[onp.ArrayND[np.float64, _ShapeT_co]]
-    nfev: onp.ArrayND[np.int32, _ShapeT_co]
-    nit: onp.ArrayND[np.int32, _ShapeT_co]
+class _FindRootResult[ShapeT: tuple[int, ...]](_FindResultBase[ShapeT, _Tuple2[onp.ArrayND[np.float64, ShapeT]]]): ...
+
+@type_check_only
+@final
+class _FindMinResult[ShapeT: tuple[int, ...]](_FindResultBase[ShapeT, _Tuple3[onp.ArrayND[np.float64, ShapeT]]]): ...
+
+@type_check_only
+@final
+class _BracketRootResult[ShapeT: tuple[int, ...]](_ResultBase[ShapeT, _Tuple2[onp.ArrayND[np.float64, ShapeT]]]): ...
+
+@type_check_only
+@final
+class _BracketMinResult[ShapeT: tuple[int, ...]](_ResultBase[ShapeT, _Tuple3[onp.ArrayND[np.float64, ShapeT]]]): ...
 
 ###
 
@@ -48,39 +55,39 @@ class _BracketResult(_RichResult, Generic[_ShapeT_co]):
 @overload
 def find_root[ShapeT: tuple[int, ...]](
     f: Callable[[onp.ArrayND[np.float64, ShapeT]], onp.ArrayND[npc.floating]],
-    init: _Bracket[onp.ToFloat] | _Bracket[onp.ToFloatND],
+    init: _Tuple2[onp.ToFloat] | _Tuple2[onp.ToFloatND],
     /,
     *,
     args: tuple[()] = (),
     kwargs: None = None,
     tolerances: _Tolerances | None = None,
     maxiter: int | None = None,
-    callback: Callable[[_FindResult[ShapeT]], None] | None = None,
-) -> _FindResult[ShapeT]: ...
+    callback: Callable[[_FindRootResult[ShapeT]], None] | None = None,
+) -> _FindRootResult[ShapeT]: ...
 @overload
 def find_root[ShapeT: tuple[int, ...]](
     f: Callable[Concatenate[onp.ArrayND[np.float64, ShapeT], ...], onp.ArrayND[npc.floating]],
-    init: _Bracket[onp.ToFloat] | _Bracket[onp.ToFloatND],
+    init: _Tuple2[onp.ToFloat] | _Tuple2[onp.ToFloatND],
     /,
     *,
     args: tuple[object, ...],
     kwargs: Mapping[str, object] | None = None,
     tolerances: _Tolerances | None = None,
     maxiter: int | None = None,
-    callback: Callable[[_FindResult[ShapeT]], None] | None = None,
-) -> _FindResult[ShapeT]: ...
+    callback: Callable[[_FindRootResult[ShapeT]], None] | None = None,
+) -> _FindRootResult[ShapeT]: ...
 @overload
 def find_root[ShapeT: tuple[int, ...]](
     f: Callable[Concatenate[onp.ArrayND[np.float64, ShapeT], ...], onp.ArrayND[npc.floating]],
-    init: _Bracket[onp.ToFloat] | _Bracket[onp.ToFloatND],
+    init: _Tuple2[onp.ToFloat] | _Tuple2[onp.ToFloatND],
     /,
     *,
     args: tuple[object, ...] = (),
     kwargs: Mapping[str, object],
     tolerances: _Tolerances | None = None,
     maxiter: int | None = None,
-    callback: Callable[[_FindResult[ShapeT]], None] | None = None,
-) -> _FindResult[ShapeT]: ...
+    callback: Callable[[_FindRootResult[ShapeT]], None] | None = None,
+) -> _FindRootResult[ShapeT]: ...
 
 # TODO(@jorenham): array-api support
 @overload
@@ -93,8 +100,8 @@ def find_minimum[ShapeT: tuple[int, ...]](
     kwargs: None = None,
     tolerances: _Tolerances | None = None,
     maxiter: int = 100,
-    callback: Callable[[_FindResult[ShapeT]], None] | None = None,
-) -> _FindResult[ShapeT]: ...
+    callback: Callable[[_FindMinResult[ShapeT]], None] | None = None,
+) -> _FindMinResult[ShapeT]: ...
 @overload
 def find_minimum[ShapeT: tuple[int, ...]](
     f: Callable[Concatenate[onp.ArrayND[np.float64, ShapeT], ...], onp.ArrayND[npc.floating]],
@@ -105,8 +112,8 @@ def find_minimum[ShapeT: tuple[int, ...]](
     kwargs: Mapping[str, object] | None = None,
     tolerances: _Tolerances | None = None,
     maxiter: int = 100,
-    callback: Callable[[_FindResult[ShapeT]], None] | None = None,
-) -> _FindResult[ShapeT]: ...
+    callback: Callable[[_FindMinResult[ShapeT]], None] | None = None,
+) -> _FindMinResult[ShapeT]: ...
 @overload
 def find_minimum[ShapeT: tuple[int, ...]](
     f: Callable[Concatenate[onp.ArrayND[np.float64, ShapeT], ...], onp.ArrayND[npc.floating]],
@@ -117,8 +124,8 @@ def find_minimum[ShapeT: tuple[int, ...]](
     kwargs: Mapping[str, object],
     tolerances: _Tolerances | None = None,
     maxiter: int = 100,
-    callback: Callable[[_FindResult[ShapeT]], None] | None = None,
-) -> _FindResult[ShapeT]: ...
+    callback: Callable[[_FindMinResult[ShapeT]], None] | None = None,
+) -> _FindMinResult[ShapeT]: ...
 
 # TODO(@jorenham): array-api support
 @overload
@@ -133,7 +140,7 @@ def bracket_root[ShapeT: tuple[int, ...]](
     args: tuple[()] = (),
     kwargs: None = None,
     maxiter: int = 1_000,
-) -> _BracketResult[ShapeT]: ...
+) -> _BracketRootResult[ShapeT]: ...
 @overload
 def bracket_root[ShapeT: tuple[int, ...]](
     f: Callable[Concatenate[onp.ArrayND[np.float64, ShapeT], ...], onp.ArrayND[npc.floating]],
@@ -146,7 +153,7 @@ def bracket_root[ShapeT: tuple[int, ...]](
     args: tuple[object, ...],
     kwargs: Mapping[str, object] | None = None,
     maxiter: int = 1_000,
-) -> _BracketResult[ShapeT]: ...
+) -> _BracketRootResult[ShapeT]: ...
 @overload
 def bracket_root[ShapeT: tuple[int, ...]](
     f: Callable[Concatenate[onp.ArrayND[np.float64, ShapeT], ...], onp.ArrayND[npc.floating]],
@@ -159,7 +166,7 @@ def bracket_root[ShapeT: tuple[int, ...]](
     args: tuple[object, ...] = (),
     kwargs: Mapping[str, object],
     maxiter: int = 1_000,
-) -> _BracketResult[ShapeT]: ...
+) -> _BracketRootResult[ShapeT]: ...
 
 # TODO(@jorenham): array-api support
 @overload
@@ -175,7 +182,7 @@ def bracket_minimum[ShapeT: tuple[int, ...]](
     args: tuple[()] = (),
     kwargs: None = None,
     maxiter: int = 1_000,
-) -> _BracketResult[ShapeT]: ...
+) -> _BracketMinResult[ShapeT]: ...
 @overload
 def bracket_minimum[ShapeT: tuple[int, ...]](
     f: Callable[Concatenate[onp.ArrayND[np.float64, ShapeT], ...], onp.ArrayND[npc.floating]],
@@ -189,7 +196,7 @@ def bracket_minimum[ShapeT: tuple[int, ...]](
     args: tuple[object, ...],
     kwargs: Mapping[str, object] | None = None,
     maxiter: int = 1_000,
-) -> _BracketResult[ShapeT]: ...
+) -> _BracketMinResult[ShapeT]: ...
 @overload
 def bracket_minimum[ShapeT: tuple[int, ...]](
     f: Callable[Concatenate[onp.ArrayND[np.float64, ShapeT], ...], onp.ArrayND[npc.floating]],
@@ -203,4 +210,4 @@ def bracket_minimum[ShapeT: tuple[int, ...]](
     args: tuple[object, ...] = (),
     kwargs: Mapping[str, object],
     maxiter: int = 1_000,
-) -> _BracketResult[ShapeT]: ...
+) -> _BracketMinResult[ShapeT]: ...

--- a/tests/optimize/test_elementwise.pyi
+++ b/tests/optimize/test_elementwise.pyi
@@ -3,29 +3,57 @@ from typing import assert_type
 import numpy as np
 import optype.numpy as onp
 
-from scipy.optimize._elementwise import _BracketResult, _FindResult
 from scipy.optimize.elementwise import bracket_minimum, bracket_root, find_minimum, find_root
+
+type _VecB = onp.Array1D[np.bool]
+type _VecI32 = onp.Array1D[np.int32]
+type _VecF64 = onp.Array1D[np.float64]
+type _MatF64 = onp.Array2D[np.float64]
 
 def f_1d(x: onp.Array1D[np.float64]) -> onp.Array1D[np.float64]: ...
 def f_2d(x: onp.Array2D[np.float64]) -> onp.Array2D[np.float64]: ...
 def g_1d(x: onp.Array1D[np.float64], a: float) -> onp.Array1D[np.float64]: ...
 
 # find_root
-assert_type(find_root(f_1d, (-1.0, 1.0)), _FindResult[tuple[int]])
-assert_type(find_root(f_2d, (-1.0, 1.0)), _FindResult[tuple[int, int]])
-assert_type(find_root(g_1d, (-1.0, 1.0), args=(0.5,)), _FindResult[tuple[int]])
+assert_type(find_root(f_1d, (-1.0, 1.0)).success, _VecB)
+assert_type(find_root(f_1d, (-1.0, 1.0)).status, _VecI32)
+assert_type(find_root(f_1d, (-1.0, 1.0)).x, _VecF64)
+assert_type(find_root(f_1d, (-1.0, 1.0)).f_x, _VecF64)
+assert_type(find_root(f_1d, (-1.0, 1.0)).nfev, _VecI32)
+assert_type(find_root(f_1d, (-1.0, 1.0)).nit, _VecI32)
+assert_type(find_root(f_1d, (-1.0, 1.0)).bracket, tuple[_VecF64, _VecF64])
+assert_type(find_root(f_1d, (-1.0, 1.0)).f_bracket, tuple[_VecF64, _VecF64])
+assert_type(find_root(f_2d, (-1.0, 1.0)).x, _MatF64)
+assert_type(find_root(g_1d, (-1.0, 1.0), args=(0.5,)).x, _VecF64)
 
 # find_minimum
-assert_type(find_minimum(f_1d, (-1.0, 0.0, 1.0)), _FindResult[tuple[int]])
-assert_type(find_minimum(f_2d, (-1.0, 0.0, 1.0)), _FindResult[tuple[int, int]])
-assert_type(find_minimum(g_1d, (-1.0, 0.0, 1.0), args=(0.5,)), _FindResult[tuple[int]])
+assert_type(find_minimum(f_1d, (-1.0, 0.0, 1.0)).success, _VecB)
+assert_type(find_minimum(f_1d, (-1.0, 0.0, 1.0)).status, _VecI32)
+assert_type(find_minimum(f_1d, (-1.0, 0.0, 1.0)).x, _VecF64)
+assert_type(find_minimum(f_1d, (-1.0, 0.0, 1.0)).f_x, _VecF64)
+assert_type(find_minimum(f_1d, (-1.0, 0.0, 1.0)).nfev, _VecI32)
+assert_type(find_minimum(f_1d, (-1.0, 0.0, 1.0)).nit, _VecI32)
+assert_type(find_minimum(f_1d, (-1.0, 0.0, 1.0)).bracket, tuple[_VecF64, _VecF64, _VecF64])
+assert_type(find_minimum(f_1d, (-1.0, 0.0, 1.0)).f_bracket, tuple[_VecF64, _VecF64, _VecF64])
+assert_type(find_minimum(f_2d, (-1.0, 0.0, 1.0)).x, _MatF64)
+assert_type(find_minimum(g_1d, (-1.0, 0.0, 1.0), args=(0.5,)).x, _VecF64)
 
 # bracket_root
-assert_type(bracket_root(f_1d, -1.0), _BracketResult[tuple[int]])
-assert_type(bracket_root(f_2d, -1.0), _BracketResult[tuple[int, int]])
-assert_type(bracket_root(g_1d, -1.0, args=(0.5,)), _BracketResult[tuple[int]])
+assert_type(bracket_root(f_1d, -1.0).success, _VecB)
+assert_type(bracket_root(f_1d, -1.0).status, _VecI32)
+assert_type(bracket_root(f_1d, -1.0).nfev, _VecI32)
+assert_type(bracket_root(f_1d, -1.0).nit, _VecI32)
+assert_type(bracket_root(f_1d, -1.0).bracket, tuple[_VecF64, _VecF64])
+assert_type(bracket_root(f_1d, -1.0).f_bracket, tuple[_VecF64, _VecF64])
+assert_type(bracket_root(f_2d, -1.0).bracket, tuple[_MatF64, _MatF64])
+assert_type(bracket_root(g_1d, -1.0, args=(0.5,)).bracket, tuple[_VecF64, _VecF64])
 
 # bracket_minimum
-assert_type(bracket_minimum(f_1d, 0.0), _BracketResult[tuple[int]])
-assert_type(bracket_minimum(f_2d, 0.0), _BracketResult[tuple[int, int]])
-assert_type(bracket_minimum(g_1d, 0.0, args=(0.5,)), _BracketResult[tuple[int]])
+assert_type(bracket_minimum(f_1d, 0.0).success, _VecB)
+assert_type(bracket_minimum(f_1d, 0.0).status, _VecI32)
+assert_type(bracket_minimum(f_1d, 0.0).nfev, _VecI32)
+assert_type(bracket_minimum(f_1d, 0.0).nit, _VecI32)
+assert_type(bracket_minimum(f_1d, 0.0).bracket, tuple[_VecF64, _VecF64, _VecF64])
+assert_type(bracket_minimum(f_1d, 0.0).f_bracket, tuple[_VecF64, _VecF64, _VecF64])
+assert_type(bracket_minimum(f_2d, 0.0).bracket, tuple[_MatF64, _MatF64, _MatF64])
+assert_type(bracket_minimum(g_1d, 0.0, args=(0.5,)).bracket, tuple[_VecF64, _VecF64, _VecF64])


### PR DESCRIPTION
`find_minimum` and `bracket_minimum` return a 3-element tuple for the `bracket` and `f_bracket` attrs of the returned result class instead of a 2-element tuple like the `*_root` functions.

I also improved the tests a bit by removing the assertions on type-check-only types, and deduped the result class attributes.