### PR TITLE
🐛 `sparse.linalg.matrix_power`: fix return types when `power` is `0` or `1`

### DIFF
--- a/scipy-stubs/sparse/linalg/_matfuncs.pyi
+++ b/scipy-stubs/sparse/linalg/_matfuncs.pyi
@@ -63,15 +63,13 @@ UPPER_TRIANGULAR: Final[_Structure] = "upper_triangular"
 class MatrixPowerOperator(LinearOperator[_SCT_co], Generic[_SCT_co]):
     @property
     @override
-    # pyrefly: ignore [bad-override]
-    def T(self, /) -> Self: ...  # type: ignore[override]  # pyright: ignore[reportIncompatibleMethodOverride]
+    def T(self, /) -> Self: ...  # type:ignore[override] # pyright:ignore[reportIncompatibleMethodOverride] # pyrefly:ignore[bad-override]
     def __init__(self, /, A: onp.Array2D[_SCT_co] | _spbase, p: int, structure: _Structure | None = None) -> None: ...
 
 class ProductOperator(LinearOperator[_SCT_co], Generic[_SCT_co]):
     @property
     @override
-    # pyrefly: ignore [bad-override]
-    def T(self, /) -> Self: ...  # type: ignore[override]  # pyright: ignore[reportIncompatibleMethodOverride]
+    def T(self, /) -> Self: ...  # type:ignore[override] # pyright:ignore[reportIncompatibleMethodOverride] # pyrefly:ignore[bad-override]
     def __init__(self, /, *args: onp.Array2D[_SCT_co] | _spbase, structure: _Structure | None = None) -> None: ...
 
 #
@@ -116,8 +114,16 @@ def expm(A: csc_matrix[_SubF]) -> csc_matrix[np.float64]: ...
 
 #
 @overload
-def matrix_power[ScalarT: npc.number | np.bool](A: _ToCSRArray[ScalarT], power: SupportsIndex) -> csr_array[ScalarT]: ...
+def matrix_power[ScalarT: npc.number | np.bool](A: _CS[ScalarT] | _NonCS[ScalarT], power: Literal[0]) -> dia_array[ScalarT]: ...
 @overload
-def matrix_power[ScalarT: npc.number | np.bool](A: _ToCSRMatrix[ScalarT], power: SupportsIndex) -> csr_matrix[ScalarT]: ...
+def matrix_power[SparseT: _CS[npc.number | np.bool] | _NonCS[npc.number | np.bool]](A: SparseT, power: Literal[1]) -> SparseT: ...  # type:ignore[overload-overlap]
+@overload
+def matrix_power[ScalarT: npc.number | np.bool](A: _ToCSRArray[ScalarT], power: Literal[2, 3, 4, 5]) -> csr_array[ScalarT]: ...
+@overload
+def matrix_power[ScalarT: npc.number | np.bool](A: _ToCSRArray[ScalarT], power: SupportsIndex) -> csr_array[ScalarT] | Any: ...
+@overload
+def matrix_power[ScalarT: npc.number | np.bool](A: _ToCSRMatrix[ScalarT], power: Literal[2, 3, 4, 5]) -> csr_matrix[ScalarT]: ...
+@overload
+def matrix_power[ScalarT: npc.number | np.bool](A: _ToCSRMatrix[ScalarT], power: SupportsIndex) -> csr_matrix[ScalarT] | Any: ...
 @overload
 def matrix_power[SparseT: _ToSelf[npc.number | np.bool]](A: SparseT, power: SupportsIndex) -> SparseT: ...

--- a/tests/sparse/linalg/test__matfuncs.pyi
+++ b/tests/sparse/linalg/test__matfuncs.pyi
@@ -127,6 +127,18 @@ assert_type(expm(_m_lil_f32), csr_matrix[np.float32])
 ###
 # matrix_power
 
+assert_type(matrix_power(_a_csr_i16, 0), dia_array[np.int16])
+assert_type(matrix_power(_m_csr_i16, 0), dia_array[np.int16])
+assert_type(matrix_power(_a_dia_i16, 0), dia_array[np.int16])
+
+assert_type(matrix_power(_a_bsr_i16, 1), bsr_array[np.int16])
+assert_type(matrix_power(_a_csc_i16, 1), csc_array[np.int16])
+assert_type(matrix_power(_a_csr_i16, 1), csr_array[np.int16])
+assert_type(matrix_power(_a_dia_i16, 1), dia_array[np.int16])
+assert_type(matrix_power(_a_dok_i16, 1), dok_array[np.int16])
+assert_type(matrix_power(_a_lil_i16, 1), lil_array[np.int16])
+assert_type(matrix_power(_m_csr_i16, 1), csr_matrix[np.int16])
+
 assert_type(matrix_power(_a_bsr_i16, 3), bsr_array[np.int16])
 assert_type(matrix_power(_a_csc_i16, 3), csc_array[np.int16])
 assert_type(matrix_power(_a_csr_i16, 3), csr_array[np.int16])


### PR DESCRIPTION
This required some literal juggling to partially work around the resulting overlapping overloads.