### PR TITLE
🐛 `linalg.expm_frechet`: fix return type when `compute_expm=False`

### DIFF
--- a/scipy-stubs/linalg/_expm_frechet.pyi
+++ b/scipy-stubs/linalg/_expm_frechet.pyi
@@ -9,27 +9,63 @@ __all__ = ["expm_cond", "expm_frechet"]
 ###
 
 type _Method = Literal["SPS", "blockEnlarge"]
-type _ArrayF64 = onp.ArrayND[np.float64]
-type _ArrayC128 = onp.ArrayND[np.complex128]
 
 ###
 
-@overload
+@overload  # +f64, +f64
 def expm_frechet(
-    A: onp.ToComplexND,
+    A: onp.ToFloatND, E: onp.ToFloatND, method: _Method | None = None, compute_expm: onp.ToTrue = True, check_finite: bool = True
+) -> tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64]]: ...
+@overload  # +f64, ~complex
+def expm_frechet(
+    A: onp.ToFloatND,
+    E: onp.ToJustComplexND,
+    method: _Method | None = None,
+    compute_expm: onp.ToTrue = True,
+    check_finite: bool = True,
+) -> tuple[onp.ArrayND[np.float64], onp.ArrayND[np.complex128]]: ...
+@overload  # ~complex, +complex
+def expm_frechet(
+    A: onp.ToJustComplexND,
     E: onp.ToComplexND,
     method: _Method | None = None,
     compute_expm: onp.ToTrue = True,
     check_finite: bool = True,
-) -> tuple[_ArrayF64, _ArrayF64] | tuple[_ArrayF64 | _ArrayC128, _ArrayC128]: ...
-@overload
+) -> tuple[onp.ArrayND[np.complex128], onp.ArrayND[np.complex128]]: ...
+@overload  # +f64, +f64, compute_expm=False
 def expm_frechet(
-    A: onp.ToComplexND, E: onp.ToComplexND, method: _Method | None, compute_expm: onp.ToFalse, check_finite: bool = True
-) -> tuple[_ArrayF64, _ArrayF64] | tuple[_ArrayF64 | _ArrayC128, _ArrayC128]: ...
-@overload
+    A: onp.ToFloatND, E: onp.ToFloatND, method: _Method | None, compute_expm: onp.ToFalse, check_finite: bool = True
+) -> onp.ArrayND[np.float64]: ...
+@overload  # +f64, +f64, compute_expm=False (keyword)
 def expm_frechet(
-    A: onp.ToComplexND, E: onp.ToComplexND, method: _Method | None = None, *, compute_expm: onp.ToFalse, check_finite: bool = True
-) -> tuple[_ArrayF64, _ArrayF64] | tuple[_ArrayF64 | _ArrayC128, _ArrayC128]: ...
+    A: onp.ToFloatND, E: onp.ToFloatND, method: _Method | None = None, *, compute_expm: onp.ToFalse, check_finite: bool = True
+) -> onp.ArrayND[np.float64]: ...
+@overload  # +f64, ~complex, compute_expm=False
+def expm_frechet(
+    A: onp.ToFloatND, E: onp.ToJustComplexND, method: _Method | None, compute_expm: onp.ToFalse, check_finite: bool = True
+) -> onp.ArrayND[np.complex128]: ...
+@overload  # +f64, ~complex, compute_expm=False (keyword)
+def expm_frechet(
+    A: onp.ToFloatND,
+    E: onp.ToJustComplexND,
+    method: _Method | None = None,
+    *,
+    compute_expm: onp.ToFalse,
+    check_finite: bool = True,
+) -> onp.ArrayND[np.complex128]: ...
+@overload  # ~complex, +complex, compute_expm=False
+def expm_frechet(
+    A: onp.ToJustComplexND, E: onp.ToComplexND, method: _Method | None, compute_expm: onp.ToFalse, check_finite: bool = True
+) -> onp.ArrayND[np.complex128]: ...
+@overload  # ~complex, +complex, compute_expm=False (keyword)
+def expm_frechet(
+    A: onp.ToJustComplexND,
+    E: onp.ToComplexND,
+    method: _Method | None = None,
+    *,
+    compute_expm: onp.ToFalse,
+    check_finite: bool = True,
+) -> onp.ArrayND[np.complex128]: ...
 
 #
 @overload

--- a/tests/linalg/test__expm_frechet.pyi
+++ b/tests/linalg/test__expm_frechet.pyi
@@ -10,29 +10,30 @@ from scipy.linalg import expm_cond, expm_frechet
 
 ###
 
-f64_2d: onp.Array2D[np.float64]
-f64_3d: onp.Array3D[np.float64]
-f64_nd: onp.ArrayND[np.float64]
-c128_2d: onp.Array2D[np.complex128]
-
-type _FreoResult = (
-    tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64]]
-    | tuple[onp.ArrayND[np.float64] | onp.ArrayND[np.complex128], onp.ArrayND[np.complex128]]
-)
+_f64_2d: onp.Array2D[np.float64]
+_f64_3d: onp.Array3D[np.float64]
+_f64_nd: onp.ArrayND[np.float64]
+_c128_2d: onp.Array2D[np.complex128]
 
 ###
 # expm_frechet
 
-assert_type(expm_frechet(f64_2d, f64_2d), _FreoResult)
-assert_type(expm_frechet(c128_2d, c128_2d), _FreoResult)
-assert_type(expm_frechet(f64_2d, f64_2d, compute_expm=True), _FreoResult)
-assert_type(expm_frechet(f64_2d, f64_2d, "SPS", False), _FreoResult)
-assert_type(expm_frechet(f64_2d, f64_2d, compute_expm=False), _FreoResult)
+assert_type(expm_frechet(_f64_2d, _f64_2d), tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64]])
+assert_type(expm_frechet(_f64_2d, _f64_2d, compute_expm=True), tuple[onp.ArrayND[np.float64], onp.ArrayND[np.float64]])
+assert_type(expm_frechet(_c128_2d, _c128_2d), tuple[onp.ArrayND[np.complex128], onp.ArrayND[np.complex128]])
+assert_type(expm_frechet(_c128_2d, _f64_2d), tuple[onp.ArrayND[np.complex128], onp.ArrayND[np.complex128]])
+assert_type(expm_frechet(_f64_2d, _c128_2d), tuple[onp.ArrayND[np.float64], onp.ArrayND[np.complex128]])
+
+assert_type(expm_frechet(_f64_2d, _f64_2d, "SPS", False), onp.ArrayND[np.float64])
+assert_type(expm_frechet(_f64_2d, _f64_2d, compute_expm=False), onp.ArrayND[np.float64])
+assert_type(expm_frechet(_c128_2d, _f64_2d, compute_expm=False), onp.ArrayND[np.complex128])
+assert_type(expm_frechet(_f64_2d, _c128_2d, compute_expm=False), onp.ArrayND[np.complex128])
+assert_type(expm_frechet(_c128_2d, _c128_2d, None, False), onp.ArrayND[np.complex128])
 
 ###
 # expm_cond
 
-assert_type(expm_cond(f64_2d), np.float64)
-assert_type(expm_cond(f64_3d), onp.Array1D[np.float64])
-assert_subtype[np.float64 | onp.ArrayND[np.float64]](expm_cond(f64_nd))
-assert_type(expm_cond(c128_2d), np.float64)
+assert_type(expm_cond(_f64_2d), np.float64)
+assert_type(expm_cond(_f64_3d), onp.Array1D[np.float64])
+assert_subtype[np.float64 | onp.ArrayND[np.float64]](expm_cond(_f64_nd))
+assert_type(expm_cond(_c128_2d), np.float64)


### PR DESCRIPTION
When `compute_expm=False`, `scipy.linalg.expm_frechet` returns an array, not a tuple of arrays. This adds a bunch of overloads to accurately type this.