### PR TITLE
✨ `stats.bws_test`: improved shape-typing and dtype propagation

### DIFF
--- a/scipy-stubs/stats/_bws_test.pyi
+++ b/scipy-stubs/stats/_bws_test.pyi
@@ -1,14 +1,141 @@
-from typing import Literal
+from typing import Any, Never, overload
 
+import numpy as np
 import optype.numpy as onp
+import optype.numpy.compat as npc
 
 from ._resampling import PermutationMethod, PermutationTestResult
+from ._typing import Alternative
 
+###
+
+type _JustAnyShape = tuple[Never, Never, Never, Never]
+
+###
+
+@overload  # Nd +f64, axis: None
 def bws_test(
-    x: onp.ToComplex1D,
-    y: onp.ToComplex1D,
+    x: onp.ToArrayND[float, npc.integer],
+    y: onp.ToArrayND[float, npc.integer],
     *,
-    alternative: Literal["two-sided", "less", "greater"] = "two-sided",
-    axis: int | None = 0,
+    alternative: Alternative = "two-sided",
+    axis: None,
     method: PermutationMethod | None = None,
-) -> PermutationTestResult: ...
+) -> PermutationTestResult[np.float64, onp.Array1D[np.float64]]: ...
+@overload  # Nd floating, axis: None
+def bws_test[FloatT: (np.float64, np.float32, np.float16)](
+    x: onp.ToArrayND[FloatT, FloatT],
+    y: onp.ToArrayND[FloatT, FloatT],
+    *,
+    alternative: Alternative = "two-sided",
+    axis: None,
+    method: PermutationMethod | None = None,
+) -> PermutationTestResult[FloatT, onp.Array1D[FloatT]]: ...
+@overload  # ?d +f64
+def bws_test(
+    x: onp.ArrayND[npc.integer, _JustAnyShape],
+    y: onp.ArrayND[npc.integer, _JustAnyShape],
+    *,
+    alternative: Alternative = "two-sided",
+    axis: int = 0,
+    method: PermutationMethod | None = None,
+) -> PermutationTestResult[onp.ArrayND[np.float64] | np.float64, onp.ArrayND[np.float64]]: ...
+@overload  # ?d floating
+def bws_test[FloatT: (np.float64, np.float32, np.float16)](
+    x: onp.ArrayND[FloatT, _JustAnyShape],
+    y: onp.ArrayND[FloatT, _JustAnyShape],
+    *,
+    alternative: Alternative = "two-sided",
+    axis: int = 0,
+    method: PermutationMethod | None = None,
+) -> PermutationTestResult[onp.ArrayND[FloatT] | FloatT, onp.ArrayND[FloatT]]: ...
+@overload  # 1d +f64
+def bws_test(
+    x: onp.ToArrayStrict1D[float, npc.integer],
+    y: onp.ToArrayStrict1D[float, npc.integer],
+    *,
+    alternative: Alternative = "two-sided",
+    axis: int = 0,
+    method: PermutationMethod | None = None,
+) -> PermutationTestResult[np.float64, onp.Array1D[np.float64]]: ...
+@overload  # 1d floating
+def bws_test[FloatT: (np.float64, np.float32, np.float16)](
+    x: onp.ToArrayStrict1D[FloatT, FloatT],
+    y: onp.ToArrayStrict1D[FloatT, FloatT],
+    *,
+    alternative: Alternative = "two-sided",
+    axis: int = 0,
+    method: PermutationMethod | None = None,
+) -> PermutationTestResult[FloatT, onp.Array1D[FloatT]]: ...
+@overload  # 2d +f64
+def bws_test(
+    x: onp.ToArrayStrict2D[float, npc.integer],
+    y: onp.ToArrayStrict2D[float, npc.integer],
+    *,
+    alternative: Alternative = "two-sided",
+    axis: int = 0,
+    method: PermutationMethod | None = None,
+) -> PermutationTestResult[onp.Array1D[np.float64], onp.Array2D[np.float64]]: ...
+@overload  # 2d floating
+def bws_test[FloatT: (np.float64, np.float32, np.float16)](
+    x: onp.ToArrayStrict2D[FloatT, FloatT],
+    y: onp.ToArrayStrict2D[FloatT, FloatT],
+    *,
+    alternative: Alternative = "two-sided",
+    axis: int = 0,
+    method: PermutationMethod | None = None,
+) -> PermutationTestResult[onp.Array1D[FloatT], onp.Array2D[FloatT]]: ...
+@overload  # 3d +f64
+def bws_test(
+    x: onp.ToArrayStrict3D[float, npc.integer],
+    y: onp.ToArrayStrict3D[float, npc.integer],
+    *,
+    alternative: Alternative = "two-sided",
+    axis: int = 0,
+    method: PermutationMethod | None = None,
+) -> PermutationTestResult[onp.Array2D[np.float64], onp.Array3D[np.float64]]: ...
+@overload  # 3d floating
+def bws_test[FloatT: (np.float64, np.float32, np.float16)](
+    x: onp.ToArrayStrict3D[FloatT, FloatT],
+    y: onp.ToArrayStrict3D[FloatT, FloatT],
+    *,
+    alternative: Alternative = "two-sided",
+    axis: int = 0,
+    method: PermutationMethod | None = None,
+) -> PermutationTestResult[onp.Array2D[FloatT], onp.Array3D[FloatT]]: ...
+@overload  # Nd +f64
+def bws_test(
+    x: onp.ToArrayND[float, npc.integer],
+    y: onp.ToArrayND[float, npc.integer],
+    *,
+    alternative: Alternative = "two-sided",
+    axis: int = 0,
+    method: PermutationMethod | None = None,
+) -> PermutationTestResult[onp.ArrayND[np.float64] | Any, onp.ArrayND[np.float64]]: ...
+@overload  # Nd floating
+def bws_test[FloatT: (np.float64, np.float32, np.float16)](
+    x: onp.ToArrayND[FloatT, FloatT],
+    y: onp.ToArrayND[FloatT, FloatT],
+    *,
+    alternative: Alternative = "two-sided",
+    axis: int = 0,
+    method: PermutationMethod | None = None,
+) -> PermutationTestResult[onp.ArrayND[FloatT] | Any, onp.ArrayND[FloatT]]: ...
+@overload  # fallback, axis=None
+def bws_test(
+    x: onp.ToComplexND,
+    y: onp.ToComplexND,
+    *,
+    alternative: Alternative = "two-sided",
+    axis: None,
+    method: PermutationMethod | None = None,
+) -> PermutationTestResult[np.float64 | Any, onp.Array1D[np.float64 | Any]]: ...
+@overload  # fallback
+def bws_test(
+    x: onp.ToComplexND,
+    y: onp.ToComplexND,
+    *,
+    alternative: Alternative = "two-sided",
+    axis: int = 0,
+    method: PermutationMethod | None = None,
+) -> PermutationTestResult[onp.ArrayND[np.float64 | Any] | Any, onp.ArrayND[np.float64 | Any]]: ...

--- a/tests/stats/test__bws_test.pyi
+++ b/tests/stats/test__bws_test.pyi
@@ -4,18 +4,39 @@ from typing import assert_type
 
 import numpy as np
 import optype.numpy as onp
+from optype.test import assert_subtype
 
 from scipy.stats import bws_test
 from scipy.stats._resampling import PermutationTestResult
 
 ###
 
+_i64_1d: onp.Array1D[np.int64]
+
+_f32_1d: onp.Array1D[np.float32]
+_f32_2d: onp.Array2D[np.float32]
+
 _f64_1d: onp.Array1D[np.float64]
+_f64_2d: onp.Array2D[np.float64]
+_f64_nd: onp.ArrayND[np.float64]
+
 _py_f_1d: list[float]
 
 ###
 # bws_test
 
-assert_type(bws_test(_py_f_1d, _py_f_1d), PermutationTestResult)
-assert_type(bws_test(_f64_1d, _f64_1d), PermutationTestResult)
-assert_type(bws_test(_f64_1d, _f64_1d, alternative="less"), PermutationTestResult)
+assert_type(bws_test(_py_f_1d, _py_f_1d), PermutationTestResult[np.float64, onp.Array1D[np.float64]])
+assert_type(bws_test(_f64_1d, _f64_1d), PermutationTestResult[np.float64, onp.Array1D[np.float64]])
+assert_type(bws_test(_i64_1d, _i64_1d), PermutationTestResult[np.float64, onp.Array1D[np.float64]])
+assert_type(bws_test(_f64_1d, _f64_1d, alternative="less"), PermutationTestResult[np.float64, onp.Array1D[np.float64]])
+assert_type(bws_test(_f32_1d, _f32_1d), PermutationTestResult[np.float32, onp.Array1D[np.float32]])
+# workaround for pyrefly (1.2.0), which infers `Unknown` here
+assert_subtype[PermutationTestResult[onp.ArrayND[np.float64] | np.float64, onp.ArrayND[np.float64]]](bws_test(_f64_nd, _f64_nd))
+
+assert_type(bws_test(_f64_2d, _f64_2d, axis=1), PermutationTestResult[onp.Array1D[np.float64], onp.Array2D[np.float64]])
+assert_type(bws_test(_f32_2d, _f32_2d, axis=1), PermutationTestResult[onp.Array1D[np.float32], onp.Array2D[np.float32]])
+
+assert_type(bws_test(_f64_1d, _f64_1d, axis=None), PermutationTestResult[np.float64, onp.Array1D[np.float64]])
+assert_type(bws_test(_f64_2d, _f64_2d, axis=None), PermutationTestResult[np.float64, onp.Array1D[np.float64]])
+assert_type(bws_test(_f32_2d, _f32_2d, axis=None), PermutationTestResult[np.float32, onp.Array1D[np.float32]])
+assert_type(bws_test(_f64_nd, _f64_nd, axis=None), PermutationTestResult[np.float64, onp.Array1D[np.float64]])


### PR DESCRIPTION
This adds 14 overloads to the `scipy.stats.bws_test` stubs so that the result types have accurate shape-types and dtypes in most common usecases.