### PR TITLE
👽️ `stats.binomtest`: restore `int` types of returned `k` and `n` for SciPy 1.18.1

### DIFF
--- a/scipy-stubs/stats/_binomtest.pyi
+++ b/scipy-stubs/stats/_binomtest.pyi
@@ -11,45 +11,46 @@ from ._typing import Alternative
 
 ###
 
-_NumT_co = TypeVar("_NumT_co", bound=np.float64 | onp.ArrayND[np.float64], default=np.float64, covariant=True)
+_NumT_co = TypeVar("_NumT_co", bound=int | onp.ArrayND[np.float64], default=int, covariant=True)
+_StatT_co = TypeVar("_StatT_co", bound=np.float64 | onp.ArrayND[np.float64], default=np.float64, covariant=True)
 
 ###
 
-class BinomTestResult(Generic[_NumT_co]):
+class BinomTestResult(Generic[_NumT_co, _StatT_co]):
     k: _NumT_co
     n: _NumT_co
     alternative: Alternative
-    statistic: _NumT_co
-    pvalue: _NumT_co
-    proportion_estimate: _NumT_co  # alias of `statistic` for backwards compatibility
+    statistic: _StatT_co
+    pvalue: _StatT_co
+    proportion_estimate: _StatT_co  # alias of `statistic` for backwards compatibility
 
     def __init__(
-        self, /, k: _NumT_co, n: _NumT_co, alternative: Alternative, statistic: _NumT_co, pvalue: _NumT_co, xp: ModuleType
+        self, /, k: _StatT_co, n: _StatT_co, alternative: Alternative, statistic: _StatT_co, pvalue: _StatT_co, xp: ModuleType
     ) -> None: ...
     def proportion_ci(
         self, /, confidence_level: float = 0.95, method: Literal["exact", "wilson", "wilsoncc"] = "exact"
-    ) -> ConfidenceInterval[_NumT_co]: ...
+    ) -> ConfidenceInterval[_StatT_co]: ...
 
 @overload
-def binomtest(k: int, n: int, p: float = 0.5, alternative: Alternative = "two-sided") -> BinomTestResult[np.float64]: ...
+def binomtest(k: int, n: int, p: float = 0.5, alternative: Alternative = "two-sided") -> BinomTestResult[int, np.float64]: ...
 @overload
 def binomtest(
     k: onp.ToArrayND[int, npc.integer] | int,
     n: onp.ToArrayND[int, npc.integer],
     p: onp.ToArrayND[float, npc.floating] | float = 0.5,
     alternative: Alternative = "two-sided",
-) -> BinomTestResult[onp.ArrayND[np.float64]]: ...
+) -> BinomTestResult[onp.ArrayND[np.float64], onp.ArrayND[np.float64]]: ...
 @overload
 def binomtest(
     k: onp.ToArrayND[int, npc.integer],
     n: onp.ToArrayND[int, npc.integer] | int,
     p: onp.ToArrayND[float, npc.floating] | float = 0.5,
     alternative: Alternative = "two-sided",
-) -> BinomTestResult[onp.ArrayND[np.float64]]: ...
+) -> BinomTestResult[onp.ArrayND[np.float64], onp.ArrayND[np.float64]]: ...
 @overload
 def binomtest(
     k: onp.ToArrayND[int, npc.integer] | int,
     n: onp.ToArrayND[int, npc.integer] | int,
     p: onp.ToArrayND[float, npc.floating],
     alternative: Alternative = "two-sided",
-) -> BinomTestResult[onp.ArrayND[np.float64]]: ...
+) -> BinomTestResult[onp.ArrayND[np.float64], onp.ArrayND[np.float64]]: ...

--- a/tests/stats/test__binomtest.pyi
+++ b/tests/stats/test__binomtest.pyi
@@ -11,8 +11,8 @@ from scipy.stats import binomtest
 # binomtest
 
 _r_0d = binomtest(5, 10)
-assert_type(_r_0d.k, np.float64)
-assert_type(_r_0d.n, np.float64)
+assert_type(_r_0d.k, int)
+assert_type(_r_0d.n, int)
 assert_type(_r_0d.statistic, np.float64)
 assert_type(_r_0d.pvalue, np.float64)
 assert_type(_r_0d.proportion_ci().low, np.float64)


### PR DESCRIPTION
For context, see (in order)

- #1683
- scipy/scipy#25340
- scipy/scipy#25509
- scipy/scipy#25884