### PR TITLE
🐛 `stats`: propagate float32 dtypes in the hypothesis test functions

### DIFF
--- a/scipy-stubs/stats/_morestats.pyi
+++ b/scipy-stubs/stats/_morestats.pyi
@@ -67,7 +67,7 @@ __all__ = [
 _NDT_co = TypeVar(
     "_NDT_co",
     covariant=True,
-    bound=np.float64 | onp.ArrayND[np.float64],
+    bound=npc.floating | onp.ArrayND[npc.floating],
     default=np.float64 | onp.ArrayND[np.float64],
 )  # fmt: skip
 
@@ -76,9 +76,15 @@ _LengthT_co = TypeVar(
     "_LengthT_co", bound=npc.floating | onp.ArrayND[npc.floating], default=onp.ArrayND[np.float64 | Any], covariant=True
 )
 
+type _AsF64 = float | npc.floating64 | onp.ToInt
+type _AsF64_1D = onp.ToArrayStrict1D[float, npc.floating64 | npc.integer | np.bool]
+type _AsF64_2D = onp.ToArrayStrict2D[float, npc.floating64 | npc.integer | np.bool]
+type _AsF64_ND = onp.ToArrayND[float, npc.floating64 | npc.integer | np.bool]
+
 type _JustAnyShape = tuple[Never, Never, Never, Never]  # workaround for https://github.com/microsoft/pyright/issues/10232
 type _Tuple2[T] = tuple[T, T]
 type _Tuple3[T] = tuple[T, T, T]
+
 type _Float1D = onp.Array1D[np.float64]
 
 type _KStatOrder = Literal[1, 2, 3, 4]
@@ -260,23 +266,19 @@ class WilcoxonResult(BaseBunch[_NDT_co, _NDT_co], Generic[_NDT_co]):  # pyright:
     @override
     def __init__(self, /, statistic: _NDT_co, pvalue: _NDT_co) -> None: ...  # pyrefly:ignore[bad-override]
 
-class MedianTestResult(BaseBunch[np.float64, np.float64, np.float64, onp.Array2D[np.float64]]):
+class MedianTestResult[MedianT: npc.floating](BaseBunch[np.float64, np.float64, MedianT, onp.Array2D[np.float64]]):
     @property
     def statistic(self, /) -> np.float64: ...
     @property
     def pvalue(self, /) -> np.float64: ...
     @property
-    def median(self, /) -> np.float64: ...
+    def median(self, /) -> MedianT: ...
     @property
     def table(self, /) -> onp.Array2D[np.int_]: ...
 
     #
-    @override
-    def __new__(_cls, statistic: np.float64, pvalue: np.float64, median: np.float64, table: onp.Array2D[np.float64]) -> Self: ...  # pyrefly:ignore[bad-override]
-    @override
-    def __init__(  # pyrefly:ignore[bad-override]
-        self, /, statistic: np.float64, pvalue: np.float64, median: np.float64, table: onp.Array2D[np.float64]
-    ) -> None: ...
+    def __new__(_cls, statistic: np.float64, pvalue: np.float64, median: MedianT, table: onp.Array2D[np.float64]) -> Self: ...
+    def __init__(self, /, statistic: np.float64, pvalue: np.float64, median: MedianT, table: onp.Array2D[np.float64]) -> None: ...
 
 def bayes_mvs(data: onp.ToFloatND, alpha: onp.ToFloat = 0.9) -> tuple[Mean, Variance, Std_dev]: ...
 
@@ -297,25 +299,43 @@ def mvsdist(
 ): ...
 
 #
-@overload
+@overload  # T:f32|f64, axis=None (default)
+def kstat[FloatT: np.float32 | np.float64](
+    data: onp.ArrayND[FloatT],
+    n: _KStatOrder = 2,
+    *,
+    axis: None = None,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: Literal[False] = False,
+) -> FloatT: ...
+@overload  # T:f32|f64, keepdims=True
+def kstat[FloatT: np.float32 | np.float64](
+    data: onp.ArrayND[FloatT],
+    n: _KStatOrder = 2,
+    *,
+    axis: SupportsIndex | None = None,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: Literal[True],
+) -> onp.ArrayND[FloatT]: ...
+@overload  # ~f64, axis=None (default)
 def kstat(
-    data: onp.ToFloatND,
+    data: _AsF64_ND,
     n: _KStatOrder = 2,
     *,
     axis: None = None,
     nan_policy: NanPolicy = "propagate",
     keepdims: Literal[False] = False,
 ) -> np.float64: ...
-@overload
+@overload  # ~f64, keepdims=True
 def kstat(
-    data: onp.ToFloatND,
+    data: _AsF64_ND,
     n: _KStatOrder = 2,
     *,
     axis: SupportsIndex | None = None,
     nan_policy: NanPolicy = "propagate",
     keepdims: Literal[True],
 ) -> onp.ArrayND[np.float64]: ...
-@overload
+@overload  # fallback
 def kstat(
     data: onp.ToFloatND,
     n: _KStatOrder = 2,
@@ -323,28 +343,46 @@ def kstat(
     axis: SupportsIndex | None = None,
     nan_policy: NanPolicy = "propagate",
     keepdims: bool = False,
-) -> np.float64 | onp.ArrayND[np.float64]: ...
+) -> np.float64 | onp.ArrayND[np.float64] | Any: ...
 
 #
-@overload
+@overload  # T:f32|f64, axis=None (default)
+def kstatvar[FloatT: np.float32 | np.float64](
+    data: onp.ArrayND[FloatT],
+    n: _KStatOrder = 2,
+    *,
+    axis: None = None,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: Literal[False] = False,
+) -> FloatT: ...
+@overload  # T:f32|f64, keepdims=True
+def kstatvar[FloatT: np.float32 | np.float64](
+    data: onp.ArrayND[FloatT],
+    n: _KStatOrder = 2,
+    *,
+    axis: SupportsIndex | None = None,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: Literal[True],
+) -> onp.ArrayND[FloatT]: ...
+@overload  # ~f64, axis=None (default)
 def kstatvar(
-    data: onp.ToFloatND,
+    data: _AsF64_ND,
     n: _KStatOrder = 2,
     *,
     axis: None = None,
     nan_policy: NanPolicy = "propagate",
     keepdims: Literal[False] = False,
 ) -> np.float64: ...
-@overload
+@overload  # ~f64, keepdims=True
 def kstatvar(
-    data: onp.ToFloatND,
+    data: _AsF64_ND,
     n: _KStatOrder = 2,
     *,
     axis: SupportsIndex | None = None,
     nan_policy: NanPolicy = "propagate",
     keepdims: Literal[True],
 ) -> onp.ArrayND[np.float64]: ...
-@overload
+@overload  # fallback
 def kstatvar(
     data: onp.ToFloatND,
     n: _KStatOrder = 2,
@@ -352,7 +390,7 @@ def kstatvar(
     axis: SupportsIndex | None = None,
     nan_policy: NanPolicy = "propagate",
     keepdims: bool = False,
-) -> np.float64 | onp.ArrayND[np.float64]: ...
+) -> np.float64 | onp.ArrayND[np.float64] | Any: ...
 
 #
 @overload
@@ -831,32 +869,32 @@ def anderson_ksamp(
 ) -> Anderson_ksampResult: ...
 
 #
-@overload
+@overload  # T:f32|f64, axis=None (default)
+def shapiro[FloatT: np.float32 | np.float64](
+    x: onp.ArrayND[FloatT], *, axis: None = None, nan_policy: NanPolicy = "propagate", keepdims: Literal[False] = False
+) -> ShapiroResult[FloatT]: ...
+@overload  # T:f32|f64, keepdims=True
+def shapiro[FloatT: np.float32 | np.float64](
+    x: onp.ArrayND[FloatT], *, axis: SupportsIndex | None = None, nan_policy: NanPolicy = "propagate", keepdims: Literal[True]
+) -> ShapiroResult[onp.ArrayND[FloatT]]: ...
+@overload  # ~f64, axis=None (default)
 def shapiro(
-    x: onp.ToFloat | onp.ToFloatND, *, axis: None = None, nan_policy: NanPolicy = "propagate", keepdims: Literal[False] = False
+    x: _AsF64_ND, *, axis: None = None, nan_policy: NanPolicy = "propagate", keepdims: Literal[False] = False
 ) -> ShapiroResult[np.float64]: ...
-@overload
+@overload  # ~f64, keepdims=True
 def shapiro(
-    x: onp.ToFloat | onp.ToFloatND,
-    *,
-    axis: SupportsIndex | None = None,
-    nan_policy: NanPolicy = "propagate",
-    keepdims: Literal[True],
+    x: _AsF64_ND, *, axis: SupportsIndex | None = None, nan_policy: NanPolicy = "propagate", keepdims: Literal[True]
 ) -> ShapiroResult[onp.ArrayND[np.float64]]: ...
-@overload
+@overload  # fallback
 def shapiro(
-    x: onp.ToFloat | onp.ToFloatND,
-    *,
-    axis: SupportsIndex | None = None,
-    nan_policy: NanPolicy = "propagate",
-    keepdims: bool = False,
-) -> ShapiroResult: ...
+    x: onp.ToFloatND, *, axis: SupportsIndex | None = None, nan_policy: NanPolicy = "propagate", keepdims: bool = False
+) -> ShapiroResult[np.float64 | onp.ArrayND[np.float64] | Any]: ...
 
 #
-@overload
+@overload  # ~f64, axis=None
 def ansari(
-    x: onp.ToFloat | onp.ToFloatND,
-    y: onp.ToFloat | onp.ToFloatND,
+    x: _AsF64 | _AsF64_ND,
+    y: _AsF64 | _AsF64_ND,
     alternative: Alternative = "two-sided",
     *,
     axis: None,
@@ -864,10 +902,10 @@ def ansari(
     nan_policy: NanPolicy = "propagate",
     keepdims: Literal[False] = False,
 ) -> AnsariResult[np.float64]: ...
-@overload
+@overload  # ~f64, keepdims=True
 def ansari(
-    x: onp.ToFloat | onp.ToFloatND,
-    y: onp.ToFloat | onp.ToFloatND,
+    x: _AsF64 | _AsF64_ND,
+    y: _AsF64 | _AsF64_ND,
     alternative: Alternative = "two-sided",
     *,
     axis: SupportsIndex | None = 0,
@@ -875,7 +913,29 @@ def ansari(
     nan_policy: NanPolicy = "propagate",
     keepdims: Literal[True],
 ) -> AnsariResult[onp.ArrayND[np.float64]]: ...
-@overload
+@overload  # ~f32, axis=None
+def ansari(
+    x: onp.ToJustFloat32_ND,
+    y: onp.ToJustFloat32_ND,
+    alternative: Alternative = "two-sided",
+    *,
+    axis: None,
+    method: _AnsariMethod = "auto",
+    nan_policy: NanPolicy = "propagate",
+    keepdims: Literal[False] = False,
+) -> AnsariResult[np.float32]: ...
+@overload  # ~f32, keepdims=True
+def ansari(
+    x: onp.ToJustFloat32_ND,
+    y: onp.ToJustFloat32_ND,
+    alternative: Alternative = "two-sided",
+    *,
+    axis: SupportsIndex | None = 0,
+    method: _AnsariMethod = "auto",
+    nan_policy: NanPolicy = "propagate",
+    keepdims: Literal[True],
+) -> AnsariResult[onp.ArrayND[np.float32]]: ...
+@overload  # fallback
 def ansari(
     x: onp.ToFloat | onp.ToFloatND,
     y: onp.ToFloat | onp.ToFloatND,
@@ -885,42 +945,68 @@ def ansari(
     method: _AnsariMethod = "auto",
     nan_policy: NanPolicy = "propagate",
     keepdims: bool = False,
-) -> AnsariResult: ...
+) -> AnsariResult[np.float64 | onp.ArrayND[np.float64] | Any]: ...
 
 #
-@overload
+@overload  # ~f64, axis=None
 def bartlett(
-    *samples: onp.ToFloatND, axis: None, nan_policy: NanPolicy = "propagate", keepdims: Literal[False] = False
+    *samples: _AsF64_ND, axis: None, nan_policy: NanPolicy = "propagate", keepdims: Literal[False] = False
 ) -> BartlettResult[np.float64]: ...
-@overload
+@overload  # ~f64, keepdims=True
 def bartlett(
-    *samples: onp.ToFloatND, axis: SupportsIndex | None = 0, nan_policy: NanPolicy = "propagate", keepdims: Literal[True]
+    *samples: _AsF64_ND, axis: SupportsIndex | None = 0, nan_policy: NanPolicy = "propagate", keepdims: Literal[True]
 ) -> BartlettResult[onp.ArrayND[np.float64]]: ...
-@overload
+@overload  # ~f32, axis=None
+def bartlett(
+    *samples: onp.ToJustFloat32_ND, axis: None, nan_policy: NanPolicy = "propagate", keepdims: Literal[False] = False
+) -> BartlettResult[np.float32]: ...
+@overload  # ~f32, keepdims=True
+def bartlett(
+    *samples: onp.ToJustFloat32_ND, axis: SupportsIndex | None = 0, nan_policy: NanPolicy = "propagate", keepdims: Literal[True]
+) -> BartlettResult[onp.ArrayND[np.float32]]: ...
+@overload  # fallback
 def bartlett(
     *samples: onp.ToFloatND, axis: SupportsIndex | None = 0, nan_policy: NanPolicy = "propagate", keepdims: bool = False
-) -> BartlettResult: ...
+) -> BartlettResult[np.float64 | onp.ArrayND[np.float64] | Any]: ...
 
 #
-@overload
+@overload  # ~f64, axis=None
 def levene(
-    *samples: onp.ToFloatND,
+    *samples: _AsF64_ND,
     center: _CenterMethod = "median",
     proportiontocut: onp.ToFloat = 0.05,
     axis: None,
     nan_policy: NanPolicy = "propagate",
     keepdims: Literal[False] = False,
 ) -> LeveneResult[np.float64]: ...
-@overload
+@overload  # ~f64, keepdims=True
 def levene(
-    *samples: onp.ToFloatND,
+    *samples: _AsF64_ND,
     center: _CenterMethod = "median",
     proportiontocut: onp.ToFloat = 0.05,
     axis: SupportsIndex | None = 0,
     nan_policy: NanPolicy = "propagate",
     keepdims: Literal[True],
 ) -> LeveneResult[onp.ArrayND[np.float64]]: ...
-@overload
+@overload  # ~f32, axis=None
+def levene(
+    *samples: onp.ToJustFloat32_ND,
+    center: _CenterMethod = "median",
+    proportiontocut: onp.ToFloat = 0.05,
+    axis: None,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: Literal[False] = False,
+) -> LeveneResult[np.float32]: ...
+@overload  # ~f32, keepdims=True
+def levene(
+    *samples: onp.ToJustFloat32_ND,
+    center: _CenterMethod = "median",
+    proportiontocut: onp.ToFloat = 0.05,
+    axis: SupportsIndex | None = 0,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: Literal[True],
+) -> LeveneResult[onp.ArrayND[np.float32]]: ...
+@overload  # fallback
 def levene(
     *samples: onp.ToFloatND,
     center: _CenterMethod = "median",
@@ -928,28 +1014,46 @@ def levene(
     axis: SupportsIndex | None = 0,
     nan_policy: NanPolicy = "propagate",
     keepdims: bool = False,
-) -> LeveneResult: ...
+) -> LeveneResult[np.float64 | onp.ArrayND[np.float64] | Any]: ...
 
 #
-@overload
+@overload  # ~f64, axis=None
 def fligner(
-    *samples: onp.ToFloatND,
+    *samples: _AsF64_ND,
     center: _CenterMethod = "median",
     proportiontocut: onp.ToFloat = 0.05,
     axis: None,
     nan_policy: NanPolicy = "propagate",
     keepdims: Literal[False] = False,
 ) -> FlignerResult[np.float64]: ...
-@overload
+@overload  # ~f64, keepdims=True
 def fligner(
-    *samples: onp.ToFloatND,
+    *samples: _AsF64_ND,
     center: _CenterMethod = "median",
     proportiontocut: onp.ToFloat = 0.05,
     axis: SupportsIndex | None = 0,
     nan_policy: NanPolicy = "propagate",
     keepdims: Literal[True],
 ) -> FlignerResult[onp.ArrayND[np.float64]]: ...
-@overload
+@overload  # ~f32, axis=None
+def fligner(
+    *samples: onp.ToJustFloat32_ND,
+    center: _CenterMethod = "median",
+    proportiontocut: onp.ToFloat = 0.05,
+    axis: None,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: Literal[False] = False,
+) -> FlignerResult[np.float32]: ...
+@overload  # ~f32, keepdims=True
+def fligner(
+    *samples: onp.ToJustFloat32_ND,
+    center: _CenterMethod = "median",
+    proportiontocut: onp.ToFloat = 0.05,
+    axis: SupportsIndex | None = 0,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: Literal[True],
+) -> FlignerResult[onp.ArrayND[np.float32]]: ...
+@overload  # fallback
 def fligner(
     *samples: onp.ToFloatND,
     center: _CenterMethod = "median",
@@ -957,30 +1061,50 @@ def fligner(
     axis: SupportsIndex | None = 0,
     nan_policy: NanPolicy = "propagate",
     keepdims: bool = False,
-) -> FlignerResult: ...
+) -> FlignerResult[np.float64 | onp.ArrayND[np.float64] | Any]: ...
 
 #
-@overload
+@overload  # ~f64, axis=None
 def mood(
-    x: onp.ToFloat | onp.ToFloatND,
-    y: onp.ToFloat | onp.ToFloatND,
+    x: _AsF64 | _AsF64_ND,
+    y: _AsF64 | _AsF64_ND,
     axis: None,
     alternative: Alternative = "two-sided",
     *,
     nan_policy: NanPolicy = "propagate",
     keepdims: Literal[False] = False,
 ) -> SignificanceResult[np.float64]: ...
-@overload
+@overload  # ~f64, keepdims=True
 def mood(
-    x: onp.ToFloat | onp.ToFloatND,
-    y: onp.ToFloat | onp.ToFloatND,
+    x: _AsF64 | _AsF64_ND,
+    y: _AsF64 | _AsF64_ND,
     axis: SupportsIndex | None = 0,
     alternative: Alternative = "two-sided",
     *,
     nan_policy: NanPolicy = "propagate",
     keepdims: Literal[True],
 ) -> SignificanceResult[onp.ArrayND[np.float64]]: ...
-@overload
+@overload  # ~f32, axis=None
+def mood(
+    x: onp.ToJustFloat32_ND,
+    y: onp.ToJustFloat32_ND,
+    axis: None,
+    alternative: Alternative = "two-sided",
+    *,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: Literal[False] = False,
+) -> SignificanceResult[np.float32]: ...
+@overload  # ~f32, keepdims=True
+def mood(
+    x: onp.ToJustFloat32_ND,
+    y: onp.ToJustFloat32_ND,
+    axis: SupportsIndex | None = 0,
+    alternative: Alternative = "two-sided",
+    *,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: Literal[True],
+) -> SignificanceResult[onp.ArrayND[np.float32]]: ...
+@overload  # fallback
 def mood(
     x: onp.ToFloat | onp.ToFloatND,
     y: onp.ToFloat | onp.ToFloatND,
@@ -989,13 +1113,13 @@ def mood(
     *,
     nan_policy: NanPolicy = "propagate",
     keepdims: bool = False,
-) -> SignificanceResult[np.float64 | onp.ArrayND[np.float64]]: ...
+) -> SignificanceResult[np.float64 | onp.ArrayND[np.float64] | Any]: ...
 
 #
-@overload  # ?d, axis=None
+@overload  # ?d ~f64, axis=None
 def wilcoxon(
-    x: onp.ToFloat | onp.ToFloatND,
-    y: onp.ToFloat | onp.ToFloatND | None = None,
+    x: _AsF64 | _AsF64_ND,
+    y: _AsF64 | _AsF64_ND | None = None,
     zero_method: _ZeroMethod = "wilcox",
     correction: bool = False,
     alternative: Alternative = "two-sided",
@@ -1005,10 +1129,10 @@ def wilcoxon(
     nan_policy: NanPolicy = "propagate",
     keepdims: Literal[False] = False,
 ) -> WilcoxonResult[np.float64]: ...
-@overload  # ?d, keepdims=True
+@overload  # ?d ~f64, keepdims=True
 def wilcoxon(
-    x: onp.ToFloat | onp.ToFloatND,
-    y: onp.ToFloat | onp.ToFloatND | None = None,
+    x: _AsF64 | _AsF64_ND,
+    y: _AsF64 | _AsF64_ND | None = None,
     zero_method: _ZeroMethod = "wilcox",
     correction: bool = False,
     alternative: Alternative = "two-sided",
@@ -1018,6 +1142,84 @@ def wilcoxon(
     nan_policy: NanPolicy = "propagate",
     keepdims: Literal[True],
 ) -> WilcoxonResult[onp.ArrayND[np.float64]]: ...
+@overload  # 1d ~f64
+def wilcoxon(
+    x: _AsF64_1D,
+    y: _AsF64_1D | None = None,
+    zero_method: _ZeroMethod = "wilcox",
+    correction: bool = False,
+    alternative: Alternative = "two-sided",
+    method: _WilcoxonMethod = "auto",
+    *,
+    axis: SupportsIndex | None = 0,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: Literal[False] = False,
+) -> WilcoxonResult[np.float64]: ...
+@overload  # 2d ~f64
+def wilcoxon(
+    x: _AsF64_2D,
+    y: _AsF64_2D | None = None,
+    zero_method: _ZeroMethod = "wilcox",
+    correction: bool = False,
+    alternative: Alternative = "two-sided",
+    method: _WilcoxonMethod = "auto",
+    *,
+    axis: SupportsIndex = 0,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: Literal[False] = False,
+) -> WilcoxonResult[onp.Array1D[np.float64]]: ...
+@overload  # ?d ~f32, axis=None
+def wilcoxon(
+    x: onp.ToJustFloat32_ND,
+    y: onp.ToJustFloat32_ND | None = None,
+    zero_method: _ZeroMethod = "wilcox",
+    correction: bool = False,
+    alternative: Alternative = "two-sided",
+    method: _WilcoxonMethod = "auto",
+    *,
+    axis: None,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: Literal[False] = False,
+) -> WilcoxonResult[np.float32]: ...
+@overload  # ?d ~f32, keepdims=True
+def wilcoxon(
+    x: onp.ToJustFloat32_ND,
+    y: onp.ToJustFloat32_ND | None = None,
+    zero_method: _ZeroMethod = "wilcox",
+    correction: bool = False,
+    alternative: Alternative = "two-sided",
+    method: _WilcoxonMethod = "auto",
+    *,
+    axis: SupportsIndex | None = 0,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: Literal[True],
+) -> WilcoxonResult[onp.ArrayND[np.float32]]: ...
+@overload  # 1d ~f32
+def wilcoxon(
+    x: onp.ToJustFloat32Strict1D,
+    y: onp.ToJustFloat32Strict1D | None = None,
+    zero_method: _ZeroMethod = "wilcox",
+    correction: bool = False,
+    alternative: Alternative = "two-sided",
+    method: _WilcoxonMethod = "auto",
+    *,
+    axis: SupportsIndex | None = 0,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: Literal[False] = False,
+) -> WilcoxonResult[np.float32]: ...
+@overload  # 2d ~f32
+def wilcoxon(
+    x: onp.ToJustFloat32Strict2D,
+    y: onp.ToJustFloat32Strict2D | None = None,
+    zero_method: _ZeroMethod = "wilcox",
+    correction: bool = False,
+    alternative: Alternative = "two-sided",
+    method: _WilcoxonMethod = "auto",
+    *,
+    axis: SupportsIndex = 0,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: Literal[False] = False,
+) -> WilcoxonResult[onp.Array1D[np.float32]]: ...
 @overload  # ?d
 def wilcoxon(
     x: onp.ArrayND[npc.floating | npc.integer, _JustAnyShape],
@@ -1030,33 +1232,7 @@ def wilcoxon(
     axis: SupportsIndex | None = 0,
     nan_policy: NanPolicy = "propagate",
     keepdims: Literal[False] = False,
-) -> WilcoxonResult: ...
-@overload  # 1d
-def wilcoxon(
-    x: onp.ToFloatStrict1D,
-    y: onp.ToFloatStrict1D | None = None,
-    zero_method: _ZeroMethod = "wilcox",
-    correction: bool = False,
-    alternative: Alternative = "two-sided",
-    method: _WilcoxonMethod = "auto",
-    *,
-    axis: SupportsIndex | None = 0,
-    nan_policy: NanPolicy = "propagate",
-    keepdims: Literal[False] = False,
-) -> WilcoxonResult[np.float64]: ...
-@overload  # 2d
-def wilcoxon(
-    x: onp.ToFloatStrict2D,
-    y: onp.ToFloatStrict2D | None = None,
-    zero_method: _ZeroMethod = "wilcox",
-    correction: bool = False,
-    alternative: Alternative = "two-sided",
-    method: _WilcoxonMethod = "auto",
-    *,
-    axis: SupportsIndex = 0,
-    nan_policy: NanPolicy = "propagate",
-    keepdims: Literal[False] = False,
-) -> WilcoxonResult[onp.Array1D[np.float64]]: ...
+) -> WilcoxonResult[np.float64 | onp.ArrayND[np.float64] | Any]: ...
 @overload  # fallback
 def wilcoxon(
     x: onp.ToFloat | onp.ToFloatND,
@@ -1069,7 +1245,7 @@ def wilcoxon(
     axis: SupportsIndex | None = 0,
     nan_policy: NanPolicy = "propagate",
     keepdims: bool = False,
-) -> WilcoxonResult: ...
+) -> WilcoxonResult[np.float64 | onp.ArrayND[np.float64] | Any]: ...
 
 #
 def wilcoxon_result_object(
@@ -1079,18 +1255,55 @@ def wilcoxon_result_unpacker(res: WilcoxonResult, _: int) -> _Tuple2[np.float64]
 def wilcoxon_outputs(kwds: dict[str, str]) -> Literal[2, 3]: ...  # undocumented
 
 #
+@overload  # ~f64
+def median_test(
+    *samples: _AsF64_ND,
+    ties: Literal["below", "above", "ignore"] = "below",
+    correction: bool = True,
+    lambda_: onp.ToFloat | str = 1,
+    nan_policy: NanPolicy = "propagate",
+) -> MedianTestResult[np.float64]: ...
+@overload  # ~f32
+def median_test(
+    *samples: onp.ToJustFloat32_ND,
+    ties: Literal["below", "above", "ignore"] = "below",
+    correction: bool = True,
+    lambda_: onp.ToFloat | str = 1,
+    nan_policy: NanPolicy = "propagate",
+) -> MedianTestResult[np.float32]: ...
+@overload  # fallback
 def median_test(
     *samples: onp.ToFloatND,
     ties: Literal["below", "above", "ignore"] = "below",
     correction: bool = True,
     lambda_: onp.ToFloat | str = 1,
     nan_policy: NanPolicy = "propagate",
-) -> MedianTestResult: ...
+) -> MedianTestResult[np.float64 | Any]: ...
 
 #
-@overload
+@overload  # T:f32|f64, axis=None (default)
+def circmean[FloatT: np.float32 | np.float64](
+    samples: onp.ArrayND[FloatT],
+    high: onp.ToFloat = 6.283_185_307_179_586,  # 2 * pi
+    low: onp.ToFloat = 0,
+    axis: None = None,
+    nan_policy: NanPolicy = "propagate",
+    *,
+    keepdims: Literal[False] = False,
+) -> FloatT: ...
+@overload  # T:f32|f64, keepdims=True
+def circmean[FloatT: np.float32 | np.float64](
+    samples: onp.ArrayND[FloatT],
+    high: onp.ToFloat = 6.283_185_307_179_586,  # 2 * pi
+    low: onp.ToFloat = 0,
+    axis: SupportsIndex | None = None,
+    nan_policy: NanPolicy = "propagate",
+    *,
+    keepdims: Literal[True],
+) -> onp.ArrayND[FloatT]: ...
+@overload  # ~f64, axis=None (default)
 def circmean(
-    samples: onp.ToFloatND,
+    samples: _AsF64_ND,
     high: onp.ToFloat = 6.283_185_307_179_586,  # 2 * pi
     low: onp.ToFloat = 0,
     axis: None = None,
@@ -1098,9 +1311,9 @@ def circmean(
     *,
     keepdims: Literal[False] = False,
 ) -> np.float64: ...
-@overload
+@overload  # ~f64, keepdims=True
 def circmean(
-    samples: onp.ToFloatND,
+    samples: _AsF64_ND,
     high: onp.ToFloat = 6.283_185_307_179_586,  # 2 * pi
     low: onp.ToFloat = 0,
     axis: SupportsIndex | None = None,
@@ -1108,7 +1321,7 @@ def circmean(
     *,
     keepdims: Literal[True],
 ) -> onp.ArrayND[np.float64]: ...
-@overload
+@overload  # fallback
 def circmean(
     samples: onp.ToFloatND,
     high: onp.ToFloat = 6.283_185_307_179_586,  # 2 * pi
@@ -1117,12 +1330,32 @@ def circmean(
     nan_policy: NanPolicy = "propagate",
     *,
     keepdims: bool = False,
-) -> np.float64 | onp.ArrayND[np.float64]: ...
+) -> np.float64 | onp.ArrayND[np.float64] | Any: ...
 
 #
-@overload
+@overload  # T:f32|f64, axis=None (default)
+def circvar[FloatT: np.float32 | np.float64](
+    samples: onp.ArrayND[FloatT],
+    high: onp.ToFloat = 6.283_185_307_179_586,  # 2 * pi
+    low: onp.ToFloat = 0,
+    axis: None = None,
+    nan_policy: NanPolicy = "propagate",
+    *,
+    keepdims: Literal[False] = False,
+) -> FloatT: ...
+@overload  # T:f32|f64, keepdims=True
+def circvar[FloatT: np.float32 | np.float64](
+    samples: onp.ArrayND[FloatT],
+    high: onp.ToFloat = 6.283_185_307_179_586,  # 2 * pi
+    low: onp.ToFloat = 0,
+    axis: SupportsIndex | None = None,
+    nan_policy: NanPolicy = "propagate",
+    *,
+    keepdims: Literal[True],
+) -> onp.ArrayND[FloatT]: ...
+@overload  # ~f64, axis=None (default)
 def circvar(
-    samples: onp.ToFloatND,
+    samples: _AsF64_ND,
     high: onp.ToFloat = 6.283_185_307_179_586,  # 2 * pi
     low: onp.ToFloat = 0,
     axis: None = None,
@@ -1130,9 +1363,9 @@ def circvar(
     *,
     keepdims: Literal[False] = False,
 ) -> np.float64: ...
-@overload
+@overload  # ~f64, keepdims=True
 def circvar(
-    samples: onp.ToFloatND,
+    samples: _AsF64_ND,
     high: onp.ToFloat = 6.283_185_307_179_586,  # 2 * pi
     low: onp.ToFloat = 0,
     axis: SupportsIndex | None = None,
@@ -1140,7 +1373,7 @@ def circvar(
     *,
     keepdims: Literal[True],
 ) -> onp.ArrayND[np.float64]: ...
-@overload
+@overload  # fallback
 def circvar(
     samples: onp.ToFloatND,
     high: onp.ToFloat = 6.283_185_307_179_586,  # 2 * pi
@@ -1149,12 +1382,34 @@ def circvar(
     nan_policy: NanPolicy = "propagate",
     *,
     keepdims: bool = False,
-) -> np.float64 | onp.ArrayND[np.float64]: ...
+) -> np.float64 | onp.ArrayND[np.float64] | Any: ...
 
 #
-@overload
+@overload  # T:f32|f64, axis=None (default)
+def circstd[FloatT: np.float32 | np.float64](
+    samples: onp.ArrayND[FloatT],
+    high: onp.ToFloat = 6.283_185_307_179_586,  # 2 * pi
+    low: onp.ToFloat = 0,
+    axis: None = None,
+    nan_policy: NanPolicy = "propagate",
+    *,
+    normalize: bool = False,
+    keepdims: Literal[False] = False,
+) -> FloatT: ...
+@overload  # T:f32|f64, keepdims=True
+def circstd[FloatT: np.float32 | np.float64](
+    samples: onp.ArrayND[FloatT],
+    high: onp.ToFloat = 6.283_185_307_179_586,  # 2 * pi
+    low: onp.ToFloat = 0,
+    axis: SupportsIndex | None = None,
+    nan_policy: NanPolicy = "propagate",
+    *,
+    normalize: bool = False,
+    keepdims: Literal[True],
+) -> onp.ArrayND[FloatT]: ...
+@overload  # ~f64, axis=None (default)
 def circstd(
-    samples: onp.ToFloatND,
+    samples: _AsF64_ND,
     high: onp.ToFloat = 6.283_185_307_179_586,  # 2 * pi
     low: onp.ToFloat = 0,
     axis: None = None,
@@ -1163,9 +1418,9 @@ def circstd(
     normalize: bool = False,
     keepdims: Literal[False] = False,
 ) -> np.float64: ...
-@overload
+@overload  # ~f64, keepdims=True
 def circstd(
-    samples: onp.ToFloatND,
+    samples: _AsF64_ND,
     high: onp.ToFloat = 6.283_185_307_179_586,  # 2 * pi
     low: onp.ToFloat = 0,
     axis: SupportsIndex | None = None,
@@ -1174,7 +1429,7 @@ def circstd(
     normalize: bool = False,
     keepdims: Literal[True],
 ) -> onp.ArrayND[np.float64]: ...
-@overload
+@overload  # fallback
 def circstd(
     samples: onp.ToFloatND,
     high: onp.ToFloat = 6.283_185_307_179_586,  # 2 * pi
@@ -1184,7 +1439,7 @@ def circstd(
     *,
     normalize: bool = False,
     keepdims: bool = False,
-) -> np.float64 | onp.ArrayND[np.float64]: ...
+) -> np.float64 | onp.ArrayND[np.float64] | Any: ...
 
 #
 @overload  # ?d +T@floating
@@ -1269,11 +1524,19 @@ def directional_stats(
 ) -> DirectionalStats[onp.ArrayND[np.clongdouble], np.longdouble | onp.ArrayND[np.longdouble]]: ...
 
 #
-@overload
+@overload  # 0d
 def false_discovery_control(
     ps: onp.ToFloat, *, axis: SupportsIndex | None = 0, method: Literal["bh", "by"] = "bh"
 ) -> np.float64: ...
-@overload
+@overload  # T:f32|f64
+def false_discovery_control[FloatT: np.float32 | np.float64](
+    ps: onp.ArrayND[FloatT], *, axis: SupportsIndex | None = 0, method: Literal["bh", "by"] = "bh"
+) -> onp.ArrayND[FloatT]: ...
+@overload  # ~f64
+def false_discovery_control(
+    ps: _AsF64_ND, *, axis: SupportsIndex | None = 0, method: Literal["bh", "by"] = "bh"
+) -> onp.ArrayND[np.float64]: ...
+@overload  # fallback
 def false_discovery_control(
     ps: onp.ToFloatND, *, axis: SupportsIndex | None = 0, method: Literal["bh", "by"] = "bh"
-) -> onp.ArrayND[np.float64]: ...
+) -> onp.ArrayND[np.float64] | Any: ...

--- a/scipy-stubs/stats/_stats_py.pyi
+++ b/scipy-stubs/stats/_stats_py.pyi
@@ -3577,128 +3577,227 @@ def trim_mean(
 ) -> onp.ArrayND[np.float64]: ...
 
 #
-@overload  # ?d, ?d|1d
+@overload  # ?d +f64, ?d|1d +f64
 def f_oneway(
-    sample1: _ToFloatStrictND,
-    sample2: _ToFloatStrictND | onp.ToFloatStrict1D,
+    sample1: _AsFloat64StrictND,
+    sample2: _AsFloat64StrictND | _AsFloat64_1D,
     /,
-    *samples: _ToFloatStrictND | onp.ToFloatStrict1D,
+    *samples: _AsFloat64StrictND | _AsFloat64_1D,
     equal_var: bool = True,
     axis: int = 0,
     nan_policy: NanPolicy = "propagate",
     keepdims: L[False] = False,
 ) -> F_onewayResult[np.float64 | Any]: ...
-@overload  # ?d|1d, ?d
+@overload  # ?d|1d +f64, ?d +f64
 def f_oneway(
-    sample1: _ToFloatStrictND | onp.ToFloatStrict1D,
-    sample2: _ToFloatStrictND,
+    sample1: _AsFloat64StrictND | _AsFloat64_1D,
+    sample2: _AsFloat64StrictND,
     /,
-    *samples: _ToFloatStrictND | onp.ToFloatStrict1D,
+    *samples: _AsFloat64StrictND | _AsFloat64_1D,
     equal_var: bool = True,
     axis: int = 0,
     nan_policy: NanPolicy = "propagate",
     keepdims: L[False] = False,
 ) -> F_onewayResult[np.float64 | Any]: ...
-@overload  # ?d, 2d|3d
+@overload  # ?d f32, ?d f32
 def f_oneway(
-    sample1: _ToFloatStrictND,
-    sample2: onp.ToFloatStrict2D | onp.ToFloatStrict3D,
+    sample1: _AsFloat32StrictND,
+    sample2: _AsFloat32StrictND | onp.ToJustFloat32Strict1D,
     /,
-    *samples: _ToFloatStrictND | onp.ToFloatStrict1D,
+    *samples: _AsFloat32StrictND | onp.ToJustFloat32Strict1D,
     equal_var: bool = True,
     axis: int = 0,
     nan_policy: NanPolicy = "propagate",
     keepdims: L[False] = False,
-) -> F_onewayResult[onp.ArrayND[np.float64]]: ...
-@overload  # 2d|3d, ?d
+) -> F_onewayResult[np.float32 | Any]: ...
+@overload  # 1d +f64, 1d +f64
 def f_oneway(
-    sample1: onp.ToFloatStrict2D | onp.ToFloatStrict3D,
-    sample2: _ToFloatStrictND,
+    sample1: _AsFloat64_1D,
+    sample2: _AsFloat64_1D,
     /,
-    *samples: _ToFloatStrictND | onp.ToFloatStrict1D,
-    equal_var: bool = True,
-    axis: int = 0,
-    nan_policy: NanPolicy = "propagate",
-    keepdims: L[False] = False,
-) -> F_onewayResult[onp.ArrayND[np.float64]]: ...
-@overload  # 1d, 1d
-def f_oneway(
-    sample1: onp.ToFloatStrict1D,
-    sample2: onp.ToFloatStrict1D,
-    /,
-    *samples: onp.ToFloatStrict1D,
+    *samples: _AsFloat64_1D,
     equal_var: bool = True,
     axis: int = 0,
     nan_policy: NanPolicy = "propagate",
     keepdims: L[False] = False,
 ) -> F_onewayResult[np.float64]: ...
-@overload  # 2d, <=2d
+@overload  # 1d ~f32, 1d ~f32
 def f_oneway(
-    sample1: onp.ToFloatStrict2D,
-    sample2: onp.ToFloatStrict2D | onp.ToFloatStrict1D,
+    sample1: onp.ToJustFloat32Strict1D,
+    sample2: onp.ToJustFloat32Strict1D,
     /,
-    *samples: onp.ToFloatStrict2D | onp.ToFloatStrict1D,
+    *samples: onp.ToJustFloat32Strict1D,
+    equal_var: bool = True,
+    axis: int = 0,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: L[False] = False,
+) -> F_onewayResult[np.float32]: ...
+@overload  # ?d +f64, 2d|3d +f64
+def f_oneway(
+    sample1: _AsFloat64StrictND,
+    sample2: _AsFloat64_2D | _AsFloat64_3D,
+    /,
+    *samples: _AsFloat64StrictND | _AsFloat64_1D,
+    equal_var: bool = True,
+    axis: int = 0,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: L[False] = False,
+) -> F_onewayResult[onp.ArrayND[np.float64]]: ...
+@overload  # 2d|3d +f64, ?d  +f64
+def f_oneway(
+    sample1: _AsFloat64_2D | _AsFloat64_3D,
+    sample2: _AsFloat64StrictND,
+    /,
+    *samples: _AsFloat64StrictND | _AsFloat64_1D,
+    equal_var: bool = True,
+    axis: int = 0,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: L[False] = False,
+) -> F_onewayResult[onp.ArrayND[np.float64]]: ...
+@overload  # ?d ~f32, 2d|3d ~f32
+def f_oneway(
+    sample1: _AsFloat32StrictND,
+    sample2: onp.ToJustFloat32Strict2D | onp.ToJustFloat32Strict3D,
+    /,
+    *samples: _AsFloat32StrictND | onp.ToJustFloat32Strict1D,
+    equal_var: bool = True,
+    axis: int = 0,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: L[False] = False,
+) -> F_onewayResult[onp.ArrayND[np.float32]]: ...
+@overload  # 2d +f64, <=2d  +f64
+def f_oneway(
+    sample1: _AsFloat64_2D,
+    sample2: _AsFloat64_2D | _AsFloat64_1D,
+    /,
+    *samples: _AsFloat64_2D | _AsFloat64_1D,
     equal_var: bool = True,
     axis: int = 0,
     nan_policy: NanPolicy = "propagate",
     keepdims: L[False] = False,
 ) -> F_onewayResult[onp.Array1D[np.float64]]: ...
-@overload  # <=2d, 2d
+@overload  # <=2d +f64, 2d +f64
 def f_oneway(
-    sample1: onp.ToFloatStrict2D | onp.ToFloatStrict1D,
-    sample2: onp.ToFloatStrict2D,
+    sample1: _AsFloat64_2D | _AsFloat64_1D,
+    sample2: _AsFloat64_2D,
     /,
-    *samples: onp.ToFloatStrict2D | onp.ToFloatStrict1D,
+    *samples: _AsFloat64_2D | _AsFloat64_1D,
     equal_var: bool = True,
     axis: int = 0,
     nan_policy: NanPolicy = "propagate",
     keepdims: L[False] = False,
 ) -> F_onewayResult[onp.Array1D[np.float64]]: ...
-@overload  # 3d, <=3d
+@overload  # 2d ~f32, 2d ~f32
 def f_oneway(
-    sample1: onp.ToFloatStrict3D,
-    sample2: onp.ToFloatStrict3D | onp.ToFloatStrict2D | onp.ToFloatStrict1D,
+    sample1: onp.ToJustFloat32Strict2D,
+    sample2: onp.ToJustFloat32Strict2D,
     /,
-    *samples: onp.ToFloatStrict3D | onp.ToFloatStrict2D | onp.ToFloatStrict1D,
+    *samples: onp.ToJustFloat32Strict2D,
+    equal_var: bool = True,
+    axis: int = 0,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: L[False] = False,
+) -> F_onewayResult[onp.Array1D[np.float32]]: ...
+@overload  # 3d +f64, <=3d +f64
+def f_oneway(
+    sample1: _AsFloat64_3D,
+    sample2: _AsFloat64_3D | _AsFloat64_2D | _AsFloat64_1D,
+    /,
+    *samples: _AsFloat64_3D | _AsFloat64_2D | _AsFloat64_1D,
     equal_var: bool = True,
     axis: int = 0,
     nan_policy: NanPolicy = "propagate",
     keepdims: L[False] = False,
 ) -> F_onewayResult[onp.Array2D[np.float64]]: ...
-@overload  # <=3d, 3d
+@overload  # <=3d +f64, 3d +f64
 def f_oneway(
-    sample1: onp.ToFloatStrict3D | onp.ToFloatStrict2D | onp.ToFloatStrict1D,
-    sample2: onp.ToFloatStrict3D,
+    sample1: _AsFloat64_3D | _AsFloat64_2D | _AsFloat64_1D,
+    sample2: _AsFloat64_3D,
     /,
-    *samples: onp.ToFloatStrict3D | onp.ToFloatStrict2D | onp.ToFloatStrict1D,
+    *samples: _AsFloat64_3D | _AsFloat64_2D | _AsFloat64_1D,
     equal_var: bool = True,
     axis: int = 0,
     nan_policy: NanPolicy = "propagate",
     keepdims: L[False] = False,
 ) -> F_onewayResult[onp.Array2D[np.float64]]: ...
-@overload  # Nd, Nd
+@overload  # 3d ~f32, 3d ~f32
 def f_oneway(
-    sample1: onp.ToFloatND,
-    sample2: onp.ToFloatND,
+    sample1: onp.ToJustFloat32Strict3D,
+    sample2: onp.ToJustFloat32Strict3D,
     /,
-    *samples: onp.ToFloatND,
+    *samples: onp.ToJustFloat32Strict3D,
+    equal_var: bool = True,
+    axis: int = 0,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: L[False] = False,
+) -> F_onewayResult[onp.Array2D[np.float32]]: ...
+@overload  # Nd +f64, Nd +f64
+def f_oneway(
+    sample1: _AsFloat64_ND,
+    sample2: _AsFloat64_ND,
+    /,
+    *samples: _AsFloat64_ND,
     equal_var: bool = True,
     axis: int = 0,
     nan_policy: NanPolicy = "propagate",
     keepdims: L[False] = False,
 ) -> F_onewayResult[onp.ArrayND[np.float64] | Any]: ...
-@overload  # axis=None
+@overload  # Nd ~f32, Nd ~f32
 def f_oneway(
-    sample1: onp.ToFloatND,
-    sample2: onp.ToFloatND,
+    sample1: onp.ToJustFloat32_ND,
+    sample2: onp.ToJustFloat32_ND,
     /,
-    *samples: onp.ToFloatND,
+    *samples: onp.ToJustFloat32_ND,
+    equal_var: bool = True,
+    axis: int = 0,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: L[False] = False,
+) -> F_onewayResult[onp.ArrayND[np.float32] | Any]: ...
+@overload  # ?d +f64, ?d +f64, axis=None
+def f_oneway(
+    sample1: _AsFloat64_ND,
+    sample2: _AsFloat64_ND,
+    /,
+    *samples: _AsFloat64_ND,
     equal_var: bool = True,
     axis: None,
     nan_policy: NanPolicy = "propagate",
     keepdims: L[False] = False,
 ) -> F_onewayResult[np.float64]: ...
-@overload  # keepdims=True
+@overload  # ?d ~f32, ?d ~f32, axis=None
+def f_oneway(
+    sample1: onp.ToJustFloat32_ND,
+    sample2: onp.ToJustFloat32_ND,
+    /,
+    *samples: onp.ToJustFloat32_ND,
+    equal_var: bool = True,
+    axis: None,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: L[False] = False,
+) -> F_onewayResult[np.float32]: ...
+@overload  # ?d +f64, ?d +f64, keepdims=True
+def f_oneway(
+    sample1: _AsFloat64_ND,
+    sample2: _AsFloat64_ND,
+    /,
+    *samples: _AsFloat64_ND,
+    equal_var: bool = True,
+    axis: int | None = 0,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: L[True],
+) -> F_onewayResult[onp.ArrayND[np.float64]]: ...
+@overload  # ?d ~f32, ?d ~f32, keepdims=True
+def f_oneway(
+    sample1: onp.ToJustFloat32_ND,
+    sample2: onp.ToJustFloat32_ND,
+    /,
+    *samples: onp.ToJustFloat32_ND,
+    equal_var: bool = True,
+    axis: int | None = 0,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: L[True],
+) -> F_onewayResult[onp.ArrayND[np.float32]]: ...
+@overload  # fallback
 def f_oneway(
     sample1: onp.ToFloatND,
     sample2: onp.ToFloatND,
@@ -3707,8 +3806,8 @@ def f_oneway(
     equal_var: bool = True,
     axis: int | None = 0,
     nan_policy: NanPolicy = "propagate",
-    keepdims: L[True],
-) -> F_onewayResult[onp.ArrayND[np.float64]]: ...
+    keepdims: bool = False,
+) -> F_onewayResult[np.float64 | Any]: ...
 
 #
 @overload  # ?d ~f64 | +integer, axis=None
@@ -5006,10 +5105,10 @@ def ttest_rel(
 ) -> TtestResult[onp.ArrayND[np.float64 | Any], onp.ArrayND[np.int_]] | TtestResult[np.float64 | Any, np.int_]: ...
 
 #
-@overload
+@overload  # 1d +f64
 def power_divergence(
-    f_obs: onp.ToFloatStrict1D,
-    f_exp: onp.ToFloatStrict1D | None = None,
+    f_obs: _AsFloat64_1D,
+    f_exp: _AsFloat64_1D | None = None,
     ddof: int = 0,
     axis: int | None = 0,
     lambda_: PowerDivergenceStatistic | float | None = None,
@@ -5017,10 +5116,21 @@ def power_divergence(
     keepdims: L[False] = False,
     nan_policy: NanPolicy = "propagate",
 ) -> Power_divergenceResult[np.float64]: ...
-@overload
+@overload  # 1d ~f32
 def power_divergence(
-    f_obs: onp.ToFloatND,
-    f_exp: onp.ToFloatND | None,
+    f_obs: onp.ToJustFloat32Strict1D,
+    f_exp: onp.ToJustFloat32Strict1D | None = None,
+    ddof: int = 0,
+    axis: int | None = 0,
+    lambda_: PowerDivergenceStatistic | float | None = None,
+    *,
+    keepdims: L[False] = False,
+    nan_policy: NanPolicy = "propagate",
+) -> Power_divergenceResult[np.float32]: ...
+@overload  # ?d +f64, axis=None
+def power_divergence(
+    f_obs: _AsFloat64_ND,
+    f_exp: _AsFloat64_ND | None,
     ddof: int,
     axis: None,
     lambda_: PowerDivergenceStatistic | float | None = None,
@@ -5028,10 +5138,10 @@ def power_divergence(
     keepdims: L[False] = False,
     nan_policy: NanPolicy = "propagate",
 ) -> Power_divergenceResult[np.float64]: ...
-@overload
+@overload  # ?d +f64, axis=None (keyword)
 def power_divergence(
-    f_obs: onp.ToFloatND,
-    f_exp: onp.ToFloatND | None = None,
+    f_obs: _AsFloat64_ND,
+    f_exp: _AsFloat64_ND | None = None,
     ddof: int = 0,
     *,
     axis: None,
@@ -5039,10 +5149,10 @@ def power_divergence(
     keepdims: L[False] = False,
     nan_policy: NanPolicy = "propagate",
 ) -> Power_divergenceResult[np.float64]: ...
-@overload
+@overload  # ?d +f64, keepdims=True
 def power_divergence(
-    f_obs: onp.ToFloatND,
-    f_exp: onp.ToFloatND | None = None,
+    f_obs: _AsFloat64_ND,
+    f_exp: _AsFloat64_ND | None = None,
     ddof: int = 0,
     axis: int | None = 0,
     lambda_: PowerDivergenceStatistic | float | None = None,
@@ -5050,7 +5160,40 @@ def power_divergence(
     keepdims: L[True],
     nan_policy: NanPolicy = "propagate",
 ) -> Power_divergenceResult[onp.ArrayND[np.float64]]: ...
-@overload
+@overload  # ?d ~f32, axis=None
+def power_divergence(
+    f_obs: onp.ToJustFloat32_ND,
+    f_exp: onp.ToJustFloat32_ND | None,
+    ddof: int,
+    axis: None,
+    lambda_: PowerDivergenceStatistic | float | None = None,
+    *,
+    keepdims: L[False] = False,
+    nan_policy: NanPolicy = "propagate",
+) -> Power_divergenceResult[np.float32]: ...
+@overload  # ?d ~f32, axis=None (keyword)
+def power_divergence(
+    f_obs: onp.ToJustFloat32_ND,
+    f_exp: onp.ToJustFloat32_ND | None = None,
+    ddof: int = 0,
+    *,
+    axis: None,
+    lambda_: PowerDivergenceStatistic | float | None = None,
+    keepdims: L[False] = False,
+    nan_policy: NanPolicy = "propagate",
+) -> Power_divergenceResult[np.float32]: ...
+@overload  # ?d ~f32, keepdims=True
+def power_divergence(
+    f_obs: onp.ToJustFloat32_ND,
+    f_exp: onp.ToJustFloat32_ND | None = None,
+    ddof: int = 0,
+    axis: int | None = 0,
+    lambda_: PowerDivergenceStatistic | float | None = None,
+    *,
+    keepdims: L[True],
+    nan_policy: NanPolicy = "propagate",
+) -> Power_divergenceResult[onp.ArrayND[np.float32]]: ...
+@overload  # fallback
 def power_divergence(
     f_obs: onp.ToFloatND,
     f_exp: onp.ToFloatND | None = None,
@@ -5063,10 +5206,10 @@ def power_divergence(
 ) -> Power_divergenceResult[np.float64 | Any]: ...
 
 #
-@overload
+@overload  # 1d +f64
 def chisquare(
-    f_obs: onp.ToFloatStrict1D,
-    f_exp: onp.ToFloatStrict1D | None = None,
+    f_obs: _AsFloat64_1D,
+    f_exp: _AsFloat64_1D | None = None,
     ddof: int = 0,
     axis: int | None = 0,
     *,
@@ -5074,10 +5217,21 @@ def chisquare(
     keepdims: L[False] = False,
     nan_policy: NanPolicy = "propagate",
 ) -> Power_divergenceResult[np.float64]: ...
-@overload
+@overload  # 1d ~f32
 def chisquare(
-    f_obs: onp.ToFloatND,
-    f_exp: onp.ToFloatND | None,
+    f_obs: onp.ToJustFloat32Strict1D,
+    f_exp: onp.ToJustFloat32Strict1D | None = None,
+    ddof: int = 0,
+    axis: int | None = 0,
+    *,
+    sum_check: bool = True,
+    keepdims: L[False] = False,
+    nan_policy: NanPolicy = "propagate",
+) -> Power_divergenceResult[np.float32]: ...
+@overload  # ?d +f64, axis=None
+def chisquare(
+    f_obs: _AsFloat64_ND,
+    f_exp: _AsFloat64_ND | None,
     ddof: int,
     axis: None,
     *,
@@ -5085,10 +5239,10 @@ def chisquare(
     keepdims: L[False] = False,
     nan_policy: NanPolicy = "propagate",
 ) -> Power_divergenceResult[np.float64]: ...
-@overload
+@overload  # ?d +f64, axis=None (keyword)
 def chisquare(
-    f_obs: onp.ToFloatND,
-    f_exp: onp.ToFloatND | None = None,
+    f_obs: _AsFloat64_ND,
+    f_exp: _AsFloat64_ND | None = None,
     ddof: int = 0,
     *,
     axis: None,
@@ -5096,10 +5250,10 @@ def chisquare(
     keepdims: L[False] = False,
     nan_policy: NanPolicy = "propagate",
 ) -> Power_divergenceResult[np.float64]: ...
-@overload
+@overload  # ?d +f64, keepdims=True
 def chisquare(
-    f_obs: onp.ToFloatND,
-    f_exp: onp.ToFloatND | None = None,
+    f_obs: _AsFloat64_ND,
+    f_exp: _AsFloat64_ND | None = None,
     ddof: int = 0,
     axis: int | None = 0,
     *,
@@ -5107,7 +5261,40 @@ def chisquare(
     keepdims: L[True],
     nan_policy: NanPolicy = "propagate",
 ) -> Power_divergenceResult[onp.ArrayND[np.float64]]: ...
-@overload
+@overload  # ?d ~f32, axis=None
+def chisquare(
+    f_obs: onp.ToJustFloat32_ND,
+    f_exp: onp.ToJustFloat32_ND | None,
+    ddof: int,
+    axis: None,
+    *,
+    sum_check: bool = True,
+    keepdims: L[False] = False,
+    nan_policy: NanPolicy = "propagate",
+) -> Power_divergenceResult[np.float32]: ...
+@overload  # ?d ~f32, axis=None (keyword)
+def chisquare(
+    f_obs: onp.ToJustFloat32_ND,
+    f_exp: onp.ToJustFloat32_ND | None = None,
+    ddof: int = 0,
+    *,
+    axis: None,
+    sum_check: bool = True,
+    keepdims: L[False] = False,
+    nan_policy: NanPolicy = "propagate",
+) -> Power_divergenceResult[np.float32]: ...
+@overload  # ?d ~f32, keepdims=True
+def chisquare(
+    f_obs: onp.ToJustFloat32_ND,
+    f_exp: onp.ToJustFloat32_ND | None = None,
+    ddof: int = 0,
+    axis: int | None = 0,
+    *,
+    sum_check: bool = True,
+    keepdims: L[True],
+    nan_policy: NanPolicy = "propagate",
+) -> Power_divergenceResult[onp.ArrayND[np.float32]]: ...
+@overload  # fallback
 def chisquare(
     f_obs: onp.ToFloatND,
     f_exp: onp.ToFloatND | None = None,
@@ -5266,10 +5453,10 @@ def ks_1samp(
 ) -> KstestResult[np.float64 | Any, np.int8 | Any]: ...
 
 #
-@overload  # ?d, ?d|1d
+@overload  # ?d +f64, ?d|1d +f64
 def ks_2samp(
-    data1: onp.ArrayND[npc.floating | npc.integer, _JustAnyShape],
-    data2: onp.ArrayND[npc.floating | npc.integer, _JustAnyShape] | onp.ToFloatStrict1D,
+    data1: _AsFloat64StrictND,
+    data2: _AsFloat64StrictND | _AsFloat64_1D,
     alternative: Alternative = "two-sided",
     method: _KS2TestMethod = "auto",
     *,
@@ -5277,10 +5464,21 @@ def ks_2samp(
     nan_policy: NanPolicy = "propagate",
     keepdims: L[False] = False,
 ) -> KstestResult[np.float64 | Any, np.int8 | Any]: ...
-@overload  # ?d|1d, ?d
+@overload  # ?d ~f32, ?d|1d ~f32
 def ks_2samp(
-    data1: onp.ArrayND[npc.floating | npc.integer, _JustAnyShape] | onp.ToFloatStrict1D,
-    data2: onp.ArrayND[npc.floating | npc.integer, _JustAnyShape],
+    data1: _AsFloat32StrictND,
+    data2: _AsFloat32StrictND | onp.ToJustFloat32Strict1D,
+    alternative: Alternative = "two-sided",
+    method: _KS2TestMethod = "auto",
+    *,
+    axis: int = 0,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: L[False] = False,
+) -> KstestResult[np.float32 | Any, np.int8 | Any]: ...
+@overload  # ?d|1d +f64, ?d +f64
+def ks_2samp(
+    data1: _AsFloat64StrictND | _AsFloat64_1D,
+    data2: _AsFloat64StrictND,
     alternative: Alternative = "two-sided",
     method: _KS2TestMethod = "auto",
     *,
@@ -5288,10 +5486,10 @@ def ks_2samp(
     nan_policy: NanPolicy = "propagate",
     keepdims: L[False] = False,
 ) -> KstestResult[np.float64 | Any, np.int8 | Any]: ...
-@overload  # ?d, 2d|3d
+@overload  # ?d +f64, 2d|3d +f64
 def ks_2samp(
-    data1: onp.ArrayND[npc.floating | npc.integer, _JustAnyShape],
-    data2: onp.ToFloatStrict2D | onp.ToFloatStrict3D,
+    data1: _AsFloat64StrictND,
+    data2: _AsFloat64_2D | _AsFloat64_3D,
     alternative: Alternative = "two-sided",
     method: _KS2TestMethod = "auto",
     *,
@@ -5299,10 +5497,21 @@ def ks_2samp(
     nan_policy: NanPolicy = "propagate",
     keepdims: L[False] = False,
 ) -> _KstestResultN: ...
-@overload  # 2d, ?d
+@overload  # ?d ~f32, 2d|3d ~f32
 def ks_2samp(
-    data1: onp.ToFloatStrict2D | onp.ToFloatStrict3D,
-    data2: onp.ArrayND[npc.floating | npc.integer, _JustAnyShape],
+    data1: _AsFloat32StrictND,
+    data2: onp.ToJustFloat32Strict2D | onp.ToJustFloat32Strict3D,
+    alternative: Alternative = "two-sided",
+    method: _KS2TestMethod = "auto",
+    *,
+    axis: int = 0,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: L[False] = False,
+) -> KstestResult[onp.ArrayND[np.float32], onp.ArrayND[np.int8]]: ...
+@overload  # 2d|3d +f64, ?d +f64
+def ks_2samp(
+    data1: _AsFloat64_2D | _AsFloat64_3D,
+    data2: _AsFloat64StrictND,
     alternative: Alternative = "two-sided",
     method: _KS2TestMethod = "auto",
     *,
@@ -5310,10 +5519,43 @@ def ks_2samp(
     nan_policy: NanPolicy = "propagate",
     keepdims: L[False] = False,
 ) -> _KstestResultN: ...
-@overload  # 1d, 1d
+@overload  # 2d +f64, <=2d +f64
 def ks_2samp(
-    data1: onp.ToFloatStrict1D,
-    data2: onp.ToFloatStrict1D,
+    data1: _AsFloat64_2D,
+    data2: _AsFloat64_2D | _AsFloat64_1D,
+    alternative: Alternative = "two-sided",
+    method: _KS2TestMethod = "auto",
+    *,
+    axis: int = 0,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: L[False] = False,
+) -> _KstestResult1: ...
+@overload  # <=2d +f64, 2d +f64
+def ks_2samp(
+    data1: _AsFloat64_2D | _AsFloat64_1D,
+    data2: _AsFloat64_2D,
+    alternative: Alternative = "two-sided",
+    method: _KS2TestMethod = "auto",
+    *,
+    axis: int = 0,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: L[False] = False,
+) -> _KstestResult1: ...
+@overload  # 2d ~f32, 2d ~f32
+def ks_2samp(
+    data1: onp.ToJustFloat32Strict2D,
+    data2: onp.ToJustFloat32Strict2D,
+    alternative: Alternative = "two-sided",
+    method: _KS2TestMethod = "auto",
+    *,
+    axis: int = 0,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: L[False] = False,
+) -> KstestResult[onp.Array1D[np.float32], onp.Array1D[np.int8]]: ...
+@overload  # 1d +f64, 1d +f64
+def ks_2samp(
+    data1: _AsFloat64_1D,
+    data2: _AsFloat64_1D,
     alternative: Alternative = "two-sided",
     method: _KS2TestMethod = "auto",
     *,
@@ -5321,32 +5563,21 @@ def ks_2samp(
     nan_policy: NanPolicy = "propagate",
     keepdims: L[False] = False,
 ) -> _KstestResult0: ...
-@overload  # 2d, <=2d
+@overload  # 1d ~f32, 1d ~f32
 def ks_2samp(
-    data1: onp.ToFloatStrict2D,
-    data2: onp.ToFloatStrict2D | onp.ToFloatStrict1D,
+    data1: onp.ToJustFloat32Strict1D,
+    data2: onp.ToJustFloat32Strict1D,
     alternative: Alternative = "two-sided",
     method: _KS2TestMethod = "auto",
     *,
     axis: int = 0,
     nan_policy: NanPolicy = "propagate",
     keepdims: L[False] = False,
-) -> _KstestResult1: ...
-@overload  # <=2d, 2d
+) -> KstestResult[np.float32, np.int8]: ...
+@overload  # 3d +f64, <=3d +f64
 def ks_2samp(
-    data1: onp.ToFloatStrict2D | onp.ToFloatStrict1D,
-    data2: onp.ToFloatStrict2D,
-    alternative: Alternative = "two-sided",
-    method: _KS2TestMethod = "auto",
-    *,
-    axis: int = 0,
-    nan_policy: NanPolicy = "propagate",
-    keepdims: L[False] = False,
-) -> _KstestResult1: ...
-@overload  # 3d, <=3d
-def ks_2samp(
-    data1: onp.ToFloatStrict3D,
-    data2: onp.ToFloatStrict3D | onp.ToFloatStrict2D | onp.ToFloatStrict1D,
+    data1: _AsFloat64_3D,
+    data2: _AsFloat64_3D | _AsFloat64_2D | _AsFloat64_1D,
     alternative: Alternative = "two-sided",
     method: _KS2TestMethod = "auto",
     *,
@@ -5354,10 +5585,10 @@ def ks_2samp(
     nan_policy: NanPolicy = "propagate",
     keepdims: L[False] = False,
 ) -> _KstestResult2: ...
-@overload  # <=3d, 3d
+@overload  # <=3d +f64, 3d +f64
 def ks_2samp(
-    data1: onp.ToFloatStrict3D | onp.ToFloatStrict2D | onp.ToFloatStrict1D,
-    data2: onp.ToFloatStrict3D,
+    data1: _AsFloat64_3D | _AsFloat64_2D | _AsFloat64_1D,
+    data2: _AsFloat64_3D,
     alternative: Alternative = "two-sided",
     method: _KS2TestMethod = "auto",
     *,
@@ -5365,7 +5596,29 @@ def ks_2samp(
     nan_policy: NanPolicy = "propagate",
     keepdims: L[False] = False,
 ) -> _KstestResult2: ...
-@overload  # Nd
+@overload  # 3d ~f32, 3d ~f32
+def ks_2samp(
+    data1: onp.ToJustFloat32Strict3D,
+    data2: onp.ToJustFloat32Strict3D,
+    alternative: Alternative = "two-sided",
+    method: _KS2TestMethod = "auto",
+    *,
+    axis: int = 0,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: L[False] = False,
+) -> KstestResult[onp.Array2D[np.float32], onp.Array2D[np.int8]]: ...
+@overload  # Nd ~f32, Nd ~f32
+def ks_2samp(
+    data1: onp.ToJustFloat32_ND,
+    data2: onp.ToJustFloat32_ND,
+    alternative: Alternative = "two-sided",
+    method: _KS2TestMethod = "auto",
+    *,
+    axis: int = 0,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: L[False] = False,
+) -> KstestResult[np.float32 | Any, np.int8 | Any]: ...
+@overload  # Nd, Nd
 def ks_2samp(
     data1: onp.ToFloatND,
     data2: onp.ToFloatND,
@@ -5376,18 +5629,29 @@ def ks_2samp(
     nan_policy: NanPolicy = "propagate",
     keepdims: L[False] = False,
 ) -> KstestResult[np.float64 | Any, np.int8 | Any]: ...
-@overload  # keepdims=True
+@overload  # ?d ~f32, ?d ~f32, keepdims=True
 def ks_2samp(
-    data1: onp.ToFloatND,
-    data2: onp.ToFloatND,
+    data1: onp.ToJustFloat32_ND,
+    data2: onp.ToJustFloat32_ND,
     alternative: Alternative = "two-sided",
     method: _KS2TestMethod = "auto",
     *,
     axis: int | None = 0,
     nan_policy: NanPolicy = "propagate",
     keepdims: L[True],
-) -> _KstestResultN: ...
-@overload  # axis=None
+) -> KstestResult[onp.ArrayND[np.float32], onp.ArrayND[np.int8]]: ...
+@overload  # ?d ~f32, ?d ~f32, axis=None
+def ks_2samp(
+    data1: onp.ToJustFloat32_ND,
+    data2: onp.ToJustFloat32_ND,
+    alternative: Alternative = "two-sided",
+    method: _KS2TestMethod = "auto",
+    *,
+    axis: None,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: L[False] = False,
+) -> KstestResult[np.float32, np.int8]: ...
+@overload  # fallback, axis=None
 def ks_2samp(
     data1: onp.ToFloatND,
     data2: onp.ToFloatND,
@@ -5398,6 +5662,17 @@ def ks_2samp(
     nan_policy: NanPolicy = "propagate",
     keepdims: L[False] = False,
 ) -> _KstestResult0: ...
+@overload  # fallback, keepdims=True
+def ks_2samp(
+    data1: onp.ToFloatND,
+    data2: onp.ToFloatND,
+    alternative: Alternative = "two-sided",
+    method: _KS2TestMethod = "auto",
+    *,
+    axis: int | None = 0,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: L[True],
+) -> _KstestResultN: ...
 
 # 1-sample iff `cdf` is a name or callable
 @overload  # 1-sample, ?d
@@ -6001,117 +6276,207 @@ def ranksums(
 ) -> RanksumsResult[onp.ArrayND[np.float64]]: ...
 
 #
-@overload  # ?d, ?d|1d
+@overload  # ?d +f64, ?d|1d +f64
 def kruskal(
-    sample1: _ToFloatStrictND,
-    sample2: _ToFloatStrictND | onp.ToFloatStrict1D,
+    sample1: _AsFloat64StrictND,
+    sample2: _AsFloat64StrictND | _AsFloat64_1D,
     /,
-    *samples: _ToFloatStrictND | onp.ToFloatStrict1D,
+    *samples: _AsFloat64StrictND | _AsFloat64_1D,
     axis: int = 0,
     nan_policy: NanPolicy = "propagate",
     keepdims: L[False] = False,
 ) -> KruskalResult[np.float64 | Any]: ...
-@overload  # ?d|1d, ?d
+@overload  # ?d|1d +f64, ?d +f64
 def kruskal(
-    sample1: _ToFloatStrictND | onp.ToFloatStrict1D,
-    sample2: _ToFloatStrictND,
+    sample1: _AsFloat64StrictND | _AsFloat64_1D,
+    sample2: _AsFloat64StrictND,
     /,
-    *samples: _ToFloatStrictND | onp.ToFloatStrict1D,
+    *samples: _AsFloat64StrictND | _AsFloat64_1D,
     axis: int = 0,
     nan_policy: NanPolicy = "propagate",
     keepdims: L[False] = False,
 ) -> KruskalResult[np.float64 | Any]: ...
-@overload  # ?d, 2d|3d
+@overload  # ?d ~f32, ?d|1d ~f32
 def kruskal(
-    sample1: _ToFloatStrictND,
-    sample2: onp.ToFloatStrict2D | onp.ToFloatStrict3D,
+    sample1: _AsFloat32StrictND,
+    sample2: _AsFloat32StrictND | onp.ToJustFloat32Strict1D,
     /,
-    *samples: _ToFloatStrictND | onp.ToFloatStrict1D,
+    *samples: _AsFloat32StrictND | onp.ToJustFloat32Strict1D,
     axis: int = 0,
     nan_policy: NanPolicy = "propagate",
     keepdims: L[False] = False,
-) -> KruskalResult[onp.ArrayND[np.float64]]: ...
-@overload  # 2d|3d, ?d
+) -> KruskalResult[np.float32 | Any]: ...
+@overload  # 1d +f64, 1d +f64
 def kruskal(
-    sample1: onp.ToFloatStrict2D | onp.ToFloatStrict3D,
-    sample2: _ToFloatStrictND,
+    sample1: _AsFloat64_1D,
+    sample2: _AsFloat64_1D,
     /,
-    *samples: _ToFloatStrictND | onp.ToFloatStrict1D,
-    axis: int = 0,
-    nan_policy: NanPolicy = "propagate",
-    keepdims: L[False] = False,
-) -> KruskalResult[onp.ArrayND[np.float64]]: ...
-@overload  # 1d, 1d
-def kruskal(
-    sample1: onp.ToFloatStrict1D,
-    sample2: onp.ToFloatStrict1D,
-    /,
-    *samples: onp.ToFloatStrict1D,
+    *samples: _AsFloat64_1D,
     axis: int = 0,
     nan_policy: NanPolicy = "propagate",
     keepdims: L[False] = False,
 ) -> KruskalResult[np.float64]: ...
-@overload  # 2d, <=2d
+@overload  # 1d ~f32, 1d ~f32
 def kruskal(
-    sample1: onp.ToFloatStrict2D,
-    sample2: onp.ToFloatStrict2D | onp.ToFloatStrict1D,
+    sample1: onp.ToJustFloat32Strict1D,
+    sample2: onp.ToJustFloat32Strict1D,
     /,
-    *samples: onp.ToFloatStrict2D | onp.ToFloatStrict1D,
+    *samples: onp.ToJustFloat32Strict1D,
+    axis: int = 0,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: L[False] = False,
+) -> KruskalResult[np.float32]: ...
+@overload  # ?d +f64, 2d|3d +f64
+def kruskal(
+    sample1: _AsFloat64StrictND,
+    sample2: _AsFloat64_2D | _AsFloat64_3D,
+    /,
+    *samples: _AsFloat64StrictND | _AsFloat64_1D,
+    axis: int = 0,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: L[False] = False,
+) -> KruskalResult[onp.ArrayND[np.float64]]: ...
+@overload  # 2d|3d +f64, ?d +f64
+def kruskal(
+    sample1: _AsFloat64_2D | _AsFloat64_3D,
+    sample2: _AsFloat64StrictND,
+    /,
+    *samples: _AsFloat64StrictND | _AsFloat64_1D,
+    axis: int = 0,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: L[False] = False,
+) -> KruskalResult[onp.ArrayND[np.float64]]: ...
+@overload  # ?d ~f32, 2d|3d ~f32
+def kruskal(
+    sample1: _AsFloat32StrictND,
+    sample2: onp.ToJustFloat32Strict2D | onp.ToJustFloat32Strict3D,
+    /,
+    *samples: _AsFloat32StrictND | onp.ToJustFloat32Strict1D,
+    axis: int = 0,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: L[False] = False,
+) -> KruskalResult[onp.ArrayND[np.float32]]: ...
+@overload  # 2d +f64, <=2d +f64
+def kruskal(
+    sample1: _AsFloat64_2D,
+    sample2: _AsFloat64_2D | _AsFloat64_1D,
+    /,
+    *samples: _AsFloat64_2D | _AsFloat64_1D,
     axis: int = 0,
     nan_policy: NanPolicy = "propagate",
     keepdims: L[False] = False,
 ) -> KruskalResult[onp.Array1D[np.float64]]: ...
-@overload  # <=2d, 2d
+@overload  # <=2d +f64, 2d +f64
 def kruskal(
-    sample1: onp.ToFloatStrict2D | onp.ToFloatStrict1D,
-    sample2: onp.ToFloatStrict2D,
+    sample1: _AsFloat64_2D | _AsFloat64_1D,
+    sample2: _AsFloat64_2D,
     /,
-    *samples: onp.ToFloatStrict2D | onp.ToFloatStrict1D,
+    *samples: _AsFloat64_2D | _AsFloat64_1D,
     axis: int = 0,
     nan_policy: NanPolicy = "propagate",
     keepdims: L[False] = False,
 ) -> KruskalResult[onp.Array1D[np.float64]]: ...
-@overload  # 3d, <=3d
+@overload  # 2d ~f32, 2d ~f32
 def kruskal(
-    sample1: onp.ToFloatStrict3D,
-    sample2: onp.ToFloatStrict3D | onp.ToFloatStrict2D | onp.ToFloatStrict1D,
+    sample1: onp.ToJustFloat32Strict2D,
+    sample2: onp.ToJustFloat32Strict2D,
     /,
-    *samples: onp.ToFloatStrict3D | onp.ToFloatStrict2D | onp.ToFloatStrict1D,
+    *samples: onp.ToJustFloat32Strict2D,
+    axis: int = 0,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: L[False] = False,
+) -> KruskalResult[onp.Array1D[np.float32]]: ...
+@overload  # 3d +f64, <=3d +f64
+def kruskal(
+    sample1: _AsFloat64_3D,
+    sample2: _AsFloat64_3D | _AsFloat64_2D | _AsFloat64_1D,
+    /,
+    *samples: _AsFloat64_3D | _AsFloat64_2D | _AsFloat64_1D,
     axis: int = 0,
     nan_policy: NanPolicy = "propagate",
     keepdims: L[False] = False,
 ) -> KruskalResult[onp.Array2D[np.float64]]: ...
-@overload  # <=3d, 3d
+@overload  # <=3d +f64, 3d +f64
 def kruskal(
-    sample1: onp.ToFloatStrict3D | onp.ToFloatStrict2D | onp.ToFloatStrict1D,
-    sample2: onp.ToFloatStrict3D,
+    sample1: _AsFloat64_3D | _AsFloat64_2D | _AsFloat64_1D,
+    sample2: _AsFloat64_3D,
     /,
-    *samples: onp.ToFloatStrict3D | onp.ToFloatStrict2D | onp.ToFloatStrict1D,
+    *samples: _AsFloat64_3D | _AsFloat64_2D | _AsFloat64_1D,
     axis: int = 0,
     nan_policy: NanPolicy = "propagate",
     keepdims: L[False] = False,
 ) -> KruskalResult[onp.Array2D[np.float64]]: ...
-@overload  # Nd, Nd
+@overload  # 3d ~f32, 3d ~f32
 def kruskal(
-    sample1: onp.ToFloatND,
-    sample2: onp.ToFloatND,
+    sample1: onp.ToJustFloat32Strict3D,
+    sample2: onp.ToJustFloat32Strict3D,
     /,
-    *samples: onp.ToFloatND,
+    *samples: onp.ToJustFloat32Strict3D,
+    axis: int = 0,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: L[False] = False,
+) -> KruskalResult[onp.Array2D[np.float32]]: ...
+@overload  # Nd +f64, Nd +f64
+def kruskal(
+    sample1: _AsFloat64_ND,
+    sample2: _AsFloat64_ND,
+    /,
+    *samples: _AsFloat64_ND,
     axis: int = 0,
     nan_policy: NanPolicy = "propagate",
     keepdims: L[False] = False,
 ) -> KruskalResult[onp.ArrayND[np.float64] | Any]: ...
-@overload  # axis=None
+@overload  # Nd ~f32, Nd ~f32
 def kruskal(
-    sample1: onp.ToFloatND,
-    sample2: onp.ToFloatND,
+    sample1: onp.ToJustFloat32_ND,
+    sample2: onp.ToJustFloat32_ND,
     /,
-    *samples: onp.ToFloatND,
+    *samples: onp.ToJustFloat32_ND,
+    axis: int = 0,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: L[False] = False,
+) -> KruskalResult[onp.ArrayND[np.float32] | Any]: ...
+@overload  # ?d +f64, ?d +f64, axis=None
+def kruskal(
+    sample1: _AsFloat64_ND,
+    sample2: _AsFloat64_ND,
+    /,
+    *samples: _AsFloat64_ND,
     axis: None,
     nan_policy: NanPolicy = "propagate",
     keepdims: L[False] = False,
 ) -> KruskalResult[np.float64]: ...
-@overload  # keepdims=True
+@overload  # ?d ~f32, ?d ~f32, axis=None
+def kruskal(
+    sample1: onp.ToJustFloat32_ND,
+    sample2: onp.ToJustFloat32_ND,
+    /,
+    *samples: onp.ToJustFloat32_ND,
+    axis: None,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: L[False] = False,
+) -> KruskalResult[np.float32]: ...
+@overload  # ?d +f64, ?d +f64, keepdims=True
+def kruskal(
+    sample1: _AsFloat64_ND,
+    sample2: _AsFloat64_ND,
+    /,
+    *samples: _AsFloat64_ND,
+    axis: int | None = 0,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: L[True],
+) -> KruskalResult[onp.ArrayND[np.float64]]: ...
+@overload  # ?d ~f32, ?d ~f32, keepdims=True
+def kruskal(
+    sample1: onp.ToJustFloat32_ND,
+    sample2: onp.ToJustFloat32_ND,
+    /,
+    *samples: onp.ToJustFloat32_ND,
+    axis: int | None = 0,
+    nan_policy: NanPolicy = "propagate",
+    keepdims: L[True],
+) -> KruskalResult[onp.ArrayND[np.float32]]: ...
+@overload  # fallback
 def kruskal(
     sample1: onp.ToFloatND,
     sample2: onp.ToFloatND,
@@ -6119,8 +6484,8 @@ def kruskal(
     *samples: onp.ToFloatND,
     axis: int | None = 0,
     nan_policy: NanPolicy = "propagate",
-    keepdims: L[True],
-) -> KruskalResult[onp.ArrayND[np.float64]]: ...
+    keepdims: bool = False,
+) -> KruskalResult[np.float64 | Any]: ...
 
 #
 @overload  # ?d ~f64 | +integer, axis=None
@@ -6323,10 +6688,10 @@ def friedmanchisquare(
 ) -> FriedmanchisquareResult[np.float64 | Any]: ...
 
 #
-@overload  # ?d, ?d|1d
+@overload  # ?d +f64, ?d|1d +f64
 def brunnermunzel(
-    x: onp.ArrayND[npc.floating | npc.integer, _JustAnyShape],
-    y: onp.ArrayND[npc.floating | npc.integer, _JustAnyShape] | onp.ToFloatStrict1D,
+    x: _AsFloat64StrictND,
+    y: _AsFloat64StrictND | _AsFloat64_1D,
     alternative: Alternative = "two-sided",
     distribution: L["t", "normal"] = "t",
     nan_policy: NanPolicy = "propagate",
@@ -6334,10 +6699,10 @@ def brunnermunzel(
     axis: int = 0,
     keepdims: L[False] = False,
 ) -> BrunnerMunzelResult[np.float64 | Any]: ...
-@overload  # ?d|1d, ?d
+@overload  # ?d|1d +f64, ?d +f64
 def brunnermunzel(
-    x: onp.ArrayND[npc.floating | npc.integer, _JustAnyShape] | onp.ToFloatStrict1D,
-    y: onp.ArrayND[npc.floating | npc.integer, _JustAnyShape],
+    x: _AsFloat64StrictND | _AsFloat64_1D,
+    y: _AsFloat64StrictND,
     alternative: Alternative = "two-sided",
     distribution: L["t", "normal"] = "t",
     nan_policy: NanPolicy = "propagate",
@@ -6345,32 +6710,21 @@ def brunnermunzel(
     axis: int = 0,
     keepdims: L[False] = False,
 ) -> BrunnerMunzelResult[np.float64 | Any]: ...
-@overload  # ?d, 2d|3d
+@overload  # ?d ~f32, ?d|1d ~f32
 def brunnermunzel(
-    x: onp.ArrayND[npc.floating | npc.integer, _JustAnyShape],
-    y: onp.ToFloatStrict2D | onp.ToFloatStrict3D,
+    x: _AsFloat32StrictND,
+    y: _AsFloat32StrictND | onp.ToJustFloat32Strict1D,
     alternative: Alternative = "two-sided",
     distribution: L["t", "normal"] = "t",
     nan_policy: NanPolicy = "propagate",
     *,
     axis: int = 0,
     keepdims: L[False] = False,
-) -> BrunnerMunzelResult[onp.ArrayND[np.float64]]: ...
-@overload  # 2d|3d, ?d
+) -> BrunnerMunzelResult[np.float32 | Any]: ...
+@overload  # 1d +f64, 1d +f64
 def brunnermunzel(
-    x: onp.ToFloatStrict2D | onp.ToFloatStrict3D,
-    y: onp.ArrayND[npc.floating | npc.integer, _JustAnyShape],
-    alternative: Alternative = "two-sided",
-    distribution: L["t", "normal"] = "t",
-    nan_policy: NanPolicy = "propagate",
-    *,
-    axis: int = 0,
-    keepdims: L[False] = False,
-) -> BrunnerMunzelResult[onp.ArrayND[np.float64]]: ...
-@overload  # 1d, 1d
-def brunnermunzel(
-    x: onp.ToFloatStrict1D,
-    y: onp.ToFloatStrict1D,
+    x: _AsFloat64_1D,
+    y: _AsFloat64_1D,
     alternative: Alternative = "two-sided",
     distribution: L["t", "normal"] = "t",
     nan_policy: NanPolicy = "propagate",
@@ -6378,10 +6732,54 @@ def brunnermunzel(
     axis: int = 0,
     keepdims: L[False] = False,
 ) -> BrunnerMunzelResult[np.float64]: ...
-@overload  # 2d, <=2d
+@overload  # 1d ~f32, 1d ~f32
 def brunnermunzel(
-    x: onp.ToFloatStrict2D,
-    y: onp.ToFloatStrict2D | onp.ToFloatStrict1D,
+    x: onp.ToJustFloat32Strict1D,
+    y: onp.ToJustFloat32Strict1D,
+    alternative: Alternative = "two-sided",
+    distribution: L["t", "normal"] = "t",
+    nan_policy: NanPolicy = "propagate",
+    *,
+    axis: int = 0,
+    keepdims: L[False] = False,
+) -> BrunnerMunzelResult[np.float32]: ...
+@overload  # ?d +f64, 2d|3d +f64
+def brunnermunzel(
+    x: _AsFloat64StrictND,
+    y: _AsFloat64_2D | _AsFloat64_3D,
+    alternative: Alternative = "two-sided",
+    distribution: L["t", "normal"] = "t",
+    nan_policy: NanPolicy = "propagate",
+    *,
+    axis: int = 0,
+    keepdims: L[False] = False,
+) -> BrunnerMunzelResult[onp.ArrayND[np.float64]]: ...
+@overload  # 2d|3d +f64, ?d +f64
+def brunnermunzel(
+    x: _AsFloat64_2D | _AsFloat64_3D,
+    y: _AsFloat64StrictND,
+    alternative: Alternative = "two-sided",
+    distribution: L["t", "normal"] = "t",
+    nan_policy: NanPolicy = "propagate",
+    *,
+    axis: int = 0,
+    keepdims: L[False] = False,
+) -> BrunnerMunzelResult[onp.ArrayND[np.float64]]: ...
+@overload  # ?d ~f32, 2d|3d ~f32
+def brunnermunzel(
+    x: _AsFloat32StrictND,
+    y: onp.ToJustFloat32Strict2D | onp.ToJustFloat32Strict3D,
+    alternative: Alternative = "two-sided",
+    distribution: L["t", "normal"] = "t",
+    nan_policy: NanPolicy = "propagate",
+    *,
+    axis: int = 0,
+    keepdims: L[False] = False,
+) -> BrunnerMunzelResult[onp.ArrayND[np.float32]]: ...
+@overload  # 2d +f64, <=2d +f64
+def brunnermunzel(
+    x: _AsFloat64_2D,
+    y: _AsFloat64_2D | _AsFloat64_1D,
     alternative: Alternative = "two-sided",
     distribution: L["t", "normal"] = "t",
     nan_policy: NanPolicy = "propagate",
@@ -6389,10 +6787,10 @@ def brunnermunzel(
     axis: int = 0,
     keepdims: L[False] = False,
 ) -> BrunnerMunzelResult[onp.Array1D[np.float64]]: ...
-@overload  # <=2d, 2d
+@overload  # <=2d +f64, 2d +f64
 def brunnermunzel(
-    x: onp.ToFloatStrict2D | onp.ToFloatStrict1D,
-    y: onp.ToFloatStrict2D,
+    x: _AsFloat64_2D | _AsFloat64_1D,
+    y: _AsFloat64_2D,
     alternative: Alternative = "two-sided",
     distribution: L["t", "normal"] = "t",
     nan_policy: NanPolicy = "propagate",
@@ -6400,10 +6798,21 @@ def brunnermunzel(
     axis: int = 0,
     keepdims: L[False] = False,
 ) -> BrunnerMunzelResult[onp.Array1D[np.float64]]: ...
-@overload  # 3d, <=3d
+@overload  # 2d ~f32, 2d ~f32
 def brunnermunzel(
-    x: onp.ToFloatStrict3D,
-    y: onp.ToFloatStrict3D | onp.ToFloatStrict2D | onp.ToFloatStrict1D,
+    x: onp.ToJustFloat32Strict2D,
+    y: onp.ToJustFloat32Strict2D,
+    alternative: Alternative = "two-sided",
+    distribution: L["t", "normal"] = "t",
+    nan_policy: NanPolicy = "propagate",
+    *,
+    axis: int = 0,
+    keepdims: L[False] = False,
+) -> BrunnerMunzelResult[onp.Array1D[np.float32]]: ...
+@overload  # 3d +f64, <=3d +f64
+def brunnermunzel(
+    x: _AsFloat64_3D,
+    y: _AsFloat64_3D | _AsFloat64_2D | _AsFloat64_1D,
     alternative: Alternative = "two-sided",
     distribution: L["t", "normal"] = "t",
     nan_policy: NanPolicy = "propagate",
@@ -6411,10 +6820,10 @@ def brunnermunzel(
     axis: int = 0,
     keepdims: L[False] = False,
 ) -> BrunnerMunzelResult[onp.Array2D[np.float64]]: ...
-@overload  # <=3d, 3d
+@overload  # <=3d +f64, 3d +f64
 def brunnermunzel(
-    x: onp.ToFloatStrict3D | onp.ToFloatStrict2D | onp.ToFloatStrict1D,
-    y: onp.ToFloatStrict3D,
+    x: _AsFloat64_3D | _AsFloat64_2D | _AsFloat64_1D,
+    y: _AsFloat64_3D,
     alternative: Alternative = "two-sided",
     distribution: L["t", "normal"] = "t",
     nan_policy: NanPolicy = "propagate",
@@ -6422,10 +6831,21 @@ def brunnermunzel(
     axis: int = 0,
     keepdims: L[False] = False,
 ) -> BrunnerMunzelResult[onp.Array2D[np.float64]]: ...
-@overload  # Nd, Nd
+@overload  # 3d ~f32, 3d ~f32
 def brunnermunzel(
-    x: onp.ToFloatND,
-    y: onp.ToFloatND,
+    x: onp.ToJustFloat32Strict3D,
+    y: onp.ToJustFloat32Strict3D,
+    alternative: Alternative = "two-sided",
+    distribution: L["t", "normal"] = "t",
+    nan_policy: NanPolicy = "propagate",
+    *,
+    axis: int = 0,
+    keepdims: L[False] = False,
+) -> BrunnerMunzelResult[onp.Array2D[np.float32]]: ...
+@overload  # Nd +f64, Nd +f64
+def brunnermunzel(
+    x: _AsFloat64_ND,
+    y: _AsFloat64_ND,
     alternative: Alternative = "two-sided",
     distribution: L["t", "normal"] = "t",
     nan_policy: NanPolicy = "propagate",
@@ -6433,10 +6853,21 @@ def brunnermunzel(
     axis: int = 0,
     keepdims: L[False] = False,
 ) -> BrunnerMunzelResult[onp.ArrayND[np.float64] | Any]: ...
-@overload  # axis=None
+@overload  # Nd ~f32, Nd ~f32
 def brunnermunzel(
-    x: onp.ToFloatND,
-    y: onp.ToFloatND,
+    x: onp.ToJustFloat32_ND,
+    y: onp.ToJustFloat32_ND,
+    alternative: Alternative = "two-sided",
+    distribution: L["t", "normal"] = "t",
+    nan_policy: NanPolicy = "propagate",
+    *,
+    axis: int = 0,
+    keepdims: L[False] = False,
+) -> BrunnerMunzelResult[onp.ArrayND[np.float32] | Any]: ...
+@overload  # ?d +f64, ?d +f64, axis=None
+def brunnermunzel(
+    x: _AsFloat64_ND,
+    y: _AsFloat64_ND,
     alternative: Alternative = "two-sided",
     distribution: L["t", "normal"] = "t",
     nan_policy: NanPolicy = "propagate",
@@ -6444,7 +6875,40 @@ def brunnermunzel(
     axis: None,
     keepdims: L[False] = False,
 ) -> BrunnerMunzelResult[np.float64]: ...
-@overload  # keepdims=True
+@overload  # ?d ~f32, ?d ~f32, axis=None
+def brunnermunzel(
+    x: onp.ToJustFloat32_ND,
+    y: onp.ToJustFloat32_ND,
+    alternative: Alternative = "two-sided",
+    distribution: L["t", "normal"] = "t",
+    nan_policy: NanPolicy = "propagate",
+    *,
+    axis: None,
+    keepdims: L[False] = False,
+) -> BrunnerMunzelResult[np.float32]: ...
+@overload  # ?d +f64, ?d +f64, keepdims=True
+def brunnermunzel(
+    x: _AsFloat64_ND,
+    y: _AsFloat64_ND,
+    alternative: Alternative = "two-sided",
+    distribution: L["t", "normal"] = "t",
+    nan_policy: NanPolicy = "propagate",
+    *,
+    axis: int | None = 0,
+    keepdims: L[True],
+) -> BrunnerMunzelResult[onp.ArrayND[np.float64]]: ...
+@overload  # ?d ~f32, ?d ~f32, keepdims=True
+def brunnermunzel(
+    x: onp.ToJustFloat32_ND,
+    y: onp.ToJustFloat32_ND,
+    alternative: Alternative = "two-sided",
+    distribution: L["t", "normal"] = "t",
+    nan_policy: NanPolicy = "propagate",
+    *,
+    axis: int | None = 0,
+    keepdims: L[True],
+) -> BrunnerMunzelResult[onp.ArrayND[np.float32]]: ...
+@overload  # fallback
 def brunnermunzel(
     x: onp.ToFloatND,
     y: onp.ToFloatND,
@@ -6453,8 +6917,8 @@ def brunnermunzel(
     nan_policy: NanPolicy = "propagate",
     *,
     axis: int | None = 0,
-    keepdims: L[True],
-) -> BrunnerMunzelResult[onp.ArrayND[np.float64]]: ...
+    keepdims: bool = False,
+) -> BrunnerMunzelResult[np.float64 | Any]: ...
 
 #
 @overload  # ?d T@floating

--- a/tests/stats/test__morestats.pyi
+++ b/tests/stats/test__morestats.pyi
@@ -1,6 +1,6 @@
 # type-tests for `stats/_morestats.pyi`
 
-from typing import assert_type
+from typing import Any, assert_type
 
 import numpy as np
 import optype.numpy as onp
@@ -54,6 +54,7 @@ _i16_2d: onp.Array2D[np.int16]
 _i16_3d: onp.Array3D[np.int16]
 _i16_nd: onp.ArrayND[np.int16]
 
+_f32_1d: onp.Array1D[np.float32]
 _f32_2d: onp.Array2D[np.float32]
 _f32_3d: onp.Array3D[np.float32]
 _f32_nd: onp.ArrayND[np.float32]
@@ -96,7 +97,7 @@ assert_subtype[rv_continuous_frozen](mvsdist(_f64_1d)[2])
 
 assert_type(kstat(_f64_nd), np.float64)
 assert_type(kstat(_f64_nd, axis=None), np.float64)
-assert_type(kstat(_f64_nd, axis=0), np.float64 | onp.ArrayND[np.float64])
+assert_type(kstat(_f64_nd, axis=0), np.float64 | onp.ArrayND[np.float64] | Any)
 assert_type(kstat(_f64_nd, keepdims=True), onp.ArrayND[np.float64])
 
 ###
@@ -104,7 +105,7 @@ assert_type(kstat(_f64_nd, keepdims=True), onp.ArrayND[np.float64])
 
 assert_type(kstatvar(_f64_nd), np.float64)
 assert_type(kstatvar(_f64_nd, axis=None), np.float64)
-assert_type(kstatvar(_f64_nd, axis=0), np.float64 | onp.ArrayND[np.float64])
+assert_type(kstatvar(_f64_nd, axis=0), np.float64 | onp.ArrayND[np.float64] | Any)
 assert_type(kstatvar(_f64_nd, keepdims=True), onp.ArrayND[np.float64])
 
 ###
@@ -142,7 +143,7 @@ assert_type(anderson_ksamp(_f64_nd), Anderson_ksampResult)
 
 assert_type(shapiro(_f64_nd), ShapiroResult[np.float64])
 assert_type(shapiro(_f64_nd, axis=None), ShapiroResult[np.float64])
-assert_type(shapiro(_f64_nd, axis=0), ShapiroResult)
+assert_type(shapiro(_f64_nd, axis=0), ShapiroResult[np.float64 | onp.ArrayND[np.float64] | Any])
 assert_type(shapiro(_f64_nd, keepdims=True), ShapiroResult[onp.ArrayND[np.float64]])
 
 ###
@@ -150,19 +151,19 @@ assert_type(shapiro(_f64_nd, keepdims=True), ShapiroResult[onp.ArrayND[np.float6
 
 assert_type(ansari(_f64_nd, _f64_nd, axis=None), AnsariResult[np.float64])
 assert_type(ansari(_f64_nd, _f64_nd, keepdims=True), AnsariResult[onp.ArrayND[np.float64]])
-assert_type(ansari(_f64_nd, _f64_nd), AnsariResult)
+assert_type(ansari(_f64_nd, _f64_nd), AnsariResult[np.float64 | onp.ArrayND[np.float64] | Any])
 
 ###
 # bartlett
 
 assert_type(bartlett(_f64_nd, _f64_nd, axis=None), BartlettResult[np.float64])
 assert_type(bartlett(_f64_nd, _f64_nd, keepdims=True), BartlettResult[onp.ArrayND[np.float64]])
-assert_type(bartlett(_f64_nd, _f64_nd), BartlettResult)
+assert_type(bartlett(_f64_nd, _f64_nd), BartlettResult[np.float64 | onp.ArrayND[np.float64] | Any])
 
 ###
 # levene
 
-assert_type(levene(_f64_nd, _f64_nd), LeveneResult[np.float64 | onp.ArrayND[np.float64]])
+assert_type(levene(_f64_nd, _f64_nd), LeveneResult[np.float64 | onp.ArrayND[np.float64] | Any])
 assert_type(levene(_f64_nd, _f64_nd, axis=None), LeveneResult[np.float64])
 assert_type(levene(_f64_nd, _f64_nd, keepdims=True), LeveneResult[onp.ArrayND[np.float64]])
 
@@ -171,21 +172,20 @@ assert_type(levene(_f64_nd, _f64_nd, keepdims=True), LeveneResult[onp.ArrayND[np
 
 assert_type(fligner(_f64_nd, _f64_nd, axis=None), FlignerResult[np.float64])
 assert_type(fligner(_f64_nd, _f64_nd, keepdims=True), FlignerResult[onp.ArrayND[np.float64]])
-assert_type(fligner(_f64_nd, _f64_nd), FlignerResult)
+assert_type(fligner(_f64_nd, _f64_nd), FlignerResult[np.float64 | onp.ArrayND[np.float64] | Any])
 
 ###
 # mood
 
 assert_type(mood(_f64_nd, _f64_nd, None), SignificanceResult[np.float64])
 assert_type(mood(_f64_nd, _f64_nd, keepdims=True), SignificanceResult[onp.ArrayND[np.float64]])
-assert_type(mood(_f64_nd, _f64_nd), SignificanceResult[np.float64 | onp.ArrayND[np.float64]])
+assert_type(mood(_f64_nd, _f64_nd), SignificanceResult[np.float64 | onp.ArrayND[np.float64] | Any])
 
 ###
 # wilcoxon
 
 assert_type(wilcoxon(_f64_nd, axis=None), WilcoxonResult[np.float64])
 assert_type(wilcoxon(_f64_nd, keepdims=True), WilcoxonResult[onp.ArrayND[np.float64]])
-assert_type(wilcoxon(_f64_nd), WilcoxonResult)
 assert_type(wilcoxon(_f64_1d), WilcoxonResult[np.float64])
 assert_type(wilcoxon(_f64_1d, _f64_1d), WilcoxonResult[np.float64])
 assert_type(wilcoxon(_f64_2d), WilcoxonResult[onp.Array1D[np.float64]])
@@ -194,15 +194,15 @@ assert_type(wilcoxon(_f64_2d, _f64_2d), WilcoxonResult[onp.Array1D[np.float64]])
 ###
 # median_test
 
-assert_type(median_test(_f64_1d, _f64_1d), MedianTestResult)
-assert_type(median_test(_f64_1d, _f64_1d, _f64_1d), MedianTestResult)
+assert_type(median_test(_f64_1d, _f64_1d), MedianTestResult[np.float64])
+assert_type(median_test(_f64_1d, _f64_1d, _f64_1d), MedianTestResult[np.float64])
 
 ###
 # circmean
 
 assert_type(circmean(_f64_nd), np.float64)
 assert_type(circmean(_f64_nd, axis=None), np.float64)
-assert_type(circmean(_f64_nd, axis=0), np.float64 | onp.ArrayND[np.float64])
+assert_type(circmean(_f64_nd, axis=0), np.float64 | onp.ArrayND[np.float64] | Any)
 assert_type(circmean(_f64_nd, keepdims=True), onp.ArrayND[np.float64])
 
 ###
@@ -210,7 +210,7 @@ assert_type(circmean(_f64_nd, keepdims=True), onp.ArrayND[np.float64])
 
 assert_type(circvar(_f64_nd), np.float64)
 assert_type(circvar(_f64_nd, axis=None), np.float64)
-assert_type(circvar(_f64_nd, axis=0), np.float64 | onp.ArrayND[np.float64])
+assert_type(circvar(_f64_nd, axis=0), np.float64 | onp.ArrayND[np.float64] | Any)
 assert_type(circvar(_f64_nd, keepdims=True), onp.ArrayND[np.float64])
 
 ###
@@ -218,7 +218,23 @@ assert_type(circvar(_f64_nd, keepdims=True), onp.ArrayND[np.float64])
 
 assert_type(circstd(_f64_nd), np.float64)
 assert_type(circstd(_f64_nd, axis=None), np.float64)
-assert_type(circstd(_f64_nd, axis=0), np.float64 | onp.ArrayND[np.float64])
+assert_type(circstd(_f64_nd, axis=0), np.float64 | onp.ArrayND[np.float64] | Any)
+
+assert_type(shapiro(_f32_1d).statistic, np.float32)
+assert_type(shapiro(_f32_1d, keepdims=True).statistic, onp.ArrayND[np.float32])
+assert_type(ansari(_f32_1d, _f32_1d, axis=None).statistic, np.float32)
+assert_type(bartlett(_f32_1d, _f32_1d, axis=None).statistic, np.float32)
+assert_type(levene(_f32_1d, _f32_1d, axis=None).statistic, np.float32)
+assert_type(fligner(_f32_1d, _f32_1d, axis=None).statistic, np.float32)
+assert_type(mood(_f32_1d, _f32_1d, None).statistic, np.float32)
+assert_type(wilcoxon(_f32_1d).statistic, np.float32)
+assert_type(kstat(_f32_1d), np.float32)
+assert_type(kstatvar(_f32_1d), np.float32)
+assert_type(circmean(_f32_1d), np.float32)
+assert_type(circvar(_f32_1d), np.float32)
+assert_type(circstd(_f32_1d), np.float32)
+assert_type(false_discovery_control(_f32_1d), onp.ArrayND[np.float32])
+assert_type(median_test(_f32_1d, _f32_1d).median, np.float32)
 assert_type(circstd(_f64_nd, keepdims=True), onp.ArrayND[np.float64])
 
 ###

--- a/tests/stats/test__stats_py.pyi
+++ b/tests/stats/test__stats_py.pyi
@@ -1018,6 +1018,8 @@ assert_type(trim_mean(_f64_nd, 0.1), np.float64 | onp.ArrayND[np.float64])
 # f_oneway
 
 assert_type(f_oneway(_f64_1d, _f64_1d), F_onewayResult[np.float64])
+assert_type(f_oneway(_f32_1d, _f32_1d), F_onewayResult[np.float32])
+assert_type(f_oneway(_f32_2d, _f32_2d), F_onewayResult[onp.Array1D[np.float32]])
 assert_type(f_oneway(_f64_1d, _f64_2d), F_onewayResult[onp.Array1D[np.float64]])
 assert_type(f_oneway(_f64_1d, _f64_3d), F_onewayResult[onp.Array2D[np.float64]])
 assert_type(f_oneway(_f64_1d, _f64_nd), F_onewayResult[np.float64 | Any])
@@ -1125,12 +1127,14 @@ assert_type(ttest_ind_from_stats(_f32_1d, 1.0, _i64_1d, 0.0, 1.0, 10), Ttest_ind
 # power_divergence
 
 assert_type(power_divergence(_f64_1d), Power_divergenceResult[np.float64])
+assert_type(power_divergence(_f32_1d), Power_divergenceResult[np.float32])
 assert_type(power_divergence(_f64_nd, axis=None), Power_divergenceResult[np.float64])
 assert_type(power_divergence(_f64_nd, keepdims=True), Power_divergenceResult[onp.ArrayND[np.float64]])
 
 # chisquare
 
 assert_type(chisquare(_f64_1d), Power_divergenceResult[np.float64])
+assert_type(chisquare(_f32_1d), Power_divergenceResult[np.float32])
 assert_type(chisquare(_f64_1d, _f64_1d), Power_divergenceResult[np.float64])
 assert_type(chisquare(_f64_1d, ddof=1), Power_divergenceResult[np.float64])
 assert_type(chisquare(_f64_1d, axis=None), Power_divergenceResult[np.float64])
@@ -1170,6 +1174,7 @@ assert_type(ks_1samp(_f32_nd, norm.cdf, axis=None), KstestResult[np.float64 | An
 # ks_2samp
 
 assert_type(ks_2samp(_f64_1d, _f64_1d), KstestResult[np.float64, np.int8])
+assert_type(ks_2samp(_f32_1d, _f32_1d), KstestResult[np.float32, np.int8])
 assert_type(ks_2samp(_f64_1d, _f64_2d), KstestResult[onp.Array1D[np.float64], onp.Array1D[np.int8]])
 assert_type(ks_2samp(_f64_1d, _f64_3d), KstestResult[onp.Array2D[np.float64], onp.Array2D[np.int8]])
 assert_type(ks_2samp(_f64_1d, _f64_nd), KstestResult[np.float64 | Any, np.int8 | Any])
@@ -1249,6 +1254,7 @@ assert_type(ranksums(_f32_nd, _f32_nd, keepdims=True), RanksumsResult[onp.ArrayN
 # kruskal
 
 assert_type(kruskal(_f64_1d, _f64_1d), KruskalResult[np.float64])
+assert_type(kruskal(_f32_1d, _f32_1d), KruskalResult[np.float32])
 assert_type(kruskal(_f64_1d, _f64_2d), KruskalResult[onp.Array1D[np.float64]])
 assert_type(kruskal(_f64_1d, _f64_3d), KruskalResult[onp.Array2D[np.float64]])
 assert_type(kruskal(_f64_1d, _f64_nd), KruskalResult[np.float64 | Any])
@@ -1305,6 +1311,7 @@ assert_type(
 # brunnermunzel
 
 assert_type(brunnermunzel(_f64_1d, _f64_1d), BrunnerMunzelResult[np.float64])
+assert_type(brunnermunzel(_f32_1d, _f32_1d), BrunnerMunzelResult[np.float32])
 assert_type(brunnermunzel(_f64_1d, _f64_2d), BrunnerMunzelResult[onp.Array1D[np.float64]])
 assert_type(brunnermunzel(_f64_1d, _f64_3d), BrunnerMunzelResult[onp.Array2D[np.float64]])
 assert_type(brunnermunzel(_f64_1d, _f64_nd), BrunnerMunzelResult[np.float64 | Any])


### PR DESCRIPTION
That is:

- `ansari`
- `bartlett`
- `circmean`
- `circstd`
- `circvar`
- `false_discovery_control`
- `fligner`
- `kstat`
- `kstatvar`
- `levene`
- `median_test`
- `MedianTestResult`
- `mood`
- `shapiro`
- `wilcoxon`
- `brunnermunzel`
- `chisquare`
- `f_oneway`
- `kruskal`
- `ks_2samp`
- `power_divergence`