### PR TITLE
🏷️ mark disjoint base classes with `@disjoint_base`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
         run: basedpyright scipy-stubs scripts
 
       - name: stubtest
-        run: stubtest --ignore-disjoint-bases --allowlist=.mypyignore scipy
+        run: stubtest --allowlist=.mypyignore scipy
 
   typetest:
     name: typetest (${{ matrix.py }}, ${{ matrix.np }})

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -92,7 +92,6 @@
       "--no-editable",
       "--reinstall-package=scipy-stubs",
       "stubtest",
-      "--ignore-disjoint-bases",
       "--allowlist=.mypyignore",
       "scipy"
     ],

--- a/justfile
+++ b/justfile
@@ -47,7 +47,7 @@ typetest: (pyrefly "tests") (mypy "tests") (pyright "tests")
 # validate the stubs against the scipy runtime
 stubtest:
     uv run --no-editable --reinstall-package=scipy-stubs \
-        stubtest --ignore-disjoint-bases --allowlist=.mypyignore scipy
+        stubtest --allowlist=.mypyignore scipy
 
 # check stub and type-test completeness
 coverage:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -315,7 +315,7 @@ runner = "uv-venv-lock-runner"
 dependency_groups = ["type"]
 uv_sync_flags = ["--no-editable", "--reinstall-package=scipy-stubs"]
 commands = [
-  ["stubtest", "--ignore-disjoint-bases", "--allowlist=.mypyignore", "scipy"],
+  ["stubtest", "--allowlist=.mypyignore", "scipy"],
   ["stubdefaulter", "--packages=.", "--exit-zero", "--check"],
 ]
 

--- a/scipy-stubs/_cyutility.pyi
+++ b/scipy-stubs/_cyutility.pyi
@@ -2,7 +2,7 @@ from _typeshed import Incomplete
 from builtins import memoryview as py_memoryview
 from types import EllipsisType
 from typing import Any, Final, Literal, Never, Self, SupportsIndex, TypedDict, type_check_only
-from typing_extensions import CapsuleType, ReadOnly
+from typing_extensions import CapsuleType, ReadOnly, disjoint_base
 
 ###
 
@@ -59,10 +59,12 @@ class CApiDict(TypedDict):
 __pyx_capi__: Final[CApiDict] = ...  # undocumented
 __test__: Final[dict[Any, Any]] = ...  # undocumented
 
+@disjoint_base
 class Enum:  # undocumented
     def __init__(self, /, name: str) -> None: ...
     def __setstate__(self, state: tuple[str], /) -> None: ...
 
+@disjoint_base
 class memoryview:  # undocumented
     __pyx_vtable__: Final[CapsuleType]
     base: Final[array]
@@ -84,6 +86,7 @@ class _memoryviewslize(memoryview):  # undocumented
     def count(self, /, value: Incomplete) -> int: ...
     def index(self, /, value: Incomplete, start: SupportsIndex = 0, stop: SupportsIndex | None = None) -> int: ...
 
+@disjoint_base
 class array:  # undocumented
     memview: Final[memoryview]
 

--- a/scipy-stubs/cluster/hierarchy/_hierarchy.pyi
+++ b/scipy-stubs/cluster/hierarchy/_hierarchy.pyi
@@ -1,4 +1,5 @@
 from typing import Any, Final, Literal, final, type_check_only
+from typing_extensions import disjoint_base
 
 import numpy as np
 import optype.numpy as onp
@@ -16,6 +17,7 @@ class Pair:
     value: Final[float]
 
 # defined in `cluster/_structures.pxi`
+@disjoint_base
 class Heap(_CythonMixin):
     index_by_key: Final[onp.Array1D[np.int32]]
     keys_by_index: Final[onp.Array1D[np.int32]]
@@ -27,6 +29,7 @@ class Heap(_CythonMixin):
     def remove_min(self, /) -> None: ...
     def change_value(self, /, key: int, value: float) -> None: ...
 
+@disjoint_base
 class LinkageUnionFind(_CythonMixin):
     parent: Final[onp.Array1D[np.int32]]
     size: Final[onp.Array1D[np.int32]]

--- a/scipy-stubs/io/matlab/_mio5_utils.pyi
+++ b/scipy-stubs/io/matlab/_mio5_utils.pyi
@@ -2,7 +2,7 @@
 
 from collections.abc import Iterable
 from typing import Any, ClassVar, Final, Literal, Never, Self
-from typing_extensions import CapsuleType
+from typing_extensions import CapsuleType, disjoint_base
 
 import numpy as np
 import optype.numpy as onp
@@ -23,6 +23,7 @@ swapped_code: Final[Literal[">", "<"]] = ...  # undocumented  # ">" sys.byteorde
 
 def byteswap_u4(u4: np.uint32) -> np.uint32: ...  # undocumented
 
+@disjoint_base
 class VarHeader5:  # undocumented
     # cdef readonly object name
     name: Final[object]
@@ -43,6 +44,7 @@ class VarHeader5:  # undocumented
     #
     def set_dims(self, /, dims: object) -> None: ...
 
+@disjoint_base
 class VarReader5:  # undocumented
     __pyx_vtable__: ClassVar[CapsuleType] = ...
 

--- a/scipy-stubs/io/matlab/_streams.pyi
+++ b/scipy-stubs/io/matlab/_streams.pyi
@@ -1,5 +1,5 @@
 from typing import Any, ClassVar, Final, Literal, Protocol, type_check_only
-from typing_extensions import CapsuleType
+from typing_extensions import CapsuleType, disjoint_base
 
 @type_check_only
 class _FileLike(Protocol):
@@ -13,6 +13,7 @@ BLOCK_SIZE: Final = 131072  # undocumented
 
 __pyx_capi__: Final[dict[str, CapsuleType]] = ...  # undocumented
 
+@disjoint_base
 class GenericStream:  # undocumented
     __pyx_vtable__: ClassVar[CapsuleType] = ...
 
@@ -26,6 +27,7 @@ class GenericStream:  # undocumented
     def __reduce_cython__(self) -> tuple[Any, ...]: ...
     def __setstate_cython__(self, /, state: tuple[object, ...]) -> None: ...
 
+@disjoint_base
 class ZlibInputStream(GenericStream):  # undocumented
     def __init__(self, /, fobj: _FileLike, max_length: int) -> None: ...
 

--- a/scipy-stubs/optimize/_bglu_dense.pyi
+++ b/scipy-stubs/optimize/_bglu_dense.pyi
@@ -1,6 +1,6 @@
 from collections.abc import Callable
 from typing import Any, Concatenate, Generic, Never
-from typing_extensions import TypeVar
+from typing_extensions import TypeVar, disjoint_base
 
 import numpy as np
 import optype.numpy as onp
@@ -16,6 +16,7 @@ __all__ = ["BGLU", "LU"]
 
 def _consider_refactor[MethodT: Callable[Concatenate[Any, ...], object]](method: MethodT) -> MethodT: ...  # undocumented
 
+@disjoint_base
 class LU(Generic[_NumberT_co]):  # undocumented
     A: onp.Array2D[_NumberT_co]
     B: onp.Array2D[_NumberT_co]
@@ -29,6 +30,7 @@ class LU(Generic[_NumberT_co]):  # undocumented
     def update(self, /, i: int, j: int) -> None: ...
     def solve(self, /, q: onp.ArrayND[npc.number], transposed: bool = False) -> onp.ArrayND[_NumberT_co]: ...
 
+@disjoint_base
 class BGLU(LU[_NumberT_co], Generic[_NumberT_co]):  # undocumented
     plu: tuple[onp.ArrayND[Any], ...]
     L: onp.Array2D[_NumberT_co]

--- a/scipy-stubs/spatial/_ckdtree.pyi
+++ b/scipy-stubs/spatial/_ckdtree.pyi
@@ -1,5 +1,5 @@
 from typing import Any, Generic, Literal as L, Protocol, overload, override, type_check_only
-from typing_extensions import TypeVar
+from typing_extensions import TypeVar, disjoint_base
 
 import numpy as np
 import optype.numpy as onp
@@ -50,6 +50,7 @@ class _KDTreeNode(Protocol):
 
 ###
 
+@disjoint_base
 class cKDTreeNode(_CythonMixin, _KDTreeNode, Generic[_NodeT_co]):
     @property
     @override
@@ -58,6 +59,7 @@ class cKDTreeNode(_CythonMixin, _KDTreeNode, Generic[_NodeT_co]):
     @override
     def greater(self, /) -> _NodeT_co: ...
 
+@disjoint_base
 class cKDTree(_CythonMixin, Generic[_BoxSizeT_co, _BoxSizeDataT_co]):
     @property
     def data(self, /) -> _Float2D: ...

--- a/scipy-stubs/spatial/ckdtree.pyi
+++ b/scipy-stubs/spatial/ckdtree.pyi
@@ -1,11 +1,12 @@
 # This file is not meant for public use and will be removed in SciPy v2.0.0.
 # Use the `scipy.spatial` namespace for importing the functions
 # included below.
-from typing_extensions import deprecated
+from typing_extensions import deprecated, disjoint_base
 
 from ._ckdtree import cKDTree as _cKDTree
 
 __all__ = ["cKDTree"]
 
 @deprecated("will be removed in SciPy v2.0.0")
+@disjoint_base
 class cKDTree(_cKDTree): ...

--- a/scipy-stubs/spatial/kdtree.pyi
+++ b/scipy-stubs/spatial/kdtree.pyi
@@ -1,7 +1,7 @@
 # This file is not meant for public use and will be removed in SciPy v2.0.0.
 # Use the `scipy.spatial` namespace for importing the functions
 # included below.
-from typing_extensions import deprecated
+from typing_extensions import deprecated, disjoint_base
 
 from ._ckdtree import cKDTree as _cKDTree
 from ._kdtree import KDTree as _KDTree, Rectangle as _Rectangle
@@ -9,6 +9,7 @@ from ._kdtree import KDTree as _KDTree, Rectangle as _Rectangle
 __all__ = ["KDTree", "Rectangle", "cKDTree", "distance_matrix", "minkowski_distance", "minkowski_distance_p"]
 
 @deprecated("will be removed in SciPy v2.0.0")
+@disjoint_base
 class cKDTree(_cKDTree): ...
 
 @deprecated("will be removed in SciPy v2.0.0")

--- a/scipy-stubs/stats/_biasedurn.pyi
+++ b/scipy-stubs/stats/_biasedurn.pyi
@@ -1,6 +1,7 @@
 # see `scipy/stats/_biasedurn.pyx`
 
 from typing import Never, Self, type_check_only
+from typing_extensions import disjoint_base
 
 import numpy as np
 import optype as op
@@ -21,10 +22,14 @@ class _PyNCHypergeometric:
 def __setstate_cython__(self: Never, pyx_state: Never, /) -> None: ...  # undocumented
 def __reduce_cython__(self: Never, /) -> Never: ...  # undocumented
 
+@disjoint_base
 class _PyFishersNCHypergeometric(_PyNCHypergeometric): ...  # undocumented
+
+@disjoint_base
 class _PyWalleniusNCHypergeometric(_PyNCHypergeometric): ...  # undocumented
 
 # undocumented
+@disjoint_base
 class _PyStochasticLib3:
     def Random(self, /) -> float: ...
     def SetAccuracy(self, /, accur: op.CanFloat) -> None: ...

--- a/scipy-stubs/stats/_levy_stable/levyst.pyi
+++ b/scipy-stubs/stats/_levy_stable/levyst.pyi
@@ -1,3 +1,6 @@
+from typing_extensions import disjoint_base
+
+@disjoint_base
 class Nolan:
     def __init__(self, /, alpha: float, beta: float, x0: float) -> None: ...
     def g(self, /, theta: float) -> float: ...

--- a/scipy-stubs/stats/_unuran/unuran_wrapper.pyi
+++ b/scipy-stubs/stats/_unuran/unuran_wrapper.pyi
@@ -1,6 +1,6 @@
 from collections.abc import Callable
 from typing import Generic, NamedTuple, Protocol, Self, overload, type_check_only
-from typing_extensions import TypeVar
+from typing_extensions import TypeVar, disjoint_base
 
 import numpy as np
 import optype.numpy as onp
@@ -51,6 +51,7 @@ class UError(NamedTuple):
     max_error: float
     mean_absolute_error: float
 
+@disjoint_base
 class Method(Generic[_ScalarT_co]):
     @overload
     def rvs(self: Method[np.int32], /, size: None = None, random_state: onp.random.ToRNG | None = None) -> int: ...
@@ -62,6 +63,7 @@ class Method(Generic[_ScalarT_co]):
     #
     def set_random_state(self, /, random_state: onp.random.ToRNG | None = None) -> None: ...
 
+@disjoint_base
 class TransformedDensityRejection(Method[np.float64]):
     def __new__(
         cls,
@@ -137,6 +139,7 @@ class NumericalInversePolynomial(_PPFMethodMixin, Method[np.float64]):
         self, /, size: int | tuple[int, ...], d: int | None = None, qmc_engine: stats.qmc.QMCEngine | None = None
     ) -> onp.ArrayND[np.float64]: ...
 
+@disjoint_base
 class NumericalInverseHermite(_PPFMethodMixin, Method[np.float64]):
     def __new__(
         cls,
@@ -166,6 +169,7 @@ class NumericalInverseHermite(_PPFMethodMixin, Method[np.float64]):
         self, /, size: int | tuple[int, ...], d: int | None = None, qmc_engine: stats.qmc.QMCEngine | None = None
     ) -> onp.ArrayND[np.float64]: ...
 
+@disjoint_base
 class DiscreteAliasUrn(Method[np.int32]):
     def __new__(
         cls,
@@ -176,6 +180,7 @@ class DiscreteAliasUrn(Method[np.int32]):
         random_state: onp.random.ToRNG | None = None,
     ) -> Self: ...
 
+@disjoint_base
 class DiscreteGuideTable(_PPFMethodMixin, Method[np.int32]):
     def __new__(
         cls,


### PR DESCRIPTION
[PEP 800](https://peps.python.org/pep-0800/) is accepted and even Pyright supports it now, so we can start using it here.