### PR TITLE
✨ `differentiate`: improve return type for vectorized functions

### DIFF
--- a/scipy-stubs/differentiate/_differentiate.pyi
+++ b/scipy-stubs/differentiate/_differentiate.pyi
@@ -1,7 +1,7 @@
 from _typeshed import ConvertibleToInt, Unused
 from collections.abc import Callable, Mapping
-from typing import Any, Concatenate, Generic, Literal, TypedDict, overload, type_check_only
-from typing_extensions import TypeVar
+from typing import Any, Concatenate, Literal, Never, overload, type_check_only
+from typing_extensions import TypedDict
 
 import numpy as np
 import optype.numpy as onp
@@ -9,62 +9,106 @@ import optype.numpy.compat as npc
 
 from scipy._lib._util import _RichResult
 
-_FloatT_co = TypeVar("_FloatT_co", bound=npc.floating, default=np.float64, covariant=True)
-_ShapeT_co = TypeVar("_ShapeT_co", bound=tuple[int, *tuple[int, ...]], default=tuple[Any, ...], covariant=True)
-_ShapeT2_co = TypeVar("_ShapeT2_co", bound=tuple[int, int, *tuple[int, ...]], default=tuple[Any, ...], covariant=True)
+###
 
 type _Function00[FloatT: npc.floating] = Callable[Concatenate[FloatT, ...], onp.ToFloat]
 type _Function11[FloatT: npc.floating] = Callable[Concatenate[onp.Array1D[FloatT], ...], onp.ToFloat1D]
-type _FunctionNN[FloatT: npc.floating] = Callable[Concatenate[onp.ArrayND[FloatT, Any], ...], onp.ToFloatND]
+type _FunctionNN[FloatT: npc.floating] = Callable[Concatenate[onp.ArrayND[FloatT], ...], onp.ToFloatND]
+
+type _AsF64ND = onp.ToArrayND[float, np.float64 | npc.integer | np.bool]
+
+type _ToArgsND = tuple[onp.ToScalar | onp.ToArrayND, ...]
+type _ToKwargsND = Mapping[str, onp.ToScalar | onp.ToArrayND]
+
+# workaround for https://github.com/microsoft/pyright/issues/10232
+type _JustAnyShape = tuple[Never, Never, Never, Never]
 
 @type_check_only
-class _Tolerances(TypedDict, total=False):
+class _Tolerances(TypedDict, total=False, closed=True):
     rtol: onp.ToFloat
     atol: onp.ToFloat
 
 @type_check_only
-class _DerivativeResult0D(_RichResult, Generic[_FloatT_co]):
+class _DerivativeResult0D[FloatT: npc.floating](_RichResult[FloatT | np.int32 | np.bool]):
     success: np.bool
     status: np.int32
     nfev: np.int32
     nit: np.int32
-    x: _FloatT_co
-    df: _FloatT_co
-    error: _FloatT_co
+    x: FloatT
+    df: FloatT
+    error: FloatT
 
 @type_check_only
-class _DerivativeResultND(_RichResult, Generic[_FloatT_co, _ShapeT_co]):
-    success: onp.Array[_ShapeT_co, np.bool]
-    status: onp.Array[_ShapeT_co, np.int32]
-    nfev: onp.Array[_ShapeT_co, np.int32]
-    nit: onp.Array[_ShapeT_co, np.int32]
-    x: onp.Array[_ShapeT_co, _FloatT_co]
-    df: onp.Array[_ShapeT_co, _FloatT_co]
-    error: onp.Array[_ShapeT_co, _FloatT_co]
+class _DerivativeResultND[FloatT: npc.floating, ShapeT: tuple[int, ...]](
+    _RichResult[onp.ArrayND[FloatT | np.int32 | np.bool, ShapeT]]
+):
+    success: onp.ArrayND[np.bool, ShapeT]
+    status: onp.ArrayND[np.int32, ShapeT]
+    nfev: onp.ArrayND[np.int32, ShapeT]
+    nit: onp.ArrayND[np.int32, ShapeT]
+    x: onp.ArrayND[FloatT, ShapeT]
+    df: onp.ArrayND[FloatT, ShapeT]
+    error: onp.ArrayND[FloatT, ShapeT]
 
 @type_check_only
-class _JacobianResult(_RichResult, Generic[_FloatT_co, _ShapeT_co]):
-    status: onp.Array[_ShapeT_co, np.int32]
-    df: onp.Array[_ShapeT_co, _FloatT_co]
-    error: onp.Array[_ShapeT_co, _FloatT_co]
-    nit: onp.Array[_ShapeT_co, np.int32]
-    nfev: onp.Array[_ShapeT_co, np.int32]
-    success: onp.Array[_ShapeT_co, np.bool]
+class _JacobianResult[FloatT: npc.floating, ShapeT: tuple[int, ...]](
+    _RichResult[onp.ArrayND[FloatT | np.int32 | np.bool, ShapeT]]
+):
+    status: onp.ArrayND[np.int32, ShapeT]
+    df: onp.ArrayND[FloatT, ShapeT]
+    error: onp.ArrayND[FloatT, ShapeT]
+    nit: onp.ArrayND[np.int32, ShapeT]
+    nfev: onp.ArrayND[np.int32, ShapeT]
+    success: onp.ArrayND[np.bool, ShapeT]
 
 @type_check_only
-class _HessianResult(_RichResult, Generic[_FloatT_co, _ShapeT2_co]):
-    status: onp.Array[_ShapeT2_co, np.int32]
-    error: onp.Array[_ShapeT2_co, _FloatT_co]
-    nfev: onp.Array[_ShapeT2_co, np.int64]
-    success: onp.Array[_ShapeT2_co, np.bool]
-    ddf: onp.Array[_ShapeT2_co, _FloatT_co]
+class _HessianResult[FloatT: npc.floating, ShapeT: tuple[int, ...]](
+    _RichResult[onp.ArrayND[FloatT | np.int32 | np.bool, ShapeT]]
+):
+    status: onp.ArrayND[np.int32, ShapeT]
+    error: onp.ArrayND[FloatT, ShapeT]
+    nfev: onp.ArrayND[np.int64, ShapeT]
+    success: onp.ArrayND[np.bool, ShapeT]
+    ddf: onp.ArrayND[FloatT, ShapeT]
 
 ###
 
-@overload  # 0-d float64
+@overload  # ?d f64
+def derivative(
+    f: _FunctionNN[np.float64],
+    x: onp.ArrayND[np.float64 | npc.integer | np.bool, _JustAnyShape],
+    *,
+    args: _ToArgsND = (),
+    kwargs: _ToKwargsND | None = None,
+    tolerances: _Tolerances | None = None,
+    maxiter: ConvertibleToInt = 10,
+    order: ConvertibleToInt = 8,
+    initial_step: onp.ToFloat | onp.ToFloatND = 0.5,
+    step_factor: onp.ToFloat = 2.0,
+    step_direction: onp.ToJustInt | onp.ToJustIntND = 0,
+    preserve_shape: bool = False,
+    callback: Callable[[_DerivativeResultND[np.float64, tuple[Any, ...]]], Unused] | None = None,
+) -> _DerivativeResultND[np.float64, tuple[Any, ...]]: ...
+@overload  # ?d <known>
+def derivative[FloatT: npc.floating](
+    f: _FunctionNN[FloatT],
+    x: onp.ArrayND[FloatT, _JustAnyShape],
+    *,
+    args: _ToArgsND = (),
+    kwargs: _ToKwargsND | None = None,
+    tolerances: _Tolerances | None = None,
+    maxiter: ConvertibleToInt = 10,
+    order: ConvertibleToInt = 8,
+    initial_step: onp.ToFloat | onp.ToFloatND = 0.5,
+    step_factor: onp.ToFloat = 2.0,
+    step_direction: onp.ToJustInt | onp.ToJustIntND = 0,
+    preserve_shape: bool = False,
+    callback: Callable[[_DerivativeResultND[FloatT, tuple[Any, ...]]], Unused] | None = None,
+) -> _DerivativeResultND[FloatT, tuple[Any, ...]]: ...
+@overload  # 0d f64
 def derivative(
     f: _Function00[np.float64],
-    x: float | np.float64 | npc.integer | onp.CanArray0[np.float64 | npc.integer],
+    x: float | np.float64 | npc.integer | onp.Array0D[np.float64 | npc.integer],
     *,
     args: tuple[onp.ToScalar, ...] = (),
     kwargs: Mapping[str, onp.ToScalar] | None = None,
@@ -77,10 +121,10 @@ def derivative(
     preserve_shape: Literal[False] = False,
     callback: Callable[[_DerivativeResult0D[np.float64]], Unused] | None = None,
 ) -> _DerivativeResult0D[np.float64]: ...
-@overload  # 0-d <known>
+@overload  # 0d <known>
 def derivative[FloatT: npc.floating](
     f: _Function00[FloatT],
-    x: FloatT | onp.CanArray0[FloatT | npc.integer],
+    x: FloatT | onp.Array0D[FloatT | npc.integer],
     *,
     args: tuple[onp.ToScalar, ...] = (),
     kwargs: Mapping[str, onp.ToScalar] | None = None,
@@ -93,10 +137,26 @@ def derivative[FloatT: npc.floating](
     preserve_shape: Literal[False] = False,
     callback: Callable[[_DerivativeResult0D[FloatT]], Unused] | None = None,
 ) -> _DerivativeResult0D[FloatT]: ...
-@overload  # 1-d <unknown>
+@overload  # 1d f64
+def derivative(
+    f: _Function11[np.float64],
+    x: onp.ToArrayStrict1D[float, np.float64 | npc.integer | np.bool],
+    *,
+    args: tuple[onp.ToScalar | onp.ToArrayStrict1D, ...] = (),
+    kwargs: Mapping[str, onp.ToScalar | onp.ToArrayStrict1D] | None = None,
+    tolerances: _Tolerances | None = None,
+    maxiter: ConvertibleToInt = 10,
+    order: ConvertibleToInt = 8,
+    initial_step: onp.ToFloat | onp.ToFloatStrict1D = 0.5,
+    step_factor: onp.ToFloat = 2.0,
+    step_direction: onp.ToJustInt | onp.ToJustIntStrict1D = 0,
+    preserve_shape: Literal[False] = False,
+    callback: Callable[[_DerivativeResultND[np.float64, tuple[int]]], Unused] | None = None,
+) -> _DerivativeResultND[np.float64, tuple[int]]: ...
+@overload  # 1d <known>
 def derivative[FloatT: npc.floating](
     f: _Function11[FloatT],
-    x: onp.ToFloatStrict1D,
+    x: onp.Array1D[FloatT],
     *,
     args: tuple[onp.ToScalar | onp.ToArrayStrict1D, ...] = (),
     kwargs: Mapping[str, onp.ToScalar | onp.ToArrayStrict1D] | None = None,
@@ -109,13 +169,13 @@ def derivative[FloatT: npc.floating](
     preserve_shape: Literal[False] = False,
     callback: Callable[[_DerivativeResultND[FloatT, tuple[int]]], Unused] | None = None,
 ) -> _DerivativeResultND[FloatT, tuple[int]]: ...
-@overload  # n-d <known>
-def derivative[FloatT: npc.floating](
-    f: _FunctionNN[FloatT],
-    x: FloatT | onp.ToArrayND[FloatT],
+@overload  # Nd f64
+def derivative(
+    f: _FunctionNN[np.float64],
+    x: _AsF64ND,
     *,
-    args: tuple[onp.ToScalar | onp.ToArrayND, ...] = (),
-    kwargs: Mapping[str, onp.ToScalar | onp.ToArrayND] | None = None,
+    args: _ToArgsND = (),
+    kwargs: _ToKwargsND | None = None,
     tolerances: _Tolerances | None = None,
     maxiter: ConvertibleToInt = 10,
     order: ConvertibleToInt = 8,
@@ -123,15 +183,15 @@ def derivative[FloatT: npc.floating](
     step_factor: onp.ToFloat = 2.0,
     step_direction: onp.ToJustInt | onp.ToJustIntND = 0,
     preserve_shape: bool = False,
-    callback: Callable[[_DerivativeResultND[FloatT]], Unused] | None = None,
-) -> _DerivativeResultND[FloatT]: ...
-@overload  # n-d <unknown>
+    callback: Callable[[_DerivativeResultND[np.float64, tuple[Any, ...]]], Unused] | None = None,
+) -> _DerivativeResultND[np.float64, tuple[Any, ...]]: ...
+@overload  # Nd <known>
 def derivative[FloatT: npc.floating](
     f: _FunctionNN[FloatT],
-    x: onp.ToFloat | onp.ToFloatND,
+    x: FloatT | onp.CanArrayND[FloatT],
     *,
-    args: tuple[onp.ToScalar | onp.ToArrayND, ...] = (),
-    kwargs: Mapping[str, onp.ToScalar | onp.ToArrayND] | None = None,
+    args: _ToArgsND = (),
+    kwargs: _ToKwargsND | None = None,
     tolerances: _Tolerances | None = None,
     maxiter: ConvertibleToInt = 10,
     order: ConvertibleToInt = 8,
@@ -139,13 +199,26 @@ def derivative[FloatT: npc.floating](
     step_factor: onp.ToFloat = 2.0,
     step_direction: onp.ToJustInt | onp.ToJustIntND = 0,
     preserve_shape: bool = False,
-    callback: Callable[[_DerivativeResultND[FloatT]], Unused] | None = None,
-) -> _DerivativeResultND[FloatT]: ...
+    callback: Callable[[_DerivativeResultND[FloatT, tuple[Any, ...]]], Unused] | None = None,
+) -> _DerivativeResultND[FloatT, tuple[Any, ...]]: ...
 
 #
+@overload  # f64
+def jacobian(
+    f: Callable[[onp.ArrayND[np.float64]], onp.ToFloat | onp.ToFloatND],
+    x: _AsF64ND,
+    *,
+    tolerances: _Tolerances | None = None,
+    maxiter: ConvertibleToInt = 10,
+    order: ConvertibleToInt = 8,
+    initial_step: onp.ToFloat | onp.ToFloatND = 0.5,
+    step_factor: onp.ToFloat = 2.0,
+    step_direction: onp.ToJustInt | onp.ToJustIntND = 0,
+) -> _JacobianResult[np.float64, tuple[int, *tuple[Any, ...]]]: ...
+@overload  # <known>
 def jacobian[FloatT: npc.floating](
-    f: Callable[[onp.Array[Any, FloatT]], onp.ToFloat | onp.ToFloatND],
-    x: onp.ToFloatND,
+    f: Callable[[onp.ArrayND[FloatT]], onp.ToFloat | onp.ToFloatND],
+    x: onp.CanArrayND[FloatT],
     *,
     tolerances: _Tolerances | None = None,
     maxiter: ConvertibleToInt = 10,
@@ -153,16 +226,28 @@ def jacobian[FloatT: npc.floating](
     initial_step: onp.ToFloat | onp.ToFloatND = 0.5,
     step_factor: onp.ToFloat = 2.0,
     step_direction: onp.ToJustInt | onp.ToJustIntND = 0,
-) -> _JacobianResult[FloatT, onp.AtLeast1D]: ...
+) -> _JacobianResult[FloatT, tuple[int, *tuple[Any, ...]]]: ...
 
 #
-def hessian[FloatT: npc.floating](
-    f: Callable[[onp.Array[Any, FloatT]], onp.ToFloat | onp.ToFloatND],
-    x: onp.ToFloatND,
+@overload  # f64
+def hessian(
+    f: Callable[[onp.ArrayND[np.float64]], onp.ToFloat | onp.ToFloatND],
+    x: _AsF64ND,
     *,
     tolerances: _Tolerances | None = None,
     maxiter: ConvertibleToInt = 10,
     order: ConvertibleToInt = 8,
     initial_step: onp.ToFloat | onp.ToFloatND = 0.5,
     step_factor: onp.ToFloat = 2.0,
-) -> _HessianResult[FloatT, onp.AtLeast2D]: ...
+) -> _HessianResult[np.float64, tuple[int, int, *tuple[Any, ...]]]: ...
+@overload  # <known>
+def hessian[FloatT: npc.floating](
+    f: Callable[[onp.ArrayND[FloatT]], onp.ToFloat | onp.ToFloatND],
+    x: onp.CanArrayND[FloatT],
+    *,
+    tolerances: _Tolerances | None = None,
+    maxiter: ConvertibleToInt = 10,
+    order: ConvertibleToInt = 8,
+    initial_step: onp.ToFloat | onp.ToFloatND = 0.5,
+    step_factor: onp.ToFloat = 2.0,
+) -> _HessianResult[FloatT, tuple[int, int, *tuple[Any, ...]]]: ...

--- a/tests/differentiate/test_differentiate.pyi
+++ b/tests/differentiate/test_differentiate.pyi
@@ -1,6 +1,4 @@
-# ruff: file-ignore[commented-out-code]
-
-from typing import assert_type
+from typing import Any, assert_type
 
 import numpy as np
 import optype.numpy as onp
@@ -8,46 +6,53 @@ import optype.numpy as onp
 from scipy.differentiate import derivative, hessian, jacobian
 from scipy.differentiate._differentiate import _DerivativeResult0D, _DerivativeResultND, _HessianResult, _JacobianResult
 
-# Test scalar
-i32_0d: np.int32
-i64_0d: np.int64
-f32_0d: np.float32
-f64_0d: np.float64
+###
 
-i64_1d: onp.Array1D[np.int64]
-f64_1d: onp.Array1D[np.float64]
-f64_2d: onp.Array2D[np.float64]
+_i32_0d: np.int32
+_i64_0d: np.int64
+_f32_0d: np.float32
+_f64_0d: np.float64
 
-def f_f64_0d(x: np.float64) -> np.float64: ...
-def f_f32_0d(x: np.float32) -> np.float32: ...
-def f_f64_1d(x: onp.Array1D[np.float64]) -> onp.Array1D[np.float64]: ...
-def f_f64_nd(x: onp.ArrayND[np.float64]) -> onp.ArrayND[np.float64]: ...
-def f_f64_1nd_0d(x: onp.Array[onp.AtLeast1D, np.float64]) -> np.float64: ...
-def f_f64_1nd_nd(x: onp.Array[onp.AtLeast1D, np.float64]) -> onp.ArrayND[np.float64]: ...
-def f_f64_0d_arg(x: np.float64, a: float) -> np.float64: ...
+_i64_1d: onp.Array1D[np.int64]
+_f64_1d: onp.Array1D[np.float64]
+_f64_2d: onp.Array2D[np.float64]
 
-# NOTE: the commented out assertions only work on numpy 2.1+, so we instead check for assignability
+_py_f_1d: list[float]
+
+def _f_f32_0d(x: np.float32) -> np.float32: ...
+def _f_f64_0d(x: np.float64) -> np.float64: ...
+def _f_f64_1d(x: onp.Array1D[np.float64]) -> onp.Array1D[np.float64]: ...
+def _f_f64_nd(x: onp.ArrayND[np.float64]) -> onp.ArrayND[np.float64]: ...
+def _f_f64_nd_0d(x: onp.ArrayND[np.float64]) -> np.float64: ...
+def _f_f64_nd_nd(x: onp.ArrayND[np.float64]) -> onp.ArrayND[np.float64]: ...
+def _f_f64_0d_arg(x: np.float64, a: float) -> np.float64: ...
 
 ###
 # derivative
 
-assert_type(derivative(f_f64_0d, 1.0), _DerivativeResult0D[np.float64])
-assert_type(derivative(f_f64_0d, f64_0d), _DerivativeResult0D[np.float64])
-assert_type(derivative(f_f64_0d, i32_0d), _DerivativeResult0D[np.float64])
-assert_type(derivative(f_f32_0d, f32_0d), _DerivativeResult0D[np.float32])
+assert_type(derivative(_f_f64_0d, 1.0), _DerivativeResult0D[np.float64])
+assert_type(derivative(_f_f64_0d, _f64_0d), _DerivativeResult0D[np.float64])
+assert_type(derivative(_f_f64_0d, _i32_0d), _DerivativeResult0D[np.float64])
+assert_type(derivative(_f_f32_0d, _f32_0d), _DerivativeResult0D[np.float32])
 
-# assert_type(derivative(f_f64_1d, f64_1d), _DerivativeResultND[np.float64, tuple[int]])
-# assert_type(derivative(f_f64_nd, f64_2d), _DerivativeResultND[np.float64, tuple[int, int]])
-# assert_type(derivative(f_f64_1d, f64_1d, <...>), _DerivativeResultND[np.float64, tuple[int]])
-_0: _DerivativeResultND[np.float64, tuple[int]] = derivative(f_f64_1d, f64_1d)
-_1: _DerivativeResultND[np.float64, tuple[int, int]] = derivative(f_f64_nd, f64_2d)
-_2: _DerivativeResultND[np.float64, tuple[int]] = derivative(f_f64_1d, f64_1d, initial_step=f64_1d, step_direction=i64_1d)
+assert_type(derivative(_f_f64_1d, _f64_1d), _DerivativeResultND[np.float64, tuple[int]])
+assert_type(derivative(_f_f64_nd, _f64_2d), _DerivativeResultND[np.float64, tuple[Any, ...]])
+assert_type(
+    derivative(_f_f64_1d, _f64_1d, initial_step=_f64_1d, step_direction=_i64_1d), _DerivativeResultND[np.float64, tuple[int]]
+)
 
-assert_type(derivative(f_f64_0d_arg, 1.0, args=(2.0,)), _DerivativeResult0D[np.float64])
-assert_type(derivative(f_f64_0d, 1.0, tolerances={"atol": 0.1}), _DerivativeResult0D[np.float64])
+# the dtype follows `x`, not `f`
+assert_type(derivative(np.exp, _f64_1d), _DerivativeResultND[np.float64, tuple[int]])
+assert_type(derivative(np.exp, _i64_1d), _DerivativeResultND[np.float64, tuple[int]])
+assert_type(derivative(np.exp, _py_f_1d), _DerivativeResultND[np.float64, tuple[int]])
+assert_type(jacobian(np.exp, _f64_1d), _JacobianResult[np.float64, tuple[int, *tuple[Any, ...]]])
+assert_type(hessian(np.exp, _f64_1d), _HessianResult[np.float64, tuple[int, int, *tuple[Any, ...]]])
+
+assert_type(derivative(_f_f64_0d_arg, 1.0, args=(2.0,)), _DerivativeResult0D[np.float64])
+assert_type(derivative(_f_f64_0d, 1.0, tolerances={"atol": 0.1}), _DerivativeResult0D[np.float64])
 assert_type(
     derivative(
-        f_f64_0d,
+        _f_f64_0d,
         1.0,
         args=(),
         tolerances={"atol": 0.1},
@@ -62,7 +67,7 @@ assert_type(
     _DerivativeResult0D[np.float64],
 )
 
-res_der_0d = derivative(f_f64_0d, 1.0)
+res_der_0d = derivative(_f_f64_0d, 1.0)
 assert_type(res_der_0d.success, np.bool)
 assert_type(res_der_0d.status, np.int32)
 assert_type(res_der_0d.nfev, np.int32)
@@ -71,58 +76,52 @@ assert_type(res_der_0d.x, np.float64)
 assert_type(res_der_0d.df, np.float64)
 assert_type(res_der_0d.error, np.float64)
 
-res_der_nd = derivative(f_f64_1d, f64_1d)
-# assert_type(res_der_nd.success, onp.Array1D[np.bool])
-# assert_type(res_der_nd.status, onp.Array1D[np.int32])
-# assert_type(res_der_nd.nfev, onp.Array1D[np.int32])
-# assert_type(res_der_nd.nit, onp.Array1D[np.int32])
-# assert_type(res_der_nd.x, onp.Array1D[np.float64])
-# assert_type(res_der_nd.df, onp.Array1D[np.float64])
-# assert_type(res_der_nd.error, onp.Array1D[np.float64])
-_3: onp.Array1D[np.bool] = res_der_nd.success
-_4: onp.Array1D[np.int32] = res_der_nd.status
-_5: onp.Array1D[np.int32] = res_der_nd.nfev
-_6: onp.Array1D[np.int32] = res_der_nd.nit
-_7: onp.Array1D[np.float64] = res_der_nd.x
-_8: onp.Array1D[np.float64] = res_der_nd.df
-_9: onp.Array1D[np.float64] = res_der_nd.error
+res_der_nd = derivative(_f_f64_1d, _f64_1d)
+assert_type(res_der_nd.success, onp.Array1D[np.bool])
+assert_type(res_der_nd.status, onp.Array1D[np.int32])
+assert_type(res_der_nd.nfev, onp.Array1D[np.int32])
+assert_type(res_der_nd.nit, onp.Array1D[np.int32])
+assert_type(res_der_nd.x, onp.Array1D[np.float64])
+assert_type(res_der_nd.df, onp.Array1D[np.float64])
+assert_type(res_der_nd.error, onp.Array1D[np.float64])
 
 ###
 # jacobian
 
-assert_type(jacobian(f_f64_1nd_0d, f64_1d), _JacobianResult[np.float64, onp.AtLeast1D])
-assert_type(jacobian(f_f64_1nd_nd, f64_1d), _JacobianResult[np.float64, onp.AtLeast1D])
+assert_type(jacobian(_f_f64_nd_0d, _f64_1d), _JacobianResult[np.float64, tuple[int, *tuple[Any, ...]]])
+assert_type(jacobian(_f_f64_nd_nd, _f64_1d), _JacobianResult[np.float64, tuple[int, *tuple[Any, ...]]])
 assert_type(
     jacobian(
-        f_f64_1nd_0d, f64_1d, tolerances={"atol": 0.1}, maxiter=15, order=6, initial_step=0.1, step_factor=1.8, step_direction=0
+        _f_f64_nd_0d, _f64_1d, tolerances={"atol": 0.1}, maxiter=15, order=6, initial_step=0.1, step_factor=1.8, step_direction=0
     ),
-    _JacobianResult[np.float64, onp.AtLeast1D],
+    _JacobianResult[np.float64, tuple[int, *tuple[Any, ...]]],
 )
 assert_type(
-    jacobian(f_f64_1nd_nd, f64_2d, initial_step=f64_1d, step_direction=i64_1d), _JacobianResult[np.float64, onp.AtLeast1D]
+    jacobian(_f_f64_nd_nd, _f64_2d, initial_step=_f64_1d, step_direction=_i64_1d),
+    _JacobianResult[np.float64, tuple[int, *tuple[Any, ...]]],
 )
 
-res_jac = jacobian(f_f64_1nd_0d, f64_1d)
-assert_type(res_jac.status, onp.Array[onp.AtLeast1D, np.int32])
-assert_type(res_jac.df, onp.Array[onp.AtLeast1D, np.float64])
-assert_type(res_jac.error, onp.Array[onp.AtLeast1D, np.float64])
-assert_type(res_jac.nit, onp.Array[onp.AtLeast1D, np.int32])
-assert_type(res_jac.nfev, onp.Array[onp.AtLeast1D, np.int32])
-assert_type(res_jac.success, onp.Array[onp.AtLeast1D, np.bool])
+_res_jac = jacobian(_f_f64_nd_0d, _f64_1d)
+assert_type(_res_jac.status, onp.ArrayND[np.int32, tuple[int, *tuple[Any, ...]]])
+assert_type(_res_jac.df, onp.ArrayND[np.float64, tuple[int, *tuple[Any, ...]]])
+assert_type(_res_jac.error, onp.ArrayND[np.float64, tuple[int, *tuple[Any, ...]]])
+assert_type(_res_jac.nit, onp.ArrayND[np.int32, tuple[int, *tuple[Any, ...]]])
+assert_type(_res_jac.nfev, onp.ArrayND[np.int32, tuple[int, *tuple[Any, ...]]])
+assert_type(_res_jac.success, onp.ArrayND[np.bool, tuple[int, *tuple[Any, ...]]])
 
 ###
 # hessian
 
-assert_type(hessian(f_f64_1nd_0d, f64_1d), _HessianResult[np.float64, onp.AtLeast2D])
+assert_type(hessian(_f_f64_nd_0d, _f64_1d), _HessianResult[np.float64, tuple[int, int, *tuple[Any, ...]]])
 assert_type(
-    hessian(f_f64_1nd_0d, f64_1d, tolerances={"atol": 0.1}, maxiter=25, order=10, initial_step=0.05, step_factor=2.5),
-    _HessianResult[np.float64, onp.AtLeast2D],
+    hessian(_f_f64_nd_0d, _f64_1d, tolerances={"atol": 0.1}, maxiter=25, order=10, initial_step=0.05, step_factor=2.5),
+    _HessianResult[np.float64, tuple[int, int, *tuple[Any, ...]]],
 )
-assert_type(hessian(f_f64_1nd_0d, f64_2d, initial_step=f64_1d), _HessianResult[np.float64, onp.AtLeast2D])
+assert_type(hessian(_f_f64_nd_0d, _f64_2d, initial_step=_f64_1d), _HessianResult[np.float64, tuple[int, int, *tuple[Any, ...]]])
 
-res_hes = hessian(f_f64_1nd_0d, f64_1d)
-assert_type(res_hes.status, onp.Array[onp.AtLeast2D, np.int32])
-assert_type(res_hes.error, onp.Array[onp.AtLeast2D, np.float64])
-assert_type(res_hes.nfev, onp.Array[onp.AtLeast2D, np.int64])
-assert_type(res_hes.success, onp.Array[onp.AtLeast2D, np.bool])
-assert_type(res_hes.ddf, onp.Array[onp.AtLeast2D, np.float64])
+_res_hes = hessian(_f_f64_nd_0d, _f64_1d)
+assert_type(_res_hes.status, onp.ArrayND[np.int32, tuple[int, int, *tuple[Any, ...]]])
+assert_type(_res_hes.error, onp.ArrayND[np.float64, tuple[int, int, *tuple[Any, ...]]])
+assert_type(_res_hes.nfev, onp.ArrayND[np.int64, tuple[int, int, *tuple[Any, ...]]])
+assert_type(_res_hes.success, onp.ArrayND[np.bool, tuple[int, int, *tuple[Any, ...]]])
+assert_type(_res_hes.ddf, onp.ArrayND[np.float64, tuple[int, int, *tuple[Any, ...]]])


### PR DESCRIPTION
This also cleans up the `scipy.differentiate` stubs and type-tests significantly, and improves compatibility with NumPy <2.1.