### PR TITLE
🐛 `stats`: add missing `rv_frozen.expect` parameters

### DIFF
--- a/scipy-stubs/stats/_distn_infrastructure.pyi
+++ b/scipy-stubs/stats/_distn_infrastructure.pyi
@@ -253,6 +253,21 @@ class rv_discrete_frozen(rv_frozen[_DRVT_co, _FloatNDT_co], Generic[_DRVT_co, _F
         self, /, size: AnyShape | None = None, random_state: onp.random.ToRNG | None = None
     ) -> onp.ArrayND[np.int64] | Any: ...
 
+    #
+    @override
+    def expect(
+        self: rv_discrete_frozen[_DRVT_co, _Float],
+        /,
+        func: Callable[[onp.Array1D[np.int_]], onp.ToFloatND] | None = None,
+        lb: onp.ToInt | None = None,
+        ub: onp.ToInt | None = None,
+        conditional: _Bool = False,
+        *,
+        maxcount: onp.ToInt = 1000,
+        tolerance: onp.ToFloat = 1e-10,
+        chunksize: onp.ToInt = 32,
+    ) -> _Float: ...
+
 # NOTE: Because of the limitations of `ParamSpec`, there is no proper way to annotate specific "positional or keyword arguments".
 # Considering the Liskov Substitution Principle, the only remaining option is to annotate `*args, and `**kwargs` as `Any`.
 class rv_generic:

--- a/tests/stats/test_discrete_distns.pyi
+++ b/tests/stats/test_discrete_distns.pyi
@@ -63,3 +63,13 @@ assert_type(poisson.rvs(1.0), int)
 assert_type(poisson.rvs(1.0, size=None), int)
 assert_type(poisson.rvs(1.0, size=()), int)
 assert_type(poisson.rvs(1.0, size=4), onp.ArrayND[np.int64])
+
+# .expect
+
+_frozen = poisson(1.0)
+assert_type(_frozen.expect(), float | np.float64)
+assert_type(_frozen.expect(lambda k: k), float | np.float64)
+assert_type(_frozen.expect(lambda k: k, lb=0, ub=5, conditional=True), float | np.float64)
+assert_type(_frozen.expect(lambda k: k, maxcount=2000), float | np.float64)
+assert_type(_frozen.expect(lambda k: k, tolerance=1e-8), float | np.float64)
+assert_type(_frozen.expect(lambda k: k, chunksize=64), float | np.float64)


### PR DESCRIPTION
that is `maxcount`, `tolerance`, and `chunksize`