### PR TITLE
🐛 `interpolate.BivariateSpline`: fix `tck[2]` type

### DIFF
--- a/scipy-stubs/interpolate/_fitpack2.pyi
+++ b/scipy-stubs/interpolate/_fitpack2.pyi
@@ -148,7 +148,7 @@ class _DerivedBivariateSpline(_BivariateSplineBase):  # undocumented
 
 class SmoothBivariateSpline(BivariateSpline):
     fp: Final[float]
-    tck: tuple[_Float1D, _Float1D, int]
+    tck: tuple[_Float1D, _Float1D, _Float1D]
     degrees: tuple[int, int]
 
     def __init__(
@@ -167,7 +167,7 @@ class SmoothBivariateSpline(BivariateSpline):
 
 class LSQBivariateSpline(BivariateSpline):
     fp: Final[float]
-    tck: tuple[_Float1D, _Float1D, int]
+    tck: tuple[_Float1D, _Float1D, _Float1D]
     degrees: tuple[int, int]
 
     def __init__(
@@ -187,7 +187,7 @@ class LSQBivariateSpline(BivariateSpline):
 
 class RectBivariateSpline(BivariateSpline):
     fp: Final[float]
-    tck: tuple[_Float1D, _Float1D, int]
+    tck: tuple[_Float1D, _Float1D, _Float1D]
     degrees: tuple[int, int]
 
     def __init__(
@@ -212,7 +212,7 @@ class SphereBivariateSpline(_BivariateSplineBase):
 
 class SmoothSphereBivariateSpline(SphereBivariateSpline):
     fp: Final[float]
-    tck: tuple[_Float1D, _Float1D, int]
+    tck: tuple[_Float1D, _Float1D, _Float1D]
     degrees: tuple[int, int]
 
     def __init__(
@@ -228,7 +228,7 @@ class SmoothSphereBivariateSpline(SphereBivariateSpline):
 
 class LSQSphereBivariateSpline(SphereBivariateSpline):
     fp: Final[float]
-    tck: tuple[_Float1D, _Float1D, int]
+    tck: tuple[_Float1D, _Float1D, _Float1D]
     degrees: tuple[int, int]
 
     def __init__(
@@ -245,7 +245,7 @@ class LSQSphereBivariateSpline(SphereBivariateSpline):
 
 class RectSphereBivariateSpline(SphereBivariateSpline):
     fp: Final[float]
-    tck: tuple[_Float1D, _Float1D, int]
+    tck: tuple[_Float1D, _Float1D, _Float1D]
     degrees: tuple[int, int]
     v0: np.float64
 

--- a/tests/interpolate/test_fitpack2.pyi
+++ b/tests/interpolate/test_fitpack2.pyi
@@ -55,6 +55,8 @@ assert_type(sbs.get_knots(), tuple[onp.Array1D[np.float64], onp.Array1D[np.float
 assert_type(sbs.get_coeffs(), onp.Array1D[np.float64])
 assert_type(sbs.get_residual(), float)
 assert_type(sbs.integral(0.0, 1.0, 0.0, 1.0), float)
+assert_type(sbs.tck, tuple[onp.Array1D[np.float64], onp.Array1D[np.float64], onp.Array1D[np.float64]])
+assert_type(sbs.degrees, tuple[int, int])
 
 # LSQBivariateSpline
 lbs = LSQBivariateSpline(x, y, y, x[2:-2], x[2:-2])
@@ -63,6 +65,7 @@ assert_type(lbs(x, y), onp.Array2D[np.float64])
 assert_type(lbs(x, y, grid=True), onp.Array2D[np.float64])
 assert_type(lbs(x, y, grid=False), onp.Array1D[np.float64])
 assert_type(lbs.ev(x, y), onp.ArrayND[np.float64])
+assert_type(lbs.tck, tuple[onp.Array1D[np.float64], onp.Array1D[np.float64], onp.Array1D[np.float64]])
 
 # RectBivariateSpline
 rbs = RectBivariateSpline(x, y, x2d)
@@ -71,6 +74,7 @@ assert_type(rbs(x, y), onp.Array2D[np.float64])
 assert_type(rbs(x, y, grid=True), onp.Array2D[np.float64])
 assert_type(rbs(x, y, grid=False), onp.Array1D[np.float64])
 assert_type(rbs.ev(x, y), onp.ArrayND[np.float64])
+assert_type(rbs.tck, tuple[onp.Array1D[np.float64], onp.Array1D[np.float64], onp.Array1D[np.float64]])
 
 # BivariateSpline
 


### PR DESCRIPTION
It should be a 1d f64 array, not an int.