### PR TITLE
🐛 `stats`: fix `{epps_singleton, cramervonmises}_2samp` return types

### DIFF
--- a/scipy-stubs/stats/_hypotests.pyi
+++ b/scipy-stubs/stats/_hypotests.pyi
@@ -6,6 +6,7 @@ from typing_extensions import TypeVar
 import numpy as np
 import optype as op
 import optype.numpy as onp
+import optype.numpy.compat as npc
 
 from ._common import ConfidenceInterval
 from ._stats_py import SignificanceResult
@@ -24,15 +25,15 @@ __all__ = [
 
 ###
 
-type _Float2D = onp.Array2D[np.float64]
-type _FloatND = onp.ArrayND[np.float64]
-type _FloatOrND = float | _FloatND
+type _AsF64ND = onp.ToArrayND[float, npc.floating64 | npc.integer | np.bool]
+type _AsF64Strict1D = onp.ToArrayStrict1D[float, npc.floating64 | npc.integer | np.bool]
 
 type _ToCDF = str | Callable[Concatenate[float, ...], float | np.float32]
 type _ToCDFArgs = tuple[onp.ToFloat, ...]
+
 type _CV2Method = Literal["auto", "asymptotic", "exact"]
 
-_FloatOrNDT = TypeVar("_FloatOrNDT", bound=_FloatOrND, default=Any)
+_FloatOrNDT = TypeVar("_FloatOrNDT", bound=np.float32 | np.float64 | onp.ArrayND[np.float64], default=Any)
 
 ###
 
@@ -40,27 +41,92 @@ class Epps_Singleton_2sampResult(NamedTuple, Generic[_FloatOrNDT]):
     statistic: _FloatOrNDT  # readonly
     pvalue: _FloatOrNDT  # readonly
 
-@overload
+class CramerVonMisesResult(Generic[_FloatOrNDT]):
+    statistic: _FloatOrNDT  # readonly
+    pvalue: _FloatOrNDT  # readonly
+    def __init__(self, /, statistic: _FloatOrNDT, pvalue: _FloatOrNDT) -> None: ...
+
+class TukeyHSDResult:
+    statistic: Final[onp.Array2D[np.float64]]
+    pvalue: Final[onp.Array2D[np.float64]]
+    _ntreatments: Final[int]
+    _df: Final[int]
+    _stand_err: Final[float]
+
+    def __init__(
+        self,
+        /,
+        statistic: onp.Array2D[np.float64],
+        pvalue: onp.Array2D[np.float64],
+        _ntreatments: int,
+        _df: int,
+        _stand_err: float,
+    ) -> None: ...
+
+    _ci: ConfidenceInterval | None
+    _ci_cl: float | None
+
+    def confidence_interval(
+        self, /, confidence_level: float | np.float64 = 0.95
+    ) -> ConfidenceInterval[onp.Array2D[np.float64]]: ...
+
+@dataclass
+class BoschlooExactResult:
+    statistic: Final[float]
+    pvalue: Final[float]
+
+@dataclass
+class SomersDResult:
+    statistic: Final[float]
+    pvalue: Final[float]
+    table: Final[onp.Array2D[np.int_]]
+
+@dataclass
+class BarnardExactResult:
+    statistic: Final[float]
+    pvalue: Final[float]
+
+@overload  # +f64, 1d
 def epps_singleton_2samp(
-    x: onp.ToFloatStrict1D,
-    y: onp.ToFloatStrict1D,
+    x: _AsF64Strict1D,
+    y: _AsF64Strict1D,
     t: onp.ToFloatStrict1D = (0.4, 0.8),
     *,
     axis: Literal[0, -1] | None = 0,
     nan_policy: NanPolicy = "propagate",
     keepdims: onp.ToFalse = False,
-) -> Epps_Singleton_2sampResult[float]: ...
-@overload
+) -> Epps_Singleton_2sampResult[np.float64]: ...
+@overload  # +f64, axis: None
 def epps_singleton_2samp(
-    x: onp.ToFloatND,
-    y: onp.ToFloatND,
+    x: _AsF64ND,
+    y: _AsF64ND,
     t: onp.ToFloatND = (0.4, 0.8),
     *,
     axis: None,
     nan_policy: NanPolicy = "propagate",
     keepdims: onp.ToFalse = False,
-) -> Epps_Singleton_2sampResult[float]: ...
-@overload
+) -> Epps_Singleton_2sampResult[np.float64]: ...
+@overload  # ~f32, 1d
+def epps_singleton_2samp(
+    x: onp.ToJustFloat32Strict1D,
+    y: onp.ToJustFloat32Strict1D,
+    t: onp.ToFloatStrict1D = (0.4, 0.8),
+    *,
+    axis: Literal[0, -1] | None = 0,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: onp.ToFalse = False,
+) -> Epps_Singleton_2sampResult[np.float32]: ...
+@overload  # ~f32, axis: None
+def epps_singleton_2samp(
+    x: onp.ToJustFloat32_ND,
+    y: onp.ToJustFloat32_ND,
+    t: onp.ToFloatND = (0.4, 0.8),
+    *,
+    axis: None,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: onp.ToFalse = False,
+) -> Epps_Singleton_2sampResult[np.float32]: ...
+@overload  # keepdims: True
 def epps_singleton_2samp(
     x: onp.ToFloatND,
     y: onp.ToFloatND,
@@ -69,8 +135,8 @@ def epps_singleton_2samp(
     axis: int = 0,
     nan_policy: NanPolicy = "propagate",
     keepdims: onp.ToTrue,
-) -> Epps_Singleton_2sampResult[_FloatND]: ...
-@overload
+) -> Epps_Singleton_2sampResult[onp.ArrayND[np.float64]]: ...
+@overload  # fallback
 def epps_singleton_2samp(
     x: onp.ToFloatND,
     y: onp.ToFloatND,
@@ -80,12 +146,6 @@ def epps_singleton_2samp(
     nan_policy: NanPolicy = "propagate",
     keepdims: bool = False,
 ) -> Epps_Singleton_2sampResult: ...
-
-class CramerVonMisesResult(Generic[_FloatOrNDT]):
-    statistic: _FloatOrNDT  # readonly
-    pvalue: _FloatOrNDT  # readonly
-    def __init__(self, /, statistic: _FloatOrNDT, pvalue: _FloatOrNDT) -> None: ...
-
 @overload
 def cramervonmises(
     rvs: onp.ToFloatStrict1D,
@@ -95,7 +155,7 @@ def cramervonmises(
     axis: Literal[0, -1] | None = 0,
     nan_policy: NanPolicy = "propagate",
     keepdims: onp.ToFalse = False,
-) -> CramerVonMisesResult[float]: ...
+) -> CramerVonMisesResult[np.float64]: ...
 @overload
 def cramervonmises(
     rvs: onp.ToFloatND,
@@ -105,7 +165,7 @@ def cramervonmises(
     axis: None,
     nan_policy: NanPolicy = "propagate",
     keepdims: onp.ToFalse = False,
-) -> CramerVonMisesResult[float]: ...
+) -> CramerVonMisesResult[np.float64]: ...
 @overload
 def cramervonmises(
     rvs: onp.ToFloatND,
@@ -115,7 +175,7 @@ def cramervonmises(
     axis: int = 0,
     nan_policy: NanPolicy = "propagate",
     keepdims: onp.ToTrue,
-) -> CramerVonMisesResult[_FloatND]: ...
+) -> CramerVonMisesResult[onp.ArrayND[np.float64]]: ...
 @overload
 def cramervonmises(
     rvs: onp.ToFloatND,
@@ -128,27 +188,47 @@ def cramervonmises(
 ) -> CramerVonMisesResult: ...
 
 #
-@overload
+@overload  # 1d, +f64
 def cramervonmises_2samp(
-    x: onp.ToFloatStrict1D,
-    y: onp.ToFloatStrict1D,
+    x: _AsF64Strict1D,
+    y: _AsF64Strict1D,
     method: _CV2Method = "auto",
     *,
     axis: Literal[0, -1] | None = 0,
     nan_policy: NanPolicy = "propagate",
     keepdims: onp.ToFalse = False,
-) -> CramerVonMisesResult[float]: ...
-@overload
+) -> CramerVonMisesResult[np.float64]: ...
+@overload  # +f64, axis: None
 def cramervonmises_2samp(
-    x: onp.ToFloatND,
-    y: onp.ToFloatND,
+    x: _AsF64ND,
+    y: _AsF64ND,
     method: _CV2Method = "auto",
     *,
     axis: None,
     nan_policy: NanPolicy = "propagate",
     keepdims: onp.ToFalse = False,
-) -> CramerVonMisesResult[float]: ...
-@overload
+) -> CramerVonMisesResult[np.float64]: ...
+@overload  # 1d, ~f32
+def cramervonmises_2samp(
+    x: onp.ToJustFloat32Strict1D,
+    y: onp.ToJustFloat32Strict1D,
+    method: _CV2Method = "auto",
+    *,
+    axis: Literal[0, -1] | None = 0,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: onp.ToFalse = False,
+) -> CramerVonMisesResult[np.float32]: ...
+@overload  # x~f32, axis: None
+def cramervonmises_2samp(
+    x: onp.ToJustFloat32_ND,
+    y: onp.ToJustFloat32_ND,
+    method: _CV2Method = "auto",
+    *,
+    axis: None,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: onp.ToFalse = False,
+) -> CramerVonMisesResult[np.float32]: ...
+@overload  # keepdims: True
 def cramervonmises_2samp(
     x: onp.ToFloatND,
     y: onp.ToFloatND,
@@ -157,8 +237,8 @@ def cramervonmises_2samp(
     axis: int = 0,
     nan_policy: NanPolicy = "propagate",
     keepdims: onp.ToTrue,
-) -> CramerVonMisesResult[_FloatND]: ...
-@overload
+) -> CramerVonMisesResult[onp.ArrayND[np.float64]]: ...
+@overload  # fallback
 def cramervonmises_2samp(
     x: onp.ToFloatND,
     y: onp.ToFloatND,
@@ -175,46 +255,17 @@ def poisson_means_test(
 ) -> SignificanceResult[np.float64]: ...
 
 #
-@dataclass
-class SomersDResult:
-    statistic: Final[float]
-    pvalue: Final[float]
-    table: Final[onp.Array2D[np.int_]]
-
 def somersd(
     x: onp.ToFloat1D | onp.ToFloat2D, y: onp.ToFloat1D | None = None, alternative: Alternative = "two-sided"
 ) -> SomersDResult: ...
 
 #
-@dataclass
-class BarnardExactResult:
-    statistic: Final[float]
-    pvalue: Final[float]
-
 def barnard_exact(
     table: onp.ToInt2D, alternative: Alternative = "two-sided", pooled: bool = True, n: op.JustInt = 32
 ) -> BarnardExactResult: ...
 
 #
-@dataclass
-class BoschlooExactResult:
-    statistic: Final[float]
-    pvalue: Final[float]
-
 def boschloo_exact(table: onp.ToInt2D, alternative: Alternative = "two-sided", n: op.JustInt = 32) -> BoschlooExactResult: ...
 
 #
-class TukeyHSDResult:
-    statistic: Final[_Float2D]
-    pvalue: Final[_Float2D]
-    _ntreatments: Final[int]
-    _df: Final[int]
-    _stand_err: Final[float]
-    def __init__(self, /, statistic: _Float2D, pvalue: _Float2D, _ntreatments: int, _df: int, _stand_err: float) -> None: ...
-
-    #
-    _ci: ConfidenceInterval | None
-    _ci_cl: float | None
-    def confidence_interval(self, /, confidence_level: float | np.float64 = 0.95) -> ConfidenceInterval[_Float2D]: ...
-
 def tukey_hsd(arg0: onp.ToFloatND, arg1: onp.ToFloatND, /, *args: onp.ToFloatND, equal_var: bool = True) -> TukeyHSDResult: ...

--- a/tests/stats/test__hypotests.pyi
+++ b/tests/stats/test__hypotests.pyi
@@ -27,83 +27,89 @@ from scipy.stats._stats_py import SignificanceResult
 
 ###
 
-_f1d: onp.Array1D[np.float64]
-_f2d: onp.Array2D[np.float64]
-_fnd: onp.ArrayND[np.float64]
-_i2d: onp.Array2D[np.int64]
+_i64_2d: onp.Array2D[np.int64]
 
-_py_f_1d: list[float]
+_f32_1d: onp.Array1D[np.float32]
+_f32_2d: onp.Array2D[np.float32]
+
+_f64_1d: onp.Array1D[np.float64]
+_f64_2d: onp.Array2D[np.float64]
+_f64_nd: onp.ArrayND[np.float64]
+
 _py_i_2d: list[list[int]]
+_py_f_1d: list[float]
 
 ###
+
 # epps_singleton_2samp
 
-assert_type(epps_singleton_2samp(_py_f_1d, _py_f_1d), Epps_Singleton_2sampResult[float])
-assert_type(epps_singleton_2samp(_f1d, _f1d), Epps_Singleton_2sampResult[float])
-assert_type(epps_singleton_2samp(_fnd, _fnd, axis=None), Epps_Singleton_2sampResult[float])
-assert_type(epps_singleton_2samp(_fnd, _fnd, keepdims=True), Epps_Singleton_2sampResult[onp.ArrayND[np.float64]])
+assert_type(epps_singleton_2samp(_py_f_1d, _py_f_1d), Epps_Singleton_2sampResult[np.float64])
+assert_type(epps_singleton_2samp(_f64_1d, _f64_1d), Epps_Singleton_2sampResult[np.float64])
+assert_type(epps_singleton_2samp(_f64_nd, _f64_nd, axis=None), Epps_Singleton_2sampResult[np.float64])
+assert_type(epps_singleton_2samp(_f64_nd, _f64_nd, keepdims=True), Epps_Singleton_2sampResult[onp.ArrayND[np.float64]])
 
-assert_type(epps_singleton_2samp(_f1d, _f1d).statistic, float)
-assert_type(epps_singleton_2samp(_f1d, _f1d).pvalue, float)
+assert_type(epps_singleton_2samp(_f32_1d, _f32_1d), Epps_Singleton_2sampResult[np.float32])
+assert_type(epps_singleton_2samp(_f32_2d, _f32_2d, axis=None), Epps_Singleton_2sampResult[np.float32])
 
-###
+assert_type(epps_singleton_2samp(_f64_1d, _f64_1d).statistic, np.float64)
+assert_type(epps_singleton_2samp(_f64_1d, _f64_1d).pvalue, np.float64)
+
 # cramervonmises
 
-assert_type(cramervonmises(_py_f_1d, "norm"), CramerVonMisesResult[float])
-assert_type(cramervonmises(_f1d, "norm"), CramerVonMisesResult[float])
-assert_type(cramervonmises(_fnd, "norm", axis=None), CramerVonMisesResult[float])
-assert_type(cramervonmises(_fnd, "norm", keepdims=True), CramerVonMisesResult[onp.ArrayND[np.float64]])
+assert_type(cramervonmises(_py_f_1d, "norm"), CramerVonMisesResult[np.float64])
+assert_type(cramervonmises(_f64_1d, "norm"), CramerVonMisesResult[np.float64])
+assert_type(cramervonmises(_f64_nd, "norm", axis=None), CramerVonMisesResult[np.float64])
+assert_type(cramervonmises(_f64_nd, "norm", keepdims=True), CramerVonMisesResult[onp.ArrayND[np.float64]])
 
-assert_type(cramervonmises(_f1d, "norm").statistic, float)
-assert_type(cramervonmises(_f1d, "norm").pvalue, float)
+assert_type(cramervonmises(_f32_1d, "norm"), CramerVonMisesResult[np.float64])
 
-###
+assert_type(cramervonmises(_f64_1d, "norm").statistic, np.float64)
+assert_type(cramervonmises(_f64_1d, "norm").pvalue, np.float64)
+
 # cramervonmises_2samp
 
-assert_type(cramervonmises_2samp(_py_f_1d, _py_f_1d), CramerVonMisesResult[float])
-assert_type(cramervonmises_2samp(_f1d, _f1d), CramerVonMisesResult[float])
-assert_type(cramervonmises_2samp(_fnd, _fnd, axis=None), CramerVonMisesResult[float])
-assert_type(cramervonmises_2samp(_fnd, _fnd, keepdims=True), CramerVonMisesResult[onp.ArrayND[np.float64]])
+assert_type(cramervonmises_2samp(_py_f_1d, _py_f_1d), CramerVonMisesResult[np.float64])
+assert_type(cramervonmises_2samp(_f64_1d, _f64_1d), CramerVonMisesResult[np.float64])
+assert_type(cramervonmises_2samp(_f64_nd, _f64_nd, axis=None), CramerVonMisesResult[np.float64])
+assert_type(cramervonmises_2samp(_f64_nd, _f64_nd, keepdims=True), CramerVonMisesResult[onp.ArrayND[np.float64]])
 
-assert_type(cramervonmises_2samp(_f1d, _f1d).statistic, float)
-assert_type(cramervonmises_2samp(_f1d, _f1d).pvalue, float)
+assert_type(cramervonmises_2samp(_f32_1d, _f32_1d), CramerVonMisesResult[np.float32])
+assert_type(cramervonmises_2samp(_f32_2d, _f32_2d, axis=None), CramerVonMisesResult[np.float32])
 
-###
+assert_type(cramervonmises_2samp(_f64_1d, _f64_1d).statistic, np.float64)
+assert_type(cramervonmises_2samp(_f64_1d, _f64_1d).pvalue, np.float64)
+
 # poisson_means_test
 
 assert_type(poisson_means_test(5, 100.0, 3, 80.0), SignificanceResult[np.float64])
 assert_type(poisson_means_test(5, 100.0, 3, 80.0).statistic, np.float64)
 assert_type(poisson_means_test(5, 100.0, 3, 80.0).pvalue, np.float64)
 
-###
 # somersd
 
 assert_type(somersd(_py_f_1d, _py_f_1d), SomersDResult)
-assert_type(somersd(_f1d, _f1d), SomersDResult)
-assert_type(somersd(_f2d), SomersDResult)
-assert_type(somersd(_f1d, _f1d).statistic, float)
-assert_type(somersd(_f1d, _f1d).pvalue, float)
+assert_type(somersd(_f64_1d, _f64_1d), SomersDResult)
+assert_type(somersd(_f64_2d), SomersDResult)
+assert_type(somersd(_f64_1d, _f64_1d).statistic, float)
+assert_type(somersd(_f64_1d, _f64_1d).pvalue, float)
 
-###
 # barnard_exact
 
 assert_type(barnard_exact(_py_i_2d), BarnardExactResult)
-assert_type(barnard_exact(_i2d), BarnardExactResult)
-assert_type(barnard_exact(_i2d).statistic, float)
-assert_type(barnard_exact(_i2d).pvalue, float)
+assert_type(barnard_exact(_i64_2d), BarnardExactResult)
+assert_type(barnard_exact(_i64_2d).statistic, float)
+assert_type(barnard_exact(_i64_2d).pvalue, float)
 
-###
 # boschloo_exact
 
 assert_type(boschloo_exact(_py_i_2d), BoschlooExactResult)
-assert_type(boschloo_exact(_i2d), BoschlooExactResult)
-assert_type(boschloo_exact(_i2d).statistic, float)
-assert_type(boschloo_exact(_i2d).pvalue, float)
+assert_type(boschloo_exact(_i64_2d), BoschlooExactResult)
+assert_type(boschloo_exact(_i64_2d).statistic, float)
+assert_type(boschloo_exact(_i64_2d).pvalue, float)
 
-###
 # tukey_hsd
 
-assert_type(tukey_hsd(_f1d, _f1d), TukeyHSDResult)
-assert_type(tukey_hsd(_f1d, _f1d, _f1d), TukeyHSDResult)
-assert_type(tukey_hsd(_f1d, _f1d).statistic, onp.Array2D[np.float64])
-assert_type(tukey_hsd(_f1d, _f1d).pvalue, onp.Array2D[np.float64])
+assert_type(tukey_hsd(_f64_1d, _f64_1d), TukeyHSDResult)
+assert_type(tukey_hsd(_f64_1d, _f64_1d, _f64_1d), TukeyHSDResult)
+assert_type(tukey_hsd(_f64_1d, _f64_1d).statistic, onp.Array2D[np.float64])
+assert_type(tukey_hsd(_f64_1d, _f64_1d).pvalue, onp.Array2D[np.float64])


### PR DESCRIPTION
The result types of `epps_singleton_2samp`, `cramervonmises_2samp`, and `cramervonmises`  has incorrect dtypes for certain inputs.