### PR TITLE
🐛 `spatial.distance`: add missing `"matching"` literal value

### DIFF
--- a/scipy-stubs/spatial/distance.pyi
+++ b/scipy-stubs/spatial/distance.pyi
@@ -60,6 +60,7 @@ type _MetricName = Literal[
     "hamm",
     "ha",
     "h",
+    "matching",
     "minkowski",
     "mi",
     "m",

--- a/tests/spatial/test_distance.pyi
+++ b/tests/spatial/test_distance.pyi
@@ -66,6 +66,7 @@ def _f(u: Unused, v: Unused) -> float: ...
 assert_type(cdist(_f64_2d, _f64_2d), onp.Array2D[np.float64])
 assert_type(cdist(_f64_2d, _f64_2d, "euclidean"), onp.Array2D[np.float64])
 assert_type(cdist(_f64_2d, _f64_2d, "cosine"), onp.Array2D[np.float64])
+assert_type(cdist(_f64_2d, _f64_2d, "matching"), onp.Array2D[np.float64])
 assert_type(cdist(_py_f_2d, _py_f_2d), onp.Array2D[np.float64])
 assert_type(cdist(_f64_2d, _f64_2d, metric=_f), onp.Array2D[np.float64])
 
@@ -73,6 +74,7 @@ assert_type(cdist(_f64_2d, _f64_2d, metric=_f), onp.Array2D[np.float64])
 assert_type(pdist(_f64_2d), onp.Array1D[np.float64])
 assert_type(pdist(_f64_2d, "euclidean"), onp.Array1D[np.float64])
 assert_type(pdist(_f64_2d, "cosine"), onp.Array1D[np.float64])
+assert_type(pdist(_f64_2d, "matching"), onp.Array1D[np.float64])
 assert_type(pdist(_py_f_2d), onp.Array1D[np.float64])
 assert_type(pdist(_f64_2d, metric=_f), onp.Array1D[np.float64])
 


### PR DESCRIPTION
It's an alias of `"hamming"`