### PR TITLE
🐛 `stats.pearsonr`: widen `pvalue` dtype for non-f64 inputs

### DIFF
--- a/scipy-stubs/stats/_stats_py.pyi
+++ b/scipy-stubs/stats/_stats_py.pyi
@@ -4028,7 +4028,7 @@ def pearsonr(
     axis: L[0, -1] | None = 0,
     alternative: Alternative = "two-sided",
     method: ResamplingMethod | None = None,
-) -> PearsonRResult[npc.floating, np.float64]: ...
+) -> PearsonRResult[np.float64 | Any, np.float64 | Any]: ...
 @overload  # ?d +integer | ~float64, +floating, axis=None
 def pearsonr(
     x: onp.ToJustFloat64_ND | onp.ToIntND,
@@ -4055,7 +4055,7 @@ def pearsonr(
     axis: None,
     alternative: Alternative = "two-sided",
     method: ResamplingMethod | None = None,
-) -> PearsonRResult[npc.floating, np.float64]: ...
+) -> PearsonRResult[np.float64 | Any, np.float64 | Any]: ...
 @overload  # >=2d +integer | ~float64, +floating
 def pearsonr(
     x: onp.CanArray[onp.AtLeast2D, np.dtype[npc.integer | npc.floating]] | Sequence[onp.SequenceND[float]],
@@ -4082,7 +4082,7 @@ def pearsonr(
     axis: int = 0,
     alternative: Alternative = "two-sided",
     method: ResamplingMethod | None = None,
-) -> PearsonRResult[onp.ArrayND[npc.floating], onp.ArrayND[np.float64]]: ...
+) -> PearsonRResult[onp.ArrayND[np.float64 | Any], onp.ArrayND[np.float64 | Any]]: ...
 @overload  # fallback
 def pearsonr(
     x: onp.ToFloatND,
@@ -4091,7 +4091,10 @@ def pearsonr(
     axis: int | None = 0,
     alternative: Alternative = "two-sided",
     method: ResamplingMethod | None = None,
-) -> PearsonRResult[npc.floating, np.float64] | PearsonRResult[onp.ArrayND[npc.floating], onp.ArrayND[np.float64]]: ...
+) -> (
+    PearsonRResult[np.float64 | Any, np.float64 | Any]
+    | PearsonRResult[onp.ArrayND[np.float64 | Any], onp.ArrayND[np.float64 | Any]]
+): ...
 
 #
 @overload  # ?d, ?d

--- a/tests/stats/test_pearsonr.pyi
+++ b/tests/stats/test_pearsonr.pyi
@@ -1,10 +1,9 @@
 # type-tests for `pearsonr` from `stats/_stats_py.pyi`
 
-from typing import assert_type
+from typing import Any, assert_type
 
 import numpy as np
 import optype.numpy as onp
-import optype.numpy.compat as npc
 
 from scipy.stats import pearsonr
 
@@ -45,7 +44,7 @@ assert_type(pearsonr(_i8_1d, _f64_1d).statistic, np.float64)
 assert_type(pearsonr(_f16_1d, _py_i_1d).statistic, np.float64)
 assert_type(pearsonr(_f16_1d, _py_f_1d).statistic, np.float64)
 assert_type(pearsonr(_f16_1d, _i8_1d).statistic, np.float64)
-assert_type(pearsonr(_f16_1d, _f16_1d).statistic, npc.floating)
+assert_type(pearsonr(_f16_1d, _f16_1d).statistic, np.float64 | Any)
 assert_type(pearsonr(_f16_1d, _f64_1d).statistic, np.float64)
 assert_type(pearsonr(_f64_1d, _py_i_1d).statistic, np.float64)
 assert_type(pearsonr(_f64_1d, _py_f_1d).statistic, np.float64)
@@ -71,7 +70,7 @@ assert_type(pearsonr(_i8_2d, _f64_2d, axis=None).statistic, np.float64)
 assert_type(pearsonr(_f16_2d, _py_i_2d, axis=None).statistic, np.float64)
 assert_type(pearsonr(_f16_2d, _py_f_2d, axis=None).statistic, np.float64)
 assert_type(pearsonr(_f16_2d, _i8_2d, axis=None).statistic, np.float64)
-assert_type(pearsonr(_f16_2d, _f16_2d, axis=None).statistic, npc.floating)
+assert_type(pearsonr(_f16_2d, _f16_2d, axis=None).statistic, np.float64 | Any)
 assert_type(pearsonr(_f16_2d, _f64_2d, axis=None).statistic, np.float64)
 assert_type(pearsonr(_f64_2d, _py_i_2d, axis=None).statistic, np.float64)
 assert_type(pearsonr(_f64_2d, _py_f_2d, axis=None).statistic, np.float64)
@@ -97,7 +96,7 @@ assert_type(pearsonr(_i8_2d, _f64_2d).statistic, onp.ArrayND[np.float64])
 assert_type(pearsonr(_f16_2d, _py_i_2d).statistic, onp.ArrayND[np.float64])
 assert_type(pearsonr(_f16_2d, _py_f_2d).statistic, onp.ArrayND[np.float64])
 assert_type(pearsonr(_f16_2d, _i8_2d).statistic, onp.ArrayND[np.float64])
-assert_type(pearsonr(_f16_2d, _f16_2d).statistic, onp.ArrayND[npc.floating])
+assert_type(pearsonr(_f16_2d, _f16_2d).statistic, onp.ArrayND[np.float64 | Any])
 assert_type(pearsonr(_f16_2d, _f64_2d).statistic, onp.ArrayND[np.float64])
 assert_type(pearsonr(_f64_2d, _py_i_2d).statistic, onp.ArrayND[np.float64])
 assert_type(pearsonr(_f64_2d, _py_f_2d).statistic, onp.ArrayND[np.float64])
@@ -105,6 +104,7 @@ assert_type(pearsonr(_f64_2d, _i8_2d).statistic, onp.ArrayND[np.float64])
 assert_type(pearsonr(_f64_2d, _f16_2d).statistic, onp.ArrayND[np.float64])
 assert_type(pearsonr(_f64_2d, _f64_2d).statistic, onp.ArrayND[np.float64])
 
-assert_type(pearsonr(_f16_1d, _f16_1d).pvalue, np.float64)
-assert_type(pearsonr(_f16_2d, _f16_2d, axis=None).pvalue, np.float64)
-assert_type(pearsonr(_f16_2d, _f16_2d).pvalue, onp.ArrayND[np.float64])
+assert_type(pearsonr(_f16_1d, _f16_1d).pvalue, np.float64 | Any)
+assert_type(pearsonr(_f16_2d, _f16_2d, axis=None).pvalue, np.float64 | Any)
+assert_type(pearsonr(_f16_2d, _f16_2d).pvalue, onp.ArrayND[np.float64 | Any])
+assert_type(pearsonr(_f64_1d, _f64_1d).pvalue, np.float64)


### PR DESCRIPTION
it isn't always `float64`