### PR TITLE
🐛 `ndimage.label`: accept dtype-like `output`

### DIFF
--- a/scipy-stubs/ndimage/_measurements.pyi
+++ b/scipy-stubs/ndimage/_measurements.pyi
@@ -53,17 +53,31 @@ type _AsInt64OrND = int | npc.signedinteger | np.bool | onp.ToArrayND[int, npc.s
 # mypy: disable-error-code="overload-overlap"
 
 #
-@overload
+@overload  # output=<array>
 def label(
     input: onp.ToComplex | onp.ToComplexND,
     structure: onp.ToComplex | onp.ToComplexND | None = None,
     *,
     output: onp.ArrayND[np.int32 | np.intp],
 ) -> int: ...
-@overload
+@overload  # output=<known dtype>
+def label[ScalarT: npc.number | np.bool](
+    input: onp.ToComplex | onp.ToComplexND,
+    structure: onp.ToComplex | onp.ToComplexND | None = None,
+    *,
+    output: type[ScalarT] | np.dtype[ScalarT],
+) -> tuple[onp.ArrayND[ScalarT], int]: ...
+@overload  # output: None  (default)
 def label(
     input: onp.ToComplex | onp.ToComplexND, structure: onp.ToComplex | onp.ToComplexND | None = None, output: None = None
 ) -> tuple[onp.ArrayND[np.int32], int]: ...
+@overload  # output=<unknown dtype>
+def label(
+    input: onp.ToComplex | onp.ToComplexND,
+    structure: onp.ToComplex | onp.ToComplexND | None = None,
+    *,
+    output: type[complex] | str,
+) -> tuple[onp.ArrayND[Any], int]: ...
 
 #
 @overload

--- a/tests/ndimage/test__measurements.pyi
+++ b/tests/ndimage/test__measurements.pyi
@@ -61,6 +61,12 @@ assert_type(label(_i32_2d, output=_i32_i64_nd), int)
 assert_type(label(_f64_2d), tuple[onp.ArrayND[np.int32], int])
 assert_type(label(_i32_2d), tuple[onp.ArrayND[np.int32], int])
 
+# output dtype -> (labeled_array of that dtype, num_features)
+assert_type(label(_f64_2d, output=np.uint32), tuple[onp.ArrayND[np.uint32], int])
+assert_type(label(_f64_2d, output=np.dtype(np.int64)), tuple[onp.ArrayND[np.int64], int])
+assert_type(label(_f64_2d, output=int), tuple[onp.ArrayND[Any], int])
+assert_type(label(_f64_2d, output="int32"), tuple[onp.ArrayND[Any], int])
+
 ###
 # find_objects
 


### PR DESCRIPTION
Stuff like `scipy.ndimage.label(a, output=np.uint32)` is accepted at runtime, but was rejected by the stubs.