### PR TITLE
✨ `sparse.linalg.LaplacianNd.tosparse`: improved return type

### DIFF
--- a/scipy-stubs/sparse/linalg/_special_sparse_arrays.pyi
+++ b/scipy-stubs/sparse/linalg/_special_sparse_arrays.pyi
@@ -6,23 +6,12 @@ import numpy.typing as npt
 import optype.numpy as onp
 import optype.numpy.compat as npc
 
-from scipy.sparse import bsr_array, coo_array, csc_array, csr_array, dia_array, dok_array, lil_array
+from scipy.sparse import csr_array, dia_array
 from scipy.sparse.linalg import LinearOperator
 
 __all__ = ["LaplacianNd"]
 
 ###
-
-# because `scipy.sparse.sparray` does not implement anything :(
-type _SpArray[ScalarT: npc.integer | npc.floating] = (
-    bsr_array[ScalarT]
-    | coo_array[ScalarT]
-    | csc_array[ScalarT]
-    | csr_array[ScalarT]
-    | dia_array[ScalarT]
-    | dok_array[ScalarT]
-    | lil_array[ScalarT]
-)
 
 type _BCs = Literal["dirichlet", "neumann", "periodic"]
 
@@ -61,4 +50,4 @@ class LaplacianNd(LinearOperator[_SCT], Generic[_SCT]):
     def eigenvalues(self, /, m: onp.ToJustInt | None = None) -> onp.Array1D[np.float64]: ...
     def eigenvectors(self, /, m: onp.ToJustInt | None = None) -> onp.Array2D[np.float64]: ...
     def toarray(self, /) -> onp.Array2D[_SCT]: ...
-    def tosparse(self, /) -> _SpArray[_SCT]: ...
+    def tosparse(self, /) -> dia_array[_SCT] | csr_array[_SCT]: ...

--- a/tests/sparse/linalg/test__special_sparse_arrays.pyi
+++ b/tests/sparse/linalg/test__special_sparse_arrays.pyi
@@ -3,6 +3,7 @@ from typing import Any, assert_type
 import numpy as np
 import optype.numpy as onp
 
+from scipy.sparse import csr_array, dia_array
 from scipy.sparse.linalg import LaplacianNd
 
 gs: tuple[int, int]
@@ -21,3 +22,4 @@ lap: LaplacianNd[np.float64]
 assert_type(lap.eigenvalues(), onp.Array1D[np.float64])
 assert_type(lap.eigenvectors(), onp.Array2D[np.float64])
 assert_type(lap.toarray(), onp.Array2D[np.float64])
+assert_type(lap.tosparse(), dia_array[np.float64] | csr_array[np.float64])


### PR DESCRIPTION
Most of the union variants weren't necessary