### PR TITLE
🐛 `stats`: fix `rv_continuous.fit` callable type of `optimizer`

### DIFF
--- a/scipy-stubs/stats/_distn_infrastructure.pyi
+++ b/scipy-stubs/stats/_distn_infrastructure.pyi
@@ -704,12 +704,12 @@ class rv_continuous(_rv_mixin, rv_generic):
     def fit_loc_scale(self, /, data: _ToFloatOrND, *args: onp.ToFloat) -> _Tuple2[_Float]: ...
 
     #
-    def fit(
+    def fit[FuncT: Callable[..., onp.ToFloat], X0T: onp.ToFloat1D, ArgsT: tuple[Any, ...]](
         self,
         /,
         data: _ToFloatOrND | CensoredData[np.float64],
         *args: onp.ToFloat,
-        optimizer: Callable[[_FloatND, tuple[float, ...], tuple[float, ...], bool], tuple[onp.ToFloat, ...]] | None = ...,
+        optimizer: Callable[[FuncT, X0T, ArgsT, int], onp.ToFloat1D] | None = ...,
         method: _FitMethod = "MLE",
         **kwds: onp.ToFloat,
     ) -> tuple[_Float, ...]: ...

--- a/tests/stats/test_continuous_distns.pyi
+++ b/tests/stats/test_continuous_distns.pyi
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from typing import Any, assert_type
 
 import numpy as np
@@ -127,6 +128,13 @@ _f64_nd: onp.ArrayND[np.float64]
 _n: int
 _shape_nd: tuple[int, ...]
 _np_shape: tuple[np.intp, np.intp]
+
+def _optimizer(
+    func: Callable[[list[float], onp.ArrayND[np.float64]], np.float64],
+    x0: list[float],
+    args: tuple[onp.ArrayND[np.float64]],
+    disp: int,
+) -> onp.Array1D[np.float64]: ...
 
 ###
 
@@ -288,3 +296,4 @@ assert_type(norm.fit(_f64_nd, floc=0.0), tuple[float, np.float64])
 assert_type(norm.fit(_f64_nd, floc=_f32), tuple[np.float32, np.float64])
 assert_type(norm.fit(_f64_nd, fscale=1), tuple[np.float64, int])
 assert_type(norm.fit(_f64_nd, fscale=2.0), tuple[np.float64, float])
+assert_type(gamma.fit(_f64_nd, optimizer=_optimizer), tuple[float | np.float64, ...])


### PR DESCRIPTION
The `Callable` input types of the `optimizer` param were too broad, which caused false positives due it those input positions being contravariant.
The solution is to use the "free type variable trick" (of which I'm the (or perhaps a) proud inventor), to allow the input types to vary within the scope of the (outer) function within the specified bounds (more general than a "top" type would be here ;) ).