### PR TITLE
🐛 `spatial.transform.Rotation.reduce`: fix return type when `return_indices=True`

### DIFF
--- a/scipy-stubs/spatial/transform/_rotation.pyi
+++ b/scipy-stubs/spatial/transform/_rotation.pyi
@@ -240,18 +240,30 @@ class Rotation(Generic[_ShapeT_co]):
     ) -> onp.ArrayND[np.bool]: ...
 
     #
-    @overload
+    @overload  # return_indices: False
     def reduce(
         self, /, left: Rotation | None = None, right: Rotation | None = None, return_indices: L[False] = False
     ) -> Self: ...
-    @overload
+    @overload  # left, right
     def reduce(
-        self, /, left: Rotation | None, right: Rotation | None, return_indices: L[True]
-    ) -> tuple[Self, onp.ArrayND[np.int32 | np.int64], onp.ArrayND[np.int32 | np.int64]]: ...
-    @overload
+        self, /, left: Rotation, right: Rotation, return_indices: L[True]
+    ) -> tuple[Self, onp.Array1D[np.intp], onp.Array1D[np.intp]]: ...
+    @overload  # left
+    def reduce(self, /, left: Rotation, right: None, return_indices: L[True]) -> tuple[Self, onp.Array1D[np.intp], None]: ...
+    @overload  # left (keyword)
     def reduce(
-        self, /, left: Rotation | None = None, right: Rotation | None = None, *, return_indices: L[True]
-    ) -> tuple[Self, onp.ArrayND[np.int32 | np.int64], onp.ArrayND[np.int32 | np.int64]]: ...
+        self, /, left: Rotation, right: None = None, *, return_indices: L[True]
+    ) -> tuple[Self, onp.Array1D[np.intp], None]: ...
+    @overload  # right
+    def reduce(self, /, left: None, right: Rotation, return_indices: L[True]) -> tuple[Self, None, onp.Array1D[np.intp]]: ...
+    @overload  # right (keyword)
+    def reduce(
+        self, /, left: None = None, *, right: Rotation, return_indices: L[True]
+    ) -> tuple[Self, None, onp.Array1D[np.intp]]: ...
+    @overload  # neither
+    def reduce(self, /, left: None, right: None, return_indices: L[True]) -> tuple[Self, None, None]: ...
+    @overload  # neither (keyword)
+    def reduce(self, /, left: None = None, right: None = None, *, return_indices: L[True]) -> tuple[Self, None, None]: ...
 
     #
     @overload

--- a/tests/spatial/test__rotation.pyi
+++ b/tests/spatial/test__rotation.pyi
@@ -198,10 +198,12 @@ assert_type(_rot_nd.mean(axis=0), Rotation)
 assert_type(_rot_nd.reduce(), Rotation)
 assert_type(_rot_nd.reduce(left=_rot_nd), Rotation)
 
-_reduced_with_idx = _rot_nd.reduce(return_indices=True)
-assert_type(_reduced_with_idx[0], Rotation)
-assert_type(_reduced_with_idx[1], onp.ArrayND[np.int32 | np.int64])
-assert_type(_reduced_with_idx[2], onp.ArrayND[np.int32 | np.int64])
+assert_type(_rot_nd.reduce(return_indices=True), tuple[Rotation, None, None])
+assert_type(_rot_nd.reduce(None, None, True), tuple[Rotation, None, None])
+assert_type(_rot_nd.reduce(left=_rot_nd, return_indices=True), tuple[Rotation, onp.Array1D[np.intp], None])
+assert_type(_rot_nd.reduce(right=_rot_nd, return_indices=True), tuple[Rotation, None, onp.Array1D[np.intp]])
+assert_type(_rot_nd.reduce(_rot_nd, _rot_nd, True), tuple[Rotation, onp.Array1D[np.intp], onp.Array1D[np.intp]])
+assert_type(_rot_nd.reduce(_rot_nd, _rot_nd, return_indices=True), tuple[Rotation, onp.Array1D[np.intp], onp.Array1D[np.intp]])
 
 # align_vectors
 


### PR DESCRIPTION
The tuple elements can be None depending on whether `left` or `right` are set