### PR TITLE
🐛 `special.ellip_*`: accept array-like input

### DIFF
--- a/scipy-stubs/special/_ellip_harm.pyi
+++ b/scipy-stubs/special/_ellip_harm.pyi
@@ -1,8 +1,10 @@
-from typing import Literal
+from typing import Literal, overload
 
 import numpy as np
 import optype.numpy as onp
 
+#
+@overload  # 0d
 def ellip_harm(
     h2: onp.ToFloat,
     k2: onp.ToFloat,
@@ -12,5 +14,76 @@ def ellip_harm(
     signm: Literal[-1, 1] = 1,
     signn: Literal[-1, 1] = 1,
 ) -> np.float64: ...
+@overload  # Nd h2
+def ellip_harm(
+    h2: onp.ToFloatND,
+    k2: onp.ToFloat | onp.ToFloatND,
+    n: onp.ToInt | onp.ToIntND,
+    p: onp.ToFloat | onp.ToFloatND,
+    s: onp.ToFloat | onp.ToFloatND,
+    signm: Literal[-1, 1] = 1,
+    signn: Literal[-1, 1] = 1,
+) -> onp.ArrayND[np.float64]: ...
+@overload  # Nd k2
+def ellip_harm(
+    h2: onp.ToFloat | onp.ToFloatND,
+    k2: onp.ToFloatND,
+    n: onp.ToInt | onp.ToIntND,
+    p: onp.ToFloat | onp.ToFloatND,
+    s: onp.ToFloat | onp.ToFloatND,
+    signm: Literal[-1, 1] = 1,
+    signn: Literal[-1, 1] = 1,
+) -> onp.ArrayND[np.float64]: ...
+@overload  # Nd n
+def ellip_harm(
+    h2: onp.ToFloat | onp.ToFloatND,
+    k2: onp.ToFloat | onp.ToFloatND,
+    n: onp.ToIntND,
+    p: onp.ToFloat | onp.ToFloatND,
+    s: onp.ToFloat | onp.ToFloatND,
+    signm: Literal[-1, 1] = 1,
+    signn: Literal[-1, 1] = 1,
+) -> onp.ArrayND[np.float64]: ...
+@overload  # Nd p
+def ellip_harm(
+    h2: onp.ToFloat | onp.ToFloatND,
+    k2: onp.ToFloat | onp.ToFloatND,
+    n: onp.ToInt | onp.ToIntND,
+    p: onp.ToFloatND,
+    s: onp.ToFloat | onp.ToFloatND,
+    signm: Literal[-1, 1] = 1,
+    signn: Literal[-1, 1] = 1,
+) -> onp.ArrayND[np.float64]: ...
+@overload  # Nd s
+def ellip_harm(
+    h2: onp.ToFloat | onp.ToFloatND,
+    k2: onp.ToFloat | onp.ToFloatND,
+    n: onp.ToInt | onp.ToIntND,
+    p: onp.ToFloat | onp.ToFloatND,
+    s: onp.ToFloatND,
+    signm: Literal[-1, 1] = 1,
+    signn: Literal[-1, 1] = 1,
+) -> onp.ArrayND[np.float64]: ...
+
+#
+@overload  # 0d
 def ellip_harm_2(h2: onp.ToFloat, k2: onp.ToFloat, n: onp.ToInt, p: onp.ToInt, s: onp.ToFloat) -> onp.Array0D[np.float64]: ...
+@overload  # Nd
+def ellip_harm_2(
+    h2: onp.ToFloat | onp.ToFloatND,
+    k2: onp.ToFloat | onp.ToFloatND,
+    n: onp.ToInt | onp.ToIntND,
+    p: onp.ToInt | onp.ToIntND,
+    s: onp.ToFloat | onp.ToFloatND,
+) -> onp.ArrayND[np.float64]: ...
+
+#
+@overload  # 0d
 def ellip_normal(h2: onp.ToFloat, k2: onp.ToFloat, n: onp.ToFloat, p: onp.ToFloat) -> onp.Array0D[np.float64]: ...
+@overload  # Nd
+def ellip_normal(
+    h2: onp.ToFloat | onp.ToFloatND,
+    k2: onp.ToFloat | onp.ToFloatND,
+    n: onp.ToFloat | onp.ToFloatND,
+    p: onp.ToFloat | onp.ToFloatND,
+) -> onp.ArrayND[np.float64]: ...

--- a/tests/special/test_ellip_harm.pyi
+++ b/tests/special/test_ellip_harm.pyi
@@ -5,9 +5,24 @@ import optype.numpy as onp
 
 from scipy.special import ellip_harm, ellip_harm_2, ellip_normal
 
+###
+
+_i64_1d: onp.Array1D[np.int64]
+_f64_1d: onp.Array1D[np.float64]
+
+###
+
 assert_type(ellip_harm(2.0, 3.0, 3, 4.0, 6), np.float64)
-assert_type(ellip_harm(np.float32(2.0), np.float32(3.0), np.uint8(3), np.float32(4.0), np.float32(6.0)), np.float64)
-assert_type(ellip_harm(2.0, 3.0, 3, 4.0, 6, signm=1), np.float64)
-assert_type(ellip_harm(2.0, 3.0, 3, 4.0, 6, signm=1, signn=-1), np.float64)
+assert_type(ellip_harm(_f64_1d, 3.0, 3, 4.0, 6), onp.ArrayND[np.float64])
+assert_type(ellip_harm(2.0, _f64_1d, 3, 4.0, 6), onp.ArrayND[np.float64])
+assert_type(ellip_harm(2.0, 3.0, _i64_1d, 4.0, 6), onp.ArrayND[np.float64])
+assert_type(ellip_harm(2.0, 3.0, 3, _f64_1d, 6), onp.ArrayND[np.float64])
+assert_type(ellip_harm(2.0, 3.0, 3, 4.0, _f64_1d), onp.ArrayND[np.float64])
+
+#
 assert_type(ellip_harm_2(2.0, 3.0, 3, 4, 6.0), onp.Array0D[np.float64])
+assert_type(ellip_harm_2(2.0, 3.0, 3, 4, _f64_1d), onp.ArrayND[np.float64])
+
+#
 assert_type(ellip_normal(2.0, 3.0, 3, 4), onp.Array0D[np.float64])
+assert_type(ellip_normal(2.0, 3.0, _f64_1d, 4), onp.ArrayND[np.float64])


### PR DESCRIPTION
Previously, `ellip_harm`, `ellip_harm_2`, and `ellip_normal`, only accepted scalar input.