### PR TITLE
🐛 `sparse.linalg.lobcpg`: fix returned history list element types

### DIFF
--- a/scipy-stubs/sparse/linalg/_eigen/lobpcg/lobpcg.pyi
+++ b/scipy-stubs/sparse/linalg/_eigen/lobpcg/lobpcg.pyi
@@ -59,7 +59,7 @@ def lobpcg[FloatT: _Float](
     retLambdaHistory: onp.ToFalse,
     retResidualNormsHistory: onp.ToTrue,
     restartControl: int = 20,
-) -> tuple[onp.Array1D[FloatT], onp.Array2D[FloatT | _Complex], list[onp.Array0D[FloatT]]]: ...
+) -> tuple[onp.Array1D[FloatT], onp.Array2D[FloatT | _Complex], list[onp.Array1D[FloatT]]]: ...
 @overload  # retLambdaHistory: falsy = ..., retResidualNormsHistory: truthy  (keyword)
 def lobpcg[FloatT: _Float](
     A: _ToComplexMatrix[FloatT],
@@ -75,7 +75,7 @@ def lobpcg[FloatT: _Float](
     *,
     retResidualNormsHistory: onp.ToTrue,
     restartControl: int = 20,
-) -> tuple[onp.Array1D[FloatT], onp.Array2D[FloatT | _Complex], list[onp.Array0D[FloatT]]]: ...
+) -> tuple[onp.Array1D[FloatT], onp.Array2D[FloatT | _Complex], list[onp.Array1D[FloatT]]]: ...
 @overload  # retLambdaHistory: truthy  (positional), retResidualNormsHistory: falsy = ...
 def lobpcg[FloatT: _Float](
     A: _ToComplexMatrix[FloatT],
@@ -90,7 +90,7 @@ def lobpcg[FloatT: _Float](
     retLambdaHistory: onp.ToTrue,
     retResidualNormsHistory: onp.ToFalse = False,
     restartControl: int = 20,
-) -> tuple[onp.Array1D[FloatT], onp.Array2D[FloatT | _Complex], list[onp.Array0D[FloatT]]]: ...
+) -> tuple[onp.Array1D[FloatT], onp.Array2D[FloatT | _Complex], list[onp.Array1D[FloatT]]]: ...
 @overload  # retLambdaHistory: truthy  (keyword), retResidualNormsHistory: falsy = ...
 def lobpcg[FloatT: _Float](
     A: _ToComplexMatrix[FloatT],
@@ -106,7 +106,7 @@ def lobpcg[FloatT: _Float](
     retLambdaHistory: onp.ToTrue,
     retResidualNormsHistory: onp.ToFalse = False,
     restartControl: int = 20,
-) -> tuple[onp.Array1D[FloatT], onp.Array2D[FloatT | _Complex], list[onp.Array0D[FloatT]]]: ...
+) -> tuple[onp.Array1D[FloatT], onp.Array2D[FloatT | _Complex], list[onp.Array1D[FloatT]]]: ...
 @overload  # retLambdaHistory: truthy  (positional), retResidualNormsHistory: truthy
 def lobpcg[FloatT: _Float](
     A: _ToComplexMatrix[FloatT],
@@ -121,7 +121,7 @@ def lobpcg[FloatT: _Float](
     retLambdaHistory: onp.ToTrue,
     retResidualNormsHistory: onp.ToTrue,
     restartControl: int = 20,
-) -> tuple[onp.Array1D[FloatT], onp.Array2D[FloatT | _Complex], list[onp.Array0D[FloatT]], list[onp.Array0D[FloatT]]]: ...
+) -> tuple[onp.Array1D[FloatT], onp.Array2D[FloatT | _Complex], list[onp.Array1D[FloatT]], list[onp.Array1D[FloatT]]]: ...
 @overload  # retLambdaHistory: truthy  (keyword), retResidualNormsHistory: truthy
 def lobpcg[FloatT: _Float](
     A: _ToComplexMatrix[FloatT],
@@ -137,4 +137,4 @@ def lobpcg[FloatT: _Float](
     retLambdaHistory: onp.ToTrue,
     retResidualNormsHistory: onp.ToTrue,
     restartControl: int = 20,
-) -> tuple[onp.Array1D[FloatT], onp.Array2D[FloatT | _Complex], list[onp.Array0D[FloatT]], list[onp.Array0D[FloatT]]]: ...
+) -> tuple[onp.Array1D[FloatT], onp.Array2D[FloatT | _Complex], list[onp.Array1D[FloatT]], list[onp.Array1D[FloatT]]]: ...

--- a/tests/sparse/linalg/test__lobpcg.pyi
+++ b/tests/sparse/linalg/test__lobpcg.pyi
@@ -12,27 +12,27 @@ x: onp.Array2D[np.float64]
 assert_type(lobpcg(a, x), tuple[onp.Array1D[np.float64], onp.Array2D[np.float64 | np.complex64 | np.complex128]])
 assert_type(
     lobpcg(a, x, None, None, None, None, None, True, 0, False, True),
-    tuple[onp.Array1D[np.float64], onp.Array2D[np.float64 | np.complex64 | np.complex128], list[onp.Array0D[np.float64]]],
+    tuple[onp.Array1D[np.float64], onp.Array2D[np.float64 | np.complex64 | np.complex128], list[onp.Array1D[np.float64]]],
 )
 assert_type(
     lobpcg(a, x, retResidualNormsHistory=True),
-    tuple[onp.Array1D[np.float64], onp.Array2D[np.float64 | np.complex64 | np.complex128], list[onp.Array0D[np.float64]]],
+    tuple[onp.Array1D[np.float64], onp.Array2D[np.float64 | np.complex64 | np.complex128], list[onp.Array1D[np.float64]]],
 )
 assert_type(
     lobpcg(a, x, None, None, None, None, None, True, 0, True, False),
-    tuple[onp.Array1D[np.float64], onp.Array2D[np.float64 | np.complex64 | np.complex128], list[onp.Array0D[np.float64]]],
+    tuple[onp.Array1D[np.float64], onp.Array2D[np.float64 | np.complex64 | np.complex128], list[onp.Array1D[np.float64]]],
 )
 assert_type(
     lobpcg(a, x, retLambdaHistory=True),
-    tuple[onp.Array1D[np.float64], onp.Array2D[np.float64 | np.complex64 | np.complex128], list[onp.Array0D[np.float64]]],
+    tuple[onp.Array1D[np.float64], onp.Array2D[np.float64 | np.complex64 | np.complex128], list[onp.Array1D[np.float64]]],
 )
 assert_type(
     lobpcg(a, x, None, None, None, None, None, True, 0, True, True),
     tuple[
         onp.Array1D[np.float64],
         onp.Array2D[np.float64 | np.complex64 | np.complex128],
-        list[onp.Array0D[np.float64]],
-        list[onp.Array0D[np.float64]],
+        list[onp.Array1D[np.float64]],
+        list[onp.Array1D[np.float64]],
     ],
 )
 assert_type(
@@ -40,7 +40,7 @@ assert_type(
     tuple[
         onp.Array1D[np.float64],
         onp.Array2D[np.float64 | np.complex64 | np.complex128],
-        list[onp.Array0D[np.float64]],
-        list[onp.Array0D[np.float64]],
+        list[onp.Array1D[np.float64]],
+        list[onp.Array1D[np.float64]],
     ],
 )


### PR DESCRIPTION
They should be 1d instead of 0d