### PR TITLE
🐛 `special`: fix some ufuncs returning `float32` when other argument is `float64`

### DIFF
--- a/scipy-stubs/special/_ufuncs.pyi
+++ b/scipy-stubs/special/_ufuncs.pyi
@@ -2002,15 +2002,15 @@ class _UFunc31f(_UFunc31[_NameT_co, _IdentityT_co], Generic[_NameT_co, _Identity
     ) -> _Float: ...
     @overload
     def __call__[ST: _Float_D](
-        self, a: onp.ToFloat64, b: onp.ToFloat64, x: ST, /, out: _Out1[None] = None, **kw: Unpack[_KwBase]
+        self, a: ST, b: ST | _ToFloat32, x: ST | _ToFloat32, /, out: _Out1[None] = None, **kw: Unpack[_KwBase]
     ) -> ST: ...
     @overload
     def __call__[ST: _Float_D](
-        self, a: onp.ToFloat64, b: ST, x: onp.ToFloat64, /, out: _Out1[None] = None, **kw: Unpack[_KwBase]
+        self, a: ST | _ToFloat32, b: ST, x: ST | _ToFloat32, /, out: _Out1[None] = None, **kw: Unpack[_KwBase]
     ) -> ST: ...
     @overload
     def __call__[ST: _Float_D](
-        self, a: ST, b: onp.ToFloat64, x: onp.ToFloat64, /, out: _Out1[None] = None, **kw: Unpack[_KwBase]
+        self, a: ST | _ToFloat32, b: ST | _ToFloat32, x: ST, /, out: _Out1[None] = None, **kw: Unpack[_KwBase]
     ) -> ST: ...
     @overload
     def __call__(
@@ -2980,19 +2980,19 @@ class _UFunc42f(_UFunc42[_NameT_co, _IdentityT_co], Generic[_NameT_co, _Identity
     ) -> _Float: ...
     @overload
     def __call__[ST: _Float_D](
-        self, m: onp.ToFloat64, n: onp.ToFloat64, c: onp.ToFloat64, x: ST, /, out: _None2 = ..., **kw: Unpack[_Kw42f]
+        self, m: ST, n: ST | _ToFloat32, c: ST | _ToFloat32, x: ST | _ToFloat32, /, out: _None2 = ..., **kw: Unpack[_Kw42f]
     ) -> ST: ...
     @overload
     def __call__[ST: _Float_D](
-        self, m: onp.ToFloat64, n: onp.ToFloat64, c: ST, x: onp.ToFloat64, /, out: _None2 = ..., **kw: Unpack[_Kw42f]
+        self, m: ST | _ToFloat32, n: ST, c: ST | _ToFloat32, x: ST | _ToFloat32, /, out: _None2 = ..., **kw: Unpack[_Kw42f]
     ) -> ST: ...
     @overload
     def __call__[ST: _Float_D](
-        self, m: onp.ToFloat64, n: ST, c: onp.ToFloat64, x: onp.ToFloat64, /, out: _None2 = ..., **kw: Unpack[_Kw42f]
+        self, m: ST | _ToFloat32, n: ST | _ToFloat32, c: ST, x: ST | _ToFloat32, /, out: _None2 = ..., **kw: Unpack[_Kw42f]
     ) -> ST: ...
     @overload
     def __call__[ST: _Float_D](
-        self, m: ST, n: onp.ToFloat64, c: onp.ToFloat64, x: onp.ToFloat64, /, out: _None2 = ..., **kw: Unpack[_Kw42f]
+        self, m: ST | _ToFloat32, n: ST | _ToFloat32, c: ST | _ToFloat32, x: ST, /, out: _None2 = ..., **kw: Unpack[_Kw42f]
     ) -> ST: ...
     @overload
     def __call__(
@@ -3087,59 +3087,59 @@ class _UFunc52f(_UFunc52[_NameT_co, _IdentityT_co], Generic[_NameT_co, _Identity
     @overload
     def __call__[ST: _Float_D](
         self,
-        m: onp.ToFloat64,
-        n: onp.ToFloat64,
-        c: onp.ToFloat64,
-        cv: onp.ToFloat64,
-        x: ST,
-        /,
-        out: _None2 = ...,
-        **kw: Unpack[_Kw52f],
-    ) -> ST: ...
-    @overload
-    def __call__[ST: _Float_D](
-        self,
-        m: onp.ToFloat64,
-        n: onp.ToFloat64,
-        c: onp.ToFloat64,
-        cv: ST,
-        x: onp.ToFloat64,
-        /,
-        out: _None2 = ...,
-        **kw: Unpack[_Kw52f],
-    ) -> ST: ...
-    @overload
-    def __call__[ST: _Float_D](
-        self,
-        m: onp.ToFloat64,
-        n: onp.ToFloat64,
-        c: ST,
-        cv: onp.ToFloat64,
-        x: onp.ToFloat64,
-        /,
-        out: _None2 = ...,
-        **kw: Unpack[_Kw52f],
-    ) -> ST: ...
-    @overload
-    def __call__[ST: _Float_D](
-        self,
-        m: onp.ToFloat64,
-        n: ST,
-        c: onp.ToFloat64,
-        cv: onp.ToFloat64,
-        x: onp.ToFloat64,
-        /,
-        out: _None2 = ...,
-        **kw: Unpack[_Kw52f],
-    ) -> ST: ...
-    @overload
-    def __call__[ST: _Float_D](
-        self,
         m: ST,
-        n: onp.ToFloat64,
-        c: onp.ToFloat64,
-        cv: onp.ToFloat64,
-        x: onp.ToFloat64,
+        n: ST | _ToFloat32,
+        c: ST | _ToFloat32,
+        cv: ST | _ToFloat32,
+        x: ST | _ToFloat32,
+        /,
+        out: _None2 = ...,
+        **kw: Unpack[_Kw52f],
+    ) -> ST: ...
+    @overload
+    def __call__[ST: _Float_D](
+        self,
+        m: ST | _ToFloat32,
+        n: ST,
+        c: ST | _ToFloat32,
+        cv: ST | _ToFloat32,
+        x: ST | _ToFloat32,
+        /,
+        out: _None2 = ...,
+        **kw: Unpack[_Kw52f],
+    ) -> ST: ...
+    @overload
+    def __call__[ST: _Float_D](
+        self,
+        m: ST | _ToFloat32,
+        n: ST | _ToFloat32,
+        c: ST,
+        cv: ST | _ToFloat32,
+        x: ST | _ToFloat32,
+        /,
+        out: _None2 = ...,
+        **kw: Unpack[_Kw52f],
+    ) -> ST: ...
+    @overload
+    def __call__[ST: _Float_D](
+        self,
+        m: ST | _ToFloat32,
+        n: ST | _ToFloat32,
+        c: ST | _ToFloat32,
+        cv: ST,
+        x: ST | _ToFloat32,
+        /,
+        out: _None2 = ...,
+        **kw: Unpack[_Kw52f],
+    ) -> ST: ...
+    @overload
+    def __call__[ST: _Float_D](
+        self,
+        m: ST | _ToFloat32,
+        n: ST | _ToFloat32,
+        c: ST | _ToFloat32,
+        cv: ST | _ToFloat32,
+        x: ST,
         /,
         out: _None2 = ...,
         **kw: Unpack[_Kw52f],

--- a/tests/special/test_ufuncs.pyi
+++ b/tests/special/test_ufuncs.pyi
@@ -195,8 +195,19 @@ assert_type(sp.xlogy(_f8_nd, 2.0), _Float64ND)
 
 ###
 
-# _UFunc31 - TODO
+# _UFunc31f
+assert_type(sp.voigt_profile(_f4, 1.0, 1.0), np.float32)
+assert_type(sp.voigt_profile(_f8, 1.0, _f4), np.float64)
+
 # _UFunc32 - TODO
+
+# _UFunc42f
+assert_type(sp.pro_ang1(_f4, 1.0, 1.0, 1.0), np.float32)
+assert_type(sp.pro_ang1(_f8, 1.0, 1.0, _f4), np.float64)
+
+# _UFunc52f
+assert_type(sp.pro_ang1_cv(_f4, 1.0, 1.0, 1.0, 1.0), np.float32)
+assert_type(sp.pro_ang1_cv(_f8, 1.0, 1.0, 1.0, _f4), np.float64)
 
 # _UFunc31lldf
 assert_type(sp.nbdtr.ntypes, L[3])


### PR DESCRIPTION
This affects the following public `scipy.special` ufuncs:

- `bdtr`
- `bdtrc`
- `bdtri`
- `bdtrik`
- `bdtrin`
- `besselpoly`
- `betainc`
- `betaincc`
- `betainccinv`
- `betaincinv`
- `btdtria`
- `btdtrib`
- `chndtr`
- `chndtridf`
- `chndtrinc`
- `chndtrix`
- `fdtr`
- `fdtrc`
- `fdtri`
- `fdtridfd`
- `gdtr`
- `gdtrc`
- `gdtria`
- `gdtrib`
- `gdtrix`
- `hyperu`
- `log_wright_bessel`
- `lpmv`
- `nbdtrik`
- `nbdtrin`
- `nctdtr`
- `nctdtridf`
- `nctdtrinc`
- `nctdtrit`
- `nrdtrimn`
- `nrdtrisd`
- `obl_ang1`
- `obl_ang1_cv`
- `obl_cv`
- `obl_rad1`
- `obl_rad1_cv`
- `obl_rad2`
- `obl_rad2_cv`
- `pro_ang1`
- `pro_ang1_cv`
- `pro_cv`
- `pro_rad1`
- `pro_rad1_cv`
- `pro_rad2`
- `pro_rad2_cv`
- `radian`
- `voigt_profile`
- `wright_bessel`