### PR TITLE
✨ `fftpack`: improve return dtypes of the basic fft functions

### DIFF
--- a/scipy-stubs/fftpack/_basic.pyi
+++ b/scipy-stubs/fftpack/_basic.pyi
@@ -1,4 +1,4 @@
-from typing import SupportsIndex
+from typing import Any, SupportsIndex, overload
 
 import numpy as np
 import optype.numpy as onp
@@ -8,36 +8,90 @@ from scipy._typing import AnyShape
 
 __all__ = ["fft", "fft2", "fftn", "ifft", "ifft2", "ifftn", "irfft", "rfft"]
 
-type _ArrayReal = onp.ArrayND[np.float32 | np.float64 | np.longdouble]  # no float16
-type _ArrayComplex = onp.ArrayND[npc.complexfloating]
+###
+
+type _AsF64ND = onp.ToArrayND[float, np.float64 | npc.integer | np.bool]
+type _AsC128ND = onp.ToArrayND[complex, np.complex128 | np.float64 | npc.integer | np.bool]
+
+type _Axis = SupportsIndex
+type _Axes = tuple[SupportsIndex, SupportsIndex]
 
 ###
 
+# NOTE: keep in sync with `ifft`
+@overload  # +c128
 def fft(
-    x: onp.ToComplexND, n: onp.ToJustInt | None = None, axis: SupportsIndex = -1, overwrite_x: bool = False
-) -> _ArrayComplex: ...
+    x: _AsC128ND, n: onp.ToJustInt | None = None, axis: _Axis = -1, overwrite_x: bool = False
+) -> onp.ArrayND[np.complex128]: ...
+@overload  # fallback
+def fft(
+    x: onp.ToComplexND, n: onp.ToJustInt | None = None, axis: _Axis = -1, overwrite_x: bool = False
+) -> onp.ArrayND[np.complex128 | Any]: ...
+
+# NOTE: keep in sync with `fft`
+@overload  # +c128
 def ifft(
-    x: onp.ToComplexND, n: onp.ToJustInt | None = None, axis: SupportsIndex = -1, overwrite_x: bool = False
-) -> _ArrayComplex: ...
-def rfft(x: onp.ToFloatND, n: onp.ToJustInt | None = None, axis: SupportsIndex = -1, overwrite_x: bool = False) -> _ArrayReal: ...
+    x: _AsC128ND, n: onp.ToJustInt | None = None, axis: _Axis = -1, overwrite_x: bool = False
+) -> onp.ArrayND[np.complex128]: ...
+@overload  # fallback
+def ifft(
+    x: onp.ToComplexND, n: onp.ToJustInt | None = None, axis: _Axis = -1, overwrite_x: bool = False
+) -> onp.ArrayND[np.complex128 | Any]: ...
+
+# NOTE: keep in sync with `irfft`
+@overload  # +f64
+def rfft(x: _AsF64ND, n: onp.ToJustInt | None = None, axis: _Axis = -1, overwrite_x: bool = False) -> onp.ArrayND[np.float64]: ...
+@overload  # fallback
+def rfft(
+    x: onp.ToFloatND, n: onp.ToJustInt | None = None, axis: _Axis = -1, overwrite_x: bool = False
+) -> onp.ArrayND[np.float64 | Any]: ...
+
+# NOTE: keep in sync with `rfft`
+@overload  # +f64
 def irfft(
-    x: onp.ToFloatND, n: onp.ToJustInt | None = None, axis: SupportsIndex = -1, overwrite_x: bool = False
-) -> _ArrayReal: ...
+    x: _AsF64ND, n: onp.ToJustInt | None = None, axis: _Axis = -1, overwrite_x: bool = False
+) -> onp.ArrayND[np.float64]: ...
+@overload  # fallback
+def irfft(
+    x: onp.ToFloatND, n: onp.ToJustInt | None = None, axis: _Axis = -1, overwrite_x: bool = False
+) -> onp.ArrayND[np.float64 | Any]: ...
+
+# NOTE: keep in sync with `ifftn`
+@overload  # +c128
+def fftn(
+    x: _AsC128ND, shape: AnyShape | None = None, axes: AnyShape | None = None, overwrite_x: bool = False
+) -> onp.ArrayND[np.complex128]: ...
+@overload  # fallback
 def fftn(
     x: onp.ToComplexND, shape: AnyShape | None = None, axes: AnyShape | None = None, overwrite_x: bool = False
-) -> _ArrayComplex: ...
+) -> onp.ArrayND[np.complex128 | Any]: ...
+
+# NOTE: keep in sync with `fftn`
+@overload  # +c128
+def ifftn(
+    x: _AsC128ND, shape: AnyShape | None = None, axes: AnyShape | None = None, overwrite_x: bool = False
+) -> onp.ArrayND[np.complex128]: ...
+@overload  # fallback
 def ifftn(
     x: onp.ToComplexND, shape: AnyShape | None = None, axes: AnyShape | None = None, overwrite_x: bool = False
-) -> _ArrayComplex: ...
+) -> onp.ArrayND[np.complex128 | Any]: ...
+
+# NOTE: keep in sync with `ifft2`
+@overload  # +c128
 def fft2(
-    x: onp.ToComplexND,
-    shape: AnyShape | None = None,
-    axes: tuple[SupportsIndex, SupportsIndex] = (-2, -1),
-    overwrite_x: bool = False,
-) -> _ArrayComplex: ...
+    x: _AsC128ND, shape: AnyShape | None = None, axes: _Axes = (-2, -1), overwrite_x: bool = False
+) -> onp.ArrayND[np.complex128]: ...
+@overload  # fallback
+def fft2(
+    x: onp.ToComplexND, shape: AnyShape | None = None, axes: _Axes = (-2, -1), overwrite_x: bool = False
+) -> onp.ArrayND[np.complex128 | Any]: ...
+
+# NOTE: keep in sync with `fft2`
+@overload  # +c128
 def ifft2(
-    x: onp.ToComplexND,
-    shape: AnyShape | None = None,
-    axes: tuple[SupportsIndex, SupportsIndex] = (-2, -1),
-    overwrite_x: bool = False,
-) -> _ArrayComplex: ...
+    x: _AsC128ND, shape: AnyShape | None = None, axes: _Axes = (-2, -1), overwrite_x: bool = False
+) -> onp.ArrayND[np.complex128]: ...
+@overload  # fallback
+def ifft2(
+    x: onp.ToComplexND, shape: AnyShape | None = None, axes: _Axes = (-2, -1), overwrite_x: bool = False
+) -> onp.ArrayND[np.complex128 | Any]: ...

--- a/tests/fftpack/__init__.pyi
+++ b/tests/fftpack/__init__.pyi
@@ -1,0 +1,1 @@
+# Allow importing from other test_modules for the sake of DRY.

--- a/tests/fftpack/test_basic.pyi
+++ b/tests/fftpack/test_basic.pyi
@@ -1,0 +1,31 @@
+# type-tests for `fftpack/_basic.pyi`
+
+from typing import Any, assert_type
+
+import numpy as np
+import optype.numpy as onp
+
+from scipy.fftpack import fft, fft2, fftn, rfft
+
+###
+
+_f32_nd: onp.ArrayND[np.float32]
+_f64_nd: onp.ArrayND[np.float64]
+
+###
+
+# fft (same as ifft)
+assert_type(fft(_f64_nd), onp.ArrayND[np.complex128])
+assert_type(fft(_f32_nd), onp.ArrayND[np.complex128 | Any])
+
+# rfft (same as irfft)
+assert_type(rfft(_f64_nd), onp.ArrayND[np.float64])
+assert_type(rfft(_f32_nd), onp.ArrayND[np.float64 | Any])
+
+# fft2 (same as ifft2)
+assert_type(fft2(_f64_nd), onp.ArrayND[np.complex128])
+assert_type(fft2(_f32_nd), onp.ArrayND[np.complex128 | Any])
+
+# fftn (same as ifftn)
+assert_type(fftn(_f64_nd), onp.ArrayND[np.complex128])
+assert_type(fftn(_f32_nd), onp.ArrayND[np.complex128 | Any])


### PR DESCRIPTION
Note that `fftpack` is legacy stuff, and that `fft` should be used for new code.

This affects the following public `scipy.fftpack` functions:

- `fft`
- `fft2`
- `fftn`
- `ifft`
- `ifft2`
- `ifftn`
- `irfft`
- `rfft`