### PR TITLE
🐛 `stats`: fix return dtype of `rv_sample.rvs`

### DIFF
--- a/scipy-stubs/stats/_distn_infrastructure.pyi
+++ b/scipy-stubs/stats/_distn_infrastructure.pyi
@@ -21,6 +21,9 @@ type _Tuple2[T] = tuple[T, T]
 type _Tuple3[T] = tuple[T, T, T]
 type _Tuple4[T] = tuple[T, T, T, T]
 
+# workaround for a strange bug in pyright's overlapping overload detection with `numpy<2.1`
+type _WorkaroundForPyright = tuple[int] | tuple[Any, ...]
+
 type _Floating = np.float64 | np.float32 | np.float16  # longdouble often results in trouble
 type _CoFloat = _Floating | npc.integer
 
@@ -1159,7 +1162,7 @@ class rv_sample(rv_discrete, Generic[_XKT_co, _PKT_co]):
         size: SupportsIndex | tuple[SupportsIndex, *tuple[SupportsIndex, ...]],
         random_state: onp.random.ToRNG | None = None,
         **kwds: _ToFloatOrND,
-    ) -> onp.ArrayND[_XKT_co]: ...
+    ) -> onp.ArrayND[_XKT_co, _WorkaroundForPyright]: ...
     @overload  # fallback
     def rvs(
         self,

--- a/scipy-stubs/stats/_distn_infrastructure.pyi
+++ b/scipy-stubs/stats/_distn_infrastructure.pyi
@@ -862,8 +862,8 @@ class rv_discrete(_rv_mixin, rv_generic):
         shapes: str | None = None,
         seed: onp.random.ToRNG | None = None,
     ) -> Self: ...
-    # NOTE: The return types of the following overloads is ignored by mypy
-    @overload
+    # NOTE: The return types of the following overloads is ignored by mypy (2.3)
+    @overload  # values: (int, float)
     def __new__(
         cls,
         a: onp.ToFloat,
@@ -871,13 +871,13 @@ class rv_discrete(_rv_mixin, rv_generic):
         name: str | None,
         badvalue: _Float | None,
         moment_tol: _Float,
-        values: _Tuple2[onp.ToFloatND],
+        values: tuple[onp.ToIntND, onp.ToFloatND],
         inc: int | np.int_ = 1,
         longname: str | None = None,
         shapes: str | None = None,
         seed: onp.random.ToRNG | None = None,
-    ) -> rv_sample: ...
-    @overload
+    ) -> rv_sample[np.int64]: ...
+    @overload  # values: (int, float)  (keyword)
     def __new__(
         cls,
         a: onp.ToFloat = 0,
@@ -886,12 +886,41 @@ class rv_discrete(_rv_mixin, rv_generic):
         badvalue: _Float | None = None,
         moment_tol: _Float = 1e-8,
         *,
-        values: _Tuple2[onp.ToFloatND],
+        values: tuple[onp.ToIntND, onp.ToFloatND],
         inc: int | np.int_ = 1,
         longname: str | None = None,
         shapes: str | None = None,
         seed: onp.random.ToRNG | None = None,
-    ) -> rv_sample: ...
+    ) -> rv_sample[np.int64]: ...
+    @overload  # values: (float, float)
+    def __new__(
+        cls,
+        a: onp.ToFloat,
+        b: onp.ToFloat,
+        name: str | None,
+        badvalue: _Float | None,
+        moment_tol: _Float,
+        values: tuple[onp.ToJustFloatND, onp.ToFloatND],
+        inc: int | np.int_ = 1,
+        longname: str | None = None,
+        shapes: str | None = None,
+        seed: onp.random.ToRNG | None = None,
+    ) -> rv_sample[np.float64]: ...
+    @overload  # values: (float, float)  (keyword)
+    def __new__(
+        cls,
+        a: onp.ToFloat = 0,
+        b: onp.ToFloat = ...,
+        name: str | None = None,
+        badvalue: _Float | None = None,
+        moment_tol: _Float = 1e-8,
+        *,
+        values: tuple[onp.ToJustFloatND, onp.ToFloatND],
+        inc: int | np.int_ = 1,
+        longname: str | None = None,
+        shapes: str | None = None,
+        seed: onp.random.ToRNG | None = None,
+    ) -> rv_sample[np.float64]: ...
 
     #
     def __init__(
@@ -1091,7 +1120,7 @@ class rv_sample(rv_discrete, Generic[_XKT_co, _PKT_co]):
 
     #
     @override
-    @overload
+    @overload  # size: 0d | None  (default)
     def rvs(
         self,
         /,
@@ -1100,8 +1129,28 @@ class rv_sample(rv_discrete, Generic[_XKT_co, _PKT_co]):
         size: tuple[()] | None = None,
         random_state: onp.random.ToRNG | None = None,
         **kwds: onp.ToFloat,
-    ) -> np.float64: ...
-    @overload
+    ) -> _XKT_co: ...
+    @overload  # size: 1d
+    def rvs(
+        self,
+        /,
+        *args: _ToFloatOrND,
+        loc: _ToFloatOrND = 0,
+        size: SupportsIndex,
+        random_state: onp.random.ToRNG | None = None,
+        **kwds: _ToFloatOrND,
+    ) -> onp.Array1D[_XKT_co]: ...
+    @overload  # size: >=1d (known)
+    def rvs[ShapeT: tuple[int, *tuple[int, ...]]](
+        self,
+        /,
+        *args: _ToFloatOrND,
+        loc: _ToFloatOrND = 0,
+        size: ShapeT,
+        random_state: onp.random.ToRNG | None = None,
+        **kwds: _ToFloatOrND,
+    ) -> onp.ArrayND[_XKT_co, ShapeT]: ...
+    @overload  # size: >=1d (unknown)
     def rvs(
         self,
         /,
@@ -1110,8 +1159,8 @@ class rv_sample(rv_discrete, Generic[_XKT_co, _PKT_co]):
         size: SupportsIndex | tuple[SupportsIndex, *tuple[SupportsIndex, ...]],
         random_state: onp.random.ToRNG | None = None,
         **kwds: _ToFloatOrND,
-    ) -> onp.ArrayND[np.float64]: ...
-    @overload
+    ) -> onp.ArrayND[_XKT_co]: ...
+    @overload  # fallback
     def rvs(
         self,
         /,
@@ -1120,7 +1169,7 @@ class rv_sample(rv_discrete, Generic[_XKT_co, _PKT_co]):
         size: AnyShape | None = None,
         random_state: onp.random.ToRNG | None = None,
         **kwds: _ToFloatOrND,
-    ) -> onp.ArrayND[np.float64] | np.float64: ...
+    ) -> onp.ArrayND[_XKT_co] | Any: ...
 
 # private helper subtypes
 @type_check_only

--- a/tests/stats/test_rv_sample.pyi
+++ b/tests/stats/test_rv_sample.pyi
@@ -3,10 +3,30 @@ from typing import assert_type
 import numpy as np
 import optype.numpy as onp
 
-from scipy.stats._distn_infrastructure import rv_discrete, rv_sample
+from scipy.stats import rv_discrete
+from scipy.stats._distn_infrastructure import rv_sample
 
-xk: onp.Array1D[np.int_]
-pk: tuple[float, ...]
+###
 
-# mypy fails because it (still) doesn't support __new__ returning something that isn't `Self`
-assert_type(rv_discrete(values=(xk, pk)), rv_sample)  # type: ignore[assert-type]
+_i64_1d: onp.Array1D[np.int64]
+_f64_1d: onp.Array1D[np.float64]
+_py_f_1d: tuple[float, ...]
+_n: int
+
+# mypy fails because it (still) doesn't support `__new__` returning something that isn't `Self` (if there's an `__init__`)
+assert_type(rv_discrete(values=(_i64_1d, _py_f_1d)), rv_sample[np.int64])  # type: ignore[assert-type]
+assert_type(rv_discrete(values=(_f64_1d, _py_f_1d)), rv_sample[np.float64])  # type: ignore[assert-type]
+
+###
+
+_sample_i64: rv_sample[np.int64]
+_sample_f64: rv_sample[np.float64]
+
+assert_type(_sample_i64.rvs(), np.int64)
+assert_type(_sample_i64.rvs(size=5), onp.Array1D[np.int64])
+assert_type(_sample_i64.rvs(size=(_n,)), onp.Array1D[np.int64])
+assert_type(_sample_i64.rvs(size=(_n, _n)), onp.Array2D[np.int64])
+assert_type(_sample_i64.rvs(size=(_n, _n, _n)), onp.Array3D[np.int64])
+assert_type(_sample_f64.rvs(), np.float64)
+assert_type(_sample_f64.rvs(size=5), onp.Array1D[np.float64])
+assert_type(_sample_f64.rvs(size=(_n, _n)), onp.Array2D[np.float64])


### PR DESCRIPTION
I also snuck in some shape-typing improvements.